### PR TITLE
Allow to overwrite variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ override LDFLAGS += \
   -X ${PACKAGE}.gitTreeState=${GIT_TREE_STATE}
 
 #  docker image publishing options
-DOCKER_PUSH=true
-IMAGE_NAMESPACE=argoproj
-IMAGE_TAG=v0.7
+DOCKER_PUSH?=true
+IMAGE_NAMESPACE?=argoproj
+IMAGE_TAG?=v0.7
 
 ifeq (${DOCKER_PUSH},true)
 ifndef IMAGE_NAMESPACE


### PR DESCRIPTION
I'd like to build argo-events images with custom image prefix.
e.g. `IMAGE_NAMESPACE=dtaniwaki make github-image`