### PR TITLE
Enable creating AWS sessions without providing explicit credentials f…

### DIFF
--- a/examples/event-sources/aws-sns.yaml
+++ b/examples/event-sources/aws-sns.yaml
@@ -56,3 +56,12 @@ data:
       name: aws-secret
       key: secret
     region: "us-east-1"
+
+  example-without-credentials: |-
+    topicArn: "topic-arn"
+    hook:
+     endpoint: "/"
+     # gateway can run multiple HTTP servers, just define a unique port.
+     port: "13000"
+     url: "http://mysecondfakeurl.fake"
+    region: "us-east-1"

--- a/examples/event-sources/aws-sns.yaml
+++ b/examples/event-sources/aws-sns.yaml
@@ -58,10 +58,11 @@ data:
     region: "us-east-1"
 
   example-without-credentials: |-
+    # If AWS access credentials are already present on the Pod's IAM role running the Gateway, 
+    # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
     topicArn: "topic-arn"
     hook:
      endpoint: "/"
-     # gateway can run multiple HTTP servers, just define a unique port.
      port: "13000"
      url: "http://mysecondfakeurl.fake"
     region: "us-east-1"

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -40,3 +40,8 @@ data:
     region: "us-east-1"
     queue: "my-fake-queue-2"
     waitTimeSeconds: 20
+
+  example-3: |-
+    region: "us-east-1"
+    queue: "my-fake-queue-2"
+    waitTimeSeconds: 20

--- a/gateways/common/aws.go
+++ b/gateways/common/aws.go
@@ -48,3 +48,9 @@ func GetAWSSession(creds *credentials.Credentials, region string) (*session.Sess
 		Credentials: creds,
 	})
 }
+
+func GetAWSSessionWithoutCreds(region string) (*session.Session, error) {
+	return session.NewSession(&aws.Config{
+		Region: &region,
+	})
+}

--- a/gateways/common/aws_test.go
+++ b/gateways/common/aws_test.go
@@ -75,4 +75,12 @@ func TestAWS(t *testing.T) {
 			convey.So(session, convey.ShouldNotBeNil)
 		})
 	})
+
+	convey.Convey("create AWS credential using already present config/IAM role", t, func() {
+		convey.Convey("Get a new aws session", func() {
+			session, err := GetAWSSessionWithoutCreds("mock-region")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(session, convey.ShouldNotBeNil)
+		})
+	})
 }

--- a/gateways/community/aws-sns/config_test.go
+++ b/gateways/community/aws-sns/config_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package aws_sns
 
 import (
-	"github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
 )
 
 var es = `
@@ -36,9 +37,26 @@ secretKey:
     name: sns
 `
 
+var esWithoutCreds = `
+hook:
+ endpoint: "/test"
+ port: "8080"
+ url: "myurl/test"
+topicArn: "test-arn"
+region: "us-east-1"
+`
+
 func TestParseConfig(t *testing.T) {
 	convey.Convey("Given a aws-sns event source, parse it", t, func() {
 		ps, err := parseEventSource(es)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(ps, convey.ShouldNotBeNil)
+		_, ok := ps.(*snsEventSource)
+		convey.So(ok, convey.ShouldEqual, true)
+	})
+
+	convey.Convey("Given a aws-sns event source without credentials, parse it", t, func() {
+		ps, err := parseEventSource(esWithoutCreds)
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(ps, convey.ShouldNotBeNil)
 		_, ok := ps.(*snsEventSource)

--- a/gateways/community/aws-sns/start_test.go
+++ b/gateways/community/aws-sns/start_test.go
@@ -106,5 +106,15 @@ func TestAWSSNS(t *testing.T) {
 			err = rc.PostStop()
 			convey.So(err, convey.ShouldNotBeNil)
 		})
+
+		psWithoutCreds, err2 := parseEventSource(esWithoutCreds)
+		convey.So(err2, convey.ShouldBeNil)
+
+		rc.snses = psWithoutCreds.(*snsEventSource)
+
+		convey.Convey("Run post activate on event source without credentials", func() {
+			err := rc.PostStart()
+			convey.So(err, convey.ShouldNotBeNil)
+		})
 	})
 }

--- a/gateways/community/aws-sns/validate.go
+++ b/gateways/community/aws-sns/validate.go
@@ -19,6 +19,7 @@ package aws_sns
 import (
 	"context"
 	"fmt"
+
 	"github.com/argoproj/argo-events/gateways"
 	gwcommon "github.com/argoproj/argo-events/gateways/common"
 )
@@ -38,12 +39,6 @@ func validateSNSConfig(config interface{}) error {
 	}
 	if sc.Region == "" {
 		return fmt.Errorf("must specify region")
-	}
-	if sc.AccessKey == nil {
-		return fmt.Errorf("must specify access key")
-	}
-	if sc.SecretKey == nil {
-		return fmt.Errorf("must specify secret key")
 	}
 	return gwcommon.ValidateWebhook(sc.Hook)
 }

--- a/gateways/community/aws-sqs/config_test.go
+++ b/gateways/community/aws-sqs/config_test.go
@@ -34,9 +34,23 @@ queue: "test-queue"
 waitTimeSeconds: 10
 `
 
+var esWithoutCreds = `
+region: "us-east-1"
+queue: "test-queue"
+waitTimeSeconds: 10
+`
+
 func TestParseConfig(t *testing.T) {
 	convey.Convey("Given a aws-sqsEventSource event source, parse it", t, func() {
 		ps, err := parseEventSource(es)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(ps, convey.ShouldNotBeNil)
+		_, ok := ps.(*sqsEventSource)
+		convey.So(ok, convey.ShouldEqual, true)
+	})
+
+	convey.Convey("Given a aws-sqsEventSource event source without AWS credentials, parse it", t, func() {
+		ps, err := parseEventSource(esWithoutCreds)
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(ps, convey.ShouldNotBeNil)
 		_, ok := ps.(*sqsEventSource)

--- a/gateways/community/aws-sqs/validate.go
+++ b/gateways/community/aws-sqs/validate.go
@@ -40,12 +40,6 @@ func validateSQSConfig(config interface{}) error {
 	if sc.Region == "" {
 		return fmt.Errorf("must specify region")
 	}
-	if sc.AccessKey == nil {
-		return fmt.Errorf("must specify access key")
-	}
-	if sc.SecretKey == nil {
-		return fmt.Errorf("must specify secret key")
-	}
 	if sc.Queue == "" {
 		return fmt.Errorf("must specify queue name")
 	}


### PR DESCRIPTION
…or AWS Gateways

AWS Gateways running on pods configured with IAM roles can use event sources without specifying access credentials.
The AWS Session is created using the IAM role present on the pod and has permissions associated with the IAM role.

This addresses https://github.com/argoproj/argo-events/issues/298

@VaibhavPage I added the necessary code and tests. Let me know what you think and if there are any changes to be made.