### PR TITLE
Make the instructions more explicit

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,14 +21,14 @@ Lets deploy a webhook gateway and sensor,
  * Once the gateway and sensor pods are running, trigger the webhook via a http POST request to `/example` endpoint.
    Note: the `WEBHOOK_SERVICE_URL` will differ based on the Kubernetes cluster.
 
-        export WEBHOOK_SERVICE_URL=$(minikube service -n argo-events --url <gateway_service_name>)
+        export WEBHOOK_SERVICE_URL=$(minikube service -n argo-events --url webhook-gateway-svc)
         echo $WEBHOOK_SERVICE_URL
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST $WEBHOOK_SERVICE_URL/example
  
    <b>Note</b>: 
    If you are facing an issue getting service url by running 
         
-        minikube service -n argo-events --url <gateway_service_name>
+        minikube service -n argo-events --url webhook-gateway-svc
         
    You can use port forwarding to access the service
 
@@ -36,7 +36,7 @@ Lets deploy a webhook gateway and sensor,
         
    Open another terminal window and enter 
    
-        kubectl port-forward -n argo-events <name_of_the_webhook_gateway_pod> 9003:<port_on_which_gateway_server_is_running>
+        kubectl port-forward -n argo-events <name_of_the_webhook_gateway_pod> 9003:9330
    
    You can now use `localhost:9003` to query webhook gateway
    


### PR DESCRIPTION
remove the <> so they instructions can just be copy/pasted into a terminal