### PR TITLE
Fix slack sensor example

### DIFF
--- a/examples/sensors/slack.yaml
+++ b/examples/sensors/slack.yaml
@@ -9,11 +9,12 @@ metadata:
     argo-events-sensor-version: v0.10
 spec:
   template:
-    containers:
-      - name: "sensor"
-        image: "argoproj/sensor"
-        imagePullPolicy: Always
-    serviceAccountName: argo-events-sa
+    spec:
+      containers:
+        - name: "sensor"
+          image: "argoproj/sensor"
+          imagePullPolicy: Always
+      serviceAccountName: argo-events-sa
   eventProtocol:
     type: "HTTP"
     http:


### PR DESCRIPTION
In slack example was a bug. Validation failed when creating the sensor.