### PR TITLE
Added ability to refer the eventSource in a different namespace.

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -111,7 +111,7 @@ The gateway `spec` has following fields:
 
 1. `type`: Type of the gateway. This is defined by the user.
 
-2. `eventSource`: Refers to K8s configmap that holds the list of event sources.
+2. `eventSource`: Refers to K8s configmap that holds the list of event sources. You can use `namespace/configmap-name` syntax to refer the configmap in a different namespace. 
 
 3. `processorPort`: This is a gateway server port. You can leave this to `9330` unless you really have to change it to a different port.
 


### PR DESCRIPTION
In some cases it's necessary to refer the eventSource in a different namespace. But gateway-client by default search configmaps in the gateway's namespace without any ability to change it. With this fix, you are able to refer the eventSource in custom namespace with a syntax `namespace/configmap-name`.