### PR TITLE
Make executors imagePullPolicy configurable.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -43,6 +43,10 @@ type SensorControllerConfig struct {
 	// ExecutorImage is the name of the image to run for the container inside the sensor executor jobs
 	ExecutorImage string `json:"executorImage"`
 
+	// ExecutorImagePullPolicy is the imagePullPolicy for the the executor. If this is empty,
+	// the imagePullPolicy is "Always".
+	ExecutorImagePullPolicy string `json:"executorImagePullPolicy"`
+
 	// InstanceID is a label selector to limit the controller's watch of sensor jobs to a specific instance.
 	// If omitted, the controller watches sensors that *are not* labeled with an instance id.
 	InstanceID string `json:"instanceID,omitempty"`

--- a/controller/sensorjob.go
+++ b/controller/sensorjob.go
@@ -57,7 +57,7 @@ func (soc *sOperationCtx) createSensorExecutorJob() error {
 		Name:            common.ExecutorContainerName,
 		Image:           soc.controller.Config.ExecutorImage,
 		Env:             envVars,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: corev1.PullPolicy(soc.controller.Config.ExecutorImagePullPolicy),
 	}
 	if soc.controller.Config.ExecutorResources != nil {
 		execContainer.Resources = *soc.controller.Config.ExecutorResources


### PR DESCRIPTION
Testing Done:

1. Explicitly set the policy to "always" in the config-map. Verified that
   the executor pod created had the imagePullPolicy of "always".
2. Modified the imagePullPolicy to "IfNotPresent" and the same steps above.
3. Removed the `executorImagePullPolicy` from the configMap. Verified that
   the executor pod created had the imagePullPolicy of "always".

Closes #32.