### PR TITLE
Ability to use JSON objects in the userPayload field for calendar events

### DIFF
--- a/gateways/core/calendar/config.go
+++ b/gateways/core/calendar/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package calendar
 
 import (
+	"encoding/json"
 	"github.com/sirupsen/logrus"
 	"time"
 
@@ -54,7 +55,7 @@ type calSchedule struct {
 
 	// UserPayload will be sent to sensor as extra data once the event is triggered
 	// +optional
-	UserPayload string `json:"userPayload,omitempty"`
+	UserPayload *json.RawMessage `json:"userPayload,omitempty"`
 }
 
 // calResponse is the event payload that is sent as response to sensor
@@ -63,7 +64,7 @@ type calResponse struct {
 	EventTime time.Time `json:"eventTime"`
 
 	// UserPayload if any
-	UserPayload string `json:"userPayload"`
+	UserPayload *json.RawMessage `json:"userPayload"`
 }
 
 func parseEventSource(eventSource string) (interface{}, error) {

--- a/gateways/core/calendar/start_test.go
+++ b/gateways/core/calendar/start_test.go
@@ -68,6 +68,9 @@ func TestListenEvents(t *testing.T) {
 		err = yaml.Unmarshal(data, &cal)
 		convey.So(err, convey.ShouldBeNil)
 
-		convey.So(cal.UserPayload, convey.ShouldEqual, "{\r\n\"hello\": \"world\"\r\n}")
+		payload, err := cal.UserPayload.MarshalJSON()
+		convey.So(err, convey.ShouldBeNil)
+
+		convey.So(string(payload), convey.ShouldEqual, `"{\r\n\"hello\": \"world\"\r\n}"`)
 	})
 }


### PR DESCRIPTION
At now, I am able to pass only string in userPayload field, but if I want to bind userPayload data to different places, sensor should receive it as object.

So, it would be great be able to use JSON objects in the userPayload field.