### PR TITLE
Use argoproj/argo-events-ci-builder:1.0 for argo-events builds.

### DIFF
--- a/.argo-ci/builder/Dockerfile
+++ b/.argo-ci/builder/Dockerfile
@@ -1,0 +1,4 @@
+FROM argoproj/argo-ci-builder:1.0
+
+RUN apt-get update && apt-get install unzip
+RUN mkdir /tmp/protobuf && cd /tmp/protobuf && curl -sOL https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip && unzip protoc-3.3.0-linux-x86_64.zip && cp bin/protoc /usr/local/bin/protoc && mv include /usr/local/

--- a/.argo-ci/ci.yaml
+++ b/.argo-ci/ci.yaml
@@ -41,7 +41,7 @@ spec:
           repo: "{{workflow.parameters.repo}}"
           revision: "{{workflow.parameters.revision}}"
     container:
-      image: argoproj/argo-ci-builder:1.0
+      image: argoproj/argo-events-ci-builder:1.0
       command: [sh, -c]
       args: ["{{inputs.parameters.cmd}}"]
       workingDir: /go/src/github.com/argoproj/argo-events
@@ -57,7 +57,7 @@ spec:
           repo: "{{workflow.parameters.repo}}"
           revision: "{{workflow.parameters.revision}}"
     container:
-      image: argoproj/argo-ci-builder:1.0
+      image: argoproj/argo-events-ci-builder:1.0
       command: [sh, -c]
       args: ["until docker ps; do sleep 3; done && {{inputs.parameters.cmd}}"]
       workingDir: /go/src/github.com/argoproj/argo-events


### PR DESCRIPTION
This image includes the protobuf package and dependencies for installing it.

Also added the builder directory under .argo-ci which has the Dockerfile for the above image.

Testing done:

1. Built the image. Ran builds locally. They succeeded.