### PR TITLE
Add workflow for CI.

### DIFF
--- a/.argo-ci/ci.yaml
+++ b/.argo-ci/ci.yaml
@@ -1,0 +1,73 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: argo-events-ci-
+spec:
+  entrypoint: argo-events-ci
+  arguments:
+    parameters:
+    - name: revision
+      value: master
+    - name: repo
+      value: https://github.com/argoproj/argo-events.git
+
+  templates:
+  - name: argo-events-ci
+    steps:
+    - - name: build
+        template: ci-dind
+        arguments:
+          parameters:
+          - name: cmd
+            value: "{{item}}"
+        withItems:
+        - dep ensure && make
+      - name: test
+        template: ci-builder
+        arguments:
+          parameters:
+          - name: cmd
+            value: "{{item}}"
+        withItems:
+        - dep ensure && make test
+  - name: ci-builder
+    inputs:
+      parameters:
+      - name: cmd
+      artifacts:
+      - name: code
+        path: /go/src/github.com/argoproj/argo-events
+        git:
+          repo: "{{workflow.parameters.repo}}"
+          revision: "{{workflow.parameters.revision}}"
+    container:
+      image: argoproj/argo-ci-builder:1.0
+      command: [sh, -c]
+      args: ["{{inputs.parameters.cmd}}"]
+      workingDir: /go/src/github.com/argoproj/argo-events
+
+  - name: ci-dind
+    inputs:
+      parameters:
+      - name: cmd
+      artifacts:
+      - name: code
+        path: /go/src/github.com/argoproj/argo-events
+        git:
+          repo: "{{workflow.parameters.repo}}"
+          revision: "{{workflow.parameters.revision}}"
+    container:
+      image: argoproj/argo-ci-builder:1.0
+      command: [sh, -c]
+      args: ["until docker ps; do sleep 3; done && {{inputs.parameters.cmd}}"]
+      workingDir: /go/src/github.com/argoproj/argo-events
+      env:
+      - name: DOCKER_HOST
+        value: 127.0.0.1
+    sidecars:
+    - name: dind
+      image: docker:17.10-dind
+      securityContext:
+        privileged: true
+      mirrorVolumeMounts: true
+


### PR DESCRIPTION
This commit creates the workflow that will be run on every PR for argo-events.

Testing Done:

1. Ran workflow independently on a cluster. It succeeded modulo appropriate RBAC role
(See https://github.com/argoproj/argo/issues/898 for details).

Refs #34.