### PR TITLE
Serve and read from local server for url test.

### DIFF
--- a/store/url_test.go
+++ b/store/url_test.go
@@ -1,14 +1,23 @@
 package store
 
 import (
+	"fmt"
 	"testing"
+
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestURLReader(t *testing.T) {
-	urlArtifact := v1alpha1.URLArtifact{Path: "https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml"}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	urlArtifact := v1alpha1.URLArtifact{Path: ts.URL}
 	assert.False(t, urlArtifact.VerifyCert)
 	urlReader, err := NewURLReader(&urlArtifact)
 	assert.NotNil(t, urlReader)


### PR DESCRIPTION
Instead of reading a Github url, this commit starts and local http server and makes
the URLReader read from that server.

Closes #70.