### PR TITLE
Wildcards in sensor dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -209,6 +209,20 @@
   version = "v0.19.0"
 
 [[projects]]
+  name = "github.com/gobwas/glob"
+  packages = [
+    ".",
+    "compiler",
+    "match",
+    "syntax",
+    "syntax/ast",
+    "syntax/lexer",
+    "util/runes",
+    "util/strings"
+  ]
+  revision = "e7a84e9525fe90abcda167b604e483cc959ad4aa"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -133,3 +133,7 @@ required = [
 [[constraint]]
   name = "k8s.io/gengo"
   revision = "b90029ef6cd877cb3f422d75b3a07707e3aac6b7"
+
+[[constraint]]
+  name = "github.com/gobwas/glob"
+  revision = "e7a84e9525fe90abcda167b604e483cc959ad4aa"

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -10,6 +10,7 @@ Sensors define a set of event dependencies (inputs) and triggers (outputs).
 
 ## What is an event dependency?
 A dependency is an event the sensor is waiting to happen. It is defined as "gateway-name:event-source-name".
+Also, you can use [globs](https://github.com/gobwas/glob#syntax) to catch a set of events (e.g. "gateway-name:*").
 
 ## What is a dependency group?
 A dependency group is basically a group of event dependencies.


### PR DESCRIPTION
At now argo sensor requires to specify in dependency accurate gateway and event name, but in some cases multiple events should be processed by one sensor (e.g. multiple calendar events).

So it would be great to use globs in sensor dependencies (like `gateway-name:*`)