### PR TITLE
Handle empty namespace on trigger resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1553,6 +1553,7 @@
     "github.com/nats-io/go-nats",
     "github.com/nats-io/go-nats-streaming",
     "github.com/nlopes/slack/slackevents",
+    "github.com/pkg/errors",
     "github.com/robfig/cron",
     "github.com/rs/zerolog",
     "github.com/satori/go.uuid",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1291,12 +1291,13 @@
 
 [[projects]]
   branch = "release-7.0"
-  digest = "1:6e37d35d68d68b1368b803617d346633830eb13b50120f68ead2c029c05eeea0"
+  digest = "1:7336dcb25cac9940ac84ea6c59c4c36d1b6b6ca4a3aba38d6d8c74bc53699a40"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "discovery/fake",
     "dynamic",
+    "dynamic/fake",
     "informers",
     "informers/admissionregistration",
     "informers/admissionregistration/v1alpha1",
@@ -1596,6 +1597,7 @@
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/kubernetes",

--- a/pkg/apis/sensor/v1alpha1/openapi_generated.go
+++ b/pkg/apis/sensor/v1alpha1/openapi_generated.go
@@ -159,7 +159,7 @@ func schema_pkg_apis_sensor_v1alpha1_DataFilter(ref common.ReferenceCallback) co
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the allowed string values for this key Booleans are pased using strconv.ParseBool() Numbers are parsed using as float64 using strconv.ParseFloat() Strings are taken as is Nils this value is ignored",
+							Description: "Value is the allowed string values for this key Booleans are passed using strconv.ParseBool() Numbers are parsed using as float64 using strconv.ParseFloat() Strings are taken as is Nils this value is ignored",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -387,7 +387,7 @@ func schema_pkg_apis_sensor_v1alpha1_GitArtifact(ref common.ReferenceCallback) c
 					},
 					"remote": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Git remote to manage set of tracked repositories. Defaults to \"origin\". Refer https://git-scm.com/docs/git-remote",
+							Description: "Remote to manage set of tracked repositories. Defaults to \"origin\". Refer https://git-scm.com/docs/git-remote",
 							Ref:         ref("github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1.GitRemoteConfig"),
 						},
 					},
@@ -430,7 +430,8 @@ func schema_pkg_apis_sensor_v1alpha1_GitRemoteConfig(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "GitRemoteConfig contains the configuration of a Git remote",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
@@ -595,7 +596,7 @@ func schema_pkg_apis_sensor_v1alpha1_ResourceObject(ref common.ReferenceCallback
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace in which to create this object defaults to the service account namespace",
+							Description: "Namespace in which to create this object defaults to the sensor namespace",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -261,7 +261,7 @@ type ResourceObject struct {
 	GroupVersionKind `json:",inline" protobuf:"bytes,5,opt,name=groupVersionKind"`
 
 	// Namespace in which to create this object
-	// defaults to the service account namespace
+	// defaults to the sensor namespace
 	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 
 	// Source of the K8 resource file(s)

--- a/sensors/trigger.go
+++ b/sensors/trigger.go
@@ -178,9 +178,13 @@ func (sec *sensorExecutionCtx) executeTrigger(trigger v1alpha1.Trigger) error {
 
 // createResourceObject creates K8s object for trigger
 func (sec *sensorExecutionCtx) createResourceObject(resource *v1alpha1.ResourceObject, obj *unstructured.Unstructured) error {
-	if resource.Namespace != "" {
-		obj.SetNamespace(resource.Namespace)
+	namespace := resource.Namespace
+	// Defaults to sensor's namespace
+	if namespace == "" {
+		namespace = sec.sensor.Namespace
 	}
+	obj.SetNamespace(namespace)
+
 	if resource.Labels != nil {
 		labels := obj.GetLabels()
 		if labels != nil {
@@ -225,7 +229,7 @@ func (sec *sensorExecutionCtx) createResourceObject(resource *v1alpha1.ResourceO
 	}
 	sec.log.Info().Str("api", apiResource.Name).Str("group-version", gvk.Version).Msg("created api resource")
 
-	reIf := client.Resource(apiResource, resource.Namespace)
+	reIf := client.Resource(apiResource, namespace)
 	liveObj, err := reIf.Create(obj)
 	if err != nil {
 		return fmt.Errorf("failed to create resource object. err: %+v", err)

--- a/sensors/trigger.go
+++ b/sensors/trigger.go
@@ -235,7 +235,7 @@ func (sec *sensorExecutionCtx) createResourceObject(resource *v1alpha1.ResourceO
 		return fmt.Errorf("failed to create resource object. err: %+v", err)
 	}
 	sec.log.Info().Str("kind", liveObj.GetKind()).Str("name", liveObj.GetName()).Msg("created object")
-	if !errors.IsAlreadyExists(err) {
+	if err == nil || !errors.IsAlreadyExists(err) {
 		return err
 	}
 	liveObj, err = reIf.Get(obj.GetName(), metav1.GetOptions{})


### PR DESCRIPTION
I set sensor's namespace as the default namespace of trigger resources, and added the tests.

I found OpenAPI spec is not updated when I executed `make openapi-gen`, so the PR also includes OpenAPI spec update for some other PRs.

Fixes #214 