### PR TITLE
Fix goroutine error in test

### DIFF
--- a/gateways/event-source_test.go
+++ b/gateways/event-source_test.go
@@ -151,10 +151,12 @@ testKey: testValue
 				convey.Convey("Event source should be removed", t, func() {
 					convey.So(i, convey.ShouldNotEqual, 0)
 					convey.So(event.Message, convey.ShouldEqual, "event_source_is_removed")
-					wg.Done()
 				})
+				goto end
 			}
 		}
+	end:
+		wg.Done()
 	}()
 
 	convey.Convey("Given new event sources, start consuming events", t, func() {


### PR DESCRIPTION
[The CI](https://travis-ci.org/argoproj/argo-events/builds/505797464) failed because goroutine is still waiting for the channel when the context is gone.

```
panic: Fail in goroutine after TestEventSources has completed [recovered]
	panic: Fail in goroutine after  has completed
```

I hope this fix solves the problem.