### PR TITLE
lower the wait timeout to a valid value

### DIFF
--- a/examples/gateways/aws-sqs-gateway-configmap.yaml
+++ b/examples/gateways/aws-sqs-gateway-configmap.yaml
@@ -12,4 +12,4 @@ data:
       key: secret
     region: "us-east-1"
     queue: "<queue-name>"
-    waitTimeSeconds: 50
+    waitTimeSeconds: 20


### PR DESCRIPTION
When using this cm with the default value of 50, we get errors from aws

```
2019-04-02T15:57:07Z | warn  | msg: failed to process item from queue, waiting for next timeout |  error="InvalidParameterValue: Value 50 for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20, if provided.\n\tstatus code: 400, request id: 58ec53b6-1b10-54be-a89f-06ab93836c82" event-source-name:notification
```