### PR TITLE
Fix container name of `/examples/gateways/gcp-pubsub.yaml`

### DIFF
--- a/examples/gateways/gcp-pubsub.yaml
+++ b/examples/gateways/gcp-pubsub.yaml
@@ -27,7 +27,7 @@ spec:
           image: "argoproj/gateway-client"
           imagePullPolicy: "Always"
           command: ["/bin/gateway-client"]
-        - name: "aws-sqs-events"
+        - name: "gcp-pubsub-events"
           image: "argoproj/gcp-pubsub-gateway"
           imagePullPolicy: "Always"
           command: ["/bin/gcp-pubsub-gateway"]


### PR DESCRIPTION
The name of the container in `argo-events/examples/gateways/gcp-pubsub.yaml` was named -        - `aws-sqs-events` instead of  `gcp-pubsub-events`