### PR TITLE
Support different trigger parameter operations (#315)

### DIFF
--- a/controllers/sensor/validate.go
+++ b/controllers/sensor/validate.go
@@ -156,6 +156,16 @@ func validateTriggerParameter(parameter *v1alpha1.TriggerParameter) error {
 	if parameter.Dest == "" {
 		return fmt.Errorf("parameter destination can't be empty")
 	}
+
+	switch op := parameter.Operation; op {
+	case v1alpha1.TriggerParameterOpAppend:
+	case v1alpha1.TriggerParameterOpOverwrite:
+	case v1alpha1.TriggerParameterOpPrepend:
+	case v1alpha1.TriggerParameterOpNone:
+	default:
+		return fmt.Errorf("parameter operation %+v is invalid", op)
+	}
+
 	return nil
 }
 

--- a/docs/parameterization.md
+++ b/docs/parameterization.md
@@ -21,5 +21,6 @@ A `parameter` contains:
    1. `src`:
        1. `event`: the name of the event dependency
        2. `path`: a key within event payload to look for
-       3. `value`: default value if sensor can't find `path` in event payload.   
+       3. `value`: default value if sensor can't find `path` in event payload
    2. `dest`: destination key within resource definition whose corresponding value needs to be replaced with value from event payload
+   3. `operation`: what to do with the existing value at `dest`, either `overwrite`, `prepend`, or `append`

--- a/examples/sensors/complete-trigger-parameterization.yaml
+++ b/examples/sensors/complete-trigger-parameterization.yaml
@@ -4,6 +4,7 @@
 #   "name": "trigger-wf-1",
 #   "namespace": "argo-events",
 #   "bucket": "mybucket",
+#   "port": "9000",
 #   "key": "hello.yaml",
 #   "image": "docker/busybox",
 #  }
@@ -48,7 +49,7 @@ spec:
             bucket:
               name: THIS_WILL_BE_REPLACED_BUCKET
               key: THIS_WILL_BE_REPLACED_KEY
-            endpoint: minio-service.argo-events:9000
+            endpoint: "minio-service.argo-events:"
             insecure: true
             accessKey:
               key: accesskey
@@ -74,6 +75,12 @@ spec:
             event: "webhook-gateway:example"
             path: key
           dest: source.s3.bucket.key
+        - src:
+            event: "webhook-gateway:example"
+            path: port
+          dest: source.s3.endpoint
+          # Append the port to the existing source.s3.endpoint value
+          operation: append
       # Apply parameter for workflow
       resourceParameters:
         - src:

--- a/pkg/apis/sensor/v1alpha1/openapi_generated.go
+++ b/pkg/apis/sensor/v1alpha1/openapi_generated.go
@@ -976,6 +976,13 @@ func schema_pkg_apis_sensor_v1alpha1_TriggerParameter(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"operation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Operation is what to do with the existing value at Dest, whether to 'prepend', 'overwrite', or 'append' it.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"src", "dest"},
 			},

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -239,6 +239,21 @@ type TriggerCondition struct {
 	All []string `json:"all,omitempty" protobuf:"bytes,2,rep,name=all"`
 }
 
+// TriggerParameterOperation represents how to set a trigger destination
+// resource key
+type TriggerParameterOperation string
+
+const (
+	// TriggerParameterOpNone is the zero value of TriggerParameterOperation
+	TriggerParameterOpNone TriggerParameterOperation = ""
+	// TriggerParameterOpAppend means append the new value to the existing
+	TriggerParameterOpAppend TriggerParameterOperation = "append"
+	// TriggerParameterOpOverwrite means overwrite the existing value with the new
+	TriggerParameterOpOverwrite TriggerParameterOperation = "overwrite"
+	// TriggerParameterOpPrepend means prepend the new value to the existing
+	TriggerParameterOpPrepend TriggerParameterOperation = "prepend"
+)
+
 // TriggerParameter indicates a passed parameter to a service template
 type TriggerParameter struct {
 	// Src contains a source reference to the value of the parameter from a event event
@@ -249,6 +264,10 @@ type TriggerParameter struct {
 	// The -1 key can be used to append a value to an existing array.
 	// See https://github.com/tidwall/sjson#path-syntax for more information about how this is used.
 	Dest string `json:"dest" protobuf:"bytes,2,name=dest"`
+
+	// Operation is what to do with the existing value at Dest, whether to
+	// 'prepend', 'overwrite', or 'append' it.
+	Operation TriggerParameterOperation `json:"operation" protobuf:"bytes,3,name=operation"`
 }
 
 // TriggerParameterSource defines the source for a parameter from a event event

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -267,7 +267,7 @@ type TriggerParameter struct {
 
 	// Operation is what to do with the existing value at Dest, whether to
 	// 'prepend', 'overwrite', or 'append' it.
-	Operation TriggerParameterOperation `json:"operation" protobuf:"bytes,3,name=operation"`
+	Operation TriggerParameterOperation `json:"operation,omitempty" protobuf:"bytes,3,opt,name=operation"`
 }
 
 // TriggerParameterSource defines the source for a parameter from a event event

--- a/sensors/trigger-params_test.go
+++ b/sensors/trigger-params_test.go
@@ -141,6 +141,44 @@ func Test_applyParams(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "simpleJSON (prepended field) -> success",
+			args: args{
+				jsonObj: []byte(`{"x":"before"}`),
+				params: []v1alpha1.TriggerParameter{
+					{
+						Src: &v1alpha1.TriggerParameterSource{
+							Event: "simpleJSON",
+							Path:  "name.last",
+						},
+						Dest:      "x",
+						Operation: v1alpha1.TriggerParameterOpPrepend,
+					},
+				},
+				events: events,
+			},
+			want:    []byte(`{"x":"magaldibefore"}`),
+			wantErr: false,
+		},
+		{
+			name: "simpleJSON (appended field) -> success",
+			args: args{
+				jsonObj: []byte(`{"x":"before"}`),
+				params: []v1alpha1.TriggerParameter{
+					{
+						Src: &v1alpha1.TriggerParameterSource{
+							Event: "simpleJSON",
+							Path:  "name.last",
+						},
+						Dest:      "x",
+						Operation: v1alpha1.TriggerParameterOpAppend,
+					},
+				},
+				events: events,
+			},
+			want:    []byte(`{"x":"beforemagaldi"}`),
+			wantErr: false,
+		},
+		{
 			name: "non JSON, no default -> pass payload bytes without converting",
 			args: args{
 				jsonObj: []byte(``),


### PR DESCRIPTION
Implemented an additional `operation` field for trigger parameters that
dictates what is to be done with the current value at `dest`. Possible
keyword values are:

 - `overwrite` Overwrite the current value (default/prior behavior)
 - `prepend` Prepend the value at `dest` with the value at `source.path`
 - `append` Append the value at `dest` with the value at `source.path`