### PR TITLE
Make example consistent with documentation

### DIFF
--- a/examples/event-sources/webhook.yaml
+++ b/examples/event-sources/webhook.yaml
@@ -15,7 +15,7 @@ data:
     # port to run HTTP server on
     port: "12000"
     # endpoint to listen to
-    endpoint: "/index"
+    endpoint: "/example"
     # HTTP request method to allow. In this case, only POST requests are accepted
     method: "POST"
 


### PR DESCRIPTION
[Documentation](https://argoproj.github.io/argo-events/getting_started/) tells the user to test the web hook by doing this:

```curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST `(minikube service --namespace=argo-events webhook-gateway-svc --url)`/example```

However, this will not work unless the example endpoint is set to ```/example```. This fixes it.