### PR TITLE
Support fetching/checkouts of non-branch/-tag git refs

### DIFF
--- a/pkg/apis/sensor/v1alpha1/openapi_generated.go
+++ b/pkg/apis/sensor/v1alpha1/openapi_generated.go
@@ -433,6 +433,13 @@ func schema_pkg_apis_sensor_v1alpha1_GitArtifact(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"ref": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ref to use to pull trigger resource. Will result in a shallow clone and fetch.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"remote": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Remote to manage set of tracked repositories. Defaults to \"origin\". Refer https://git-scm.com/docs/git-remote",

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -466,6 +466,11 @@ type GitArtifact struct {
 	// +optional
 	Tag string `json:"tag,omitempty" protobuf:"bytes,8,opt,name=tag"`
 
+	// Ref to use to pull trigger resource. Will result in a shallow clone and
+	// fetch.
+	// +optional
+	Ref string `json:"ref,omitempty" protobuf:"bytes,8,opt,name=ref"`
+
 	// Remote to manage set of tracked repositories. Defaults to "origin".
 	// Refer https://git-scm.com/docs/git-remote
 	// +optional

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -469,12 +469,12 @@ type GitArtifact struct {
 	// Ref to use to pull trigger resource. Will result in a shallow clone and
 	// fetch.
 	// +optional
-	Ref string `json:"ref,omitempty" protobuf:"bytes,8,opt,name=ref"`
+	Ref string `json:"ref,omitempty" protobuf:"bytes,9,opt,name=ref"`
 
 	// Remote to manage set of tracked repositories. Defaults to "origin".
 	// Refer https://git-scm.com/docs/git-remote
 	// +optional
-	Remote *GitRemoteConfig `json:"remote" protobuf:"bytes,9,opt,name=remote"`
+	Remote *GitRemoteConfig `json:"remote" protobuf:"bytes,10,opt,name=remote"`
 }
 
 // GitRemoteConfig contains the configuration of a Git remote

--- a/store/git_test.go
+++ b/store/git_test.go
@@ -94,4 +94,10 @@ func TestGetBranchOrTag(t *testing.T) {
 		tag := gar.getBranchOrTag()
 		convey.So(tag.Branch, convey.ShouldNotEqual, "refs/heads/master")
 	})
+
+	convey.Convey("Given a git artifact with a specific ref, get the ref", t, func() {
+		gar.artifact.Ref = "refs/something/weird/or/specific"
+		br := gar.getBranchOrTag()
+		convey.So(br.Branch, convey.ShouldEqual, "refs/something/weird/or/specific")
+	})
 }


### PR DESCRIPTION
Provides a `source.git.ref` field for specifying a specific non-branch
non-tag git ref at which to perform a checkout. Providing one will
result in a shallow (depth 1) clone of the repo and shallow subsequent
fetches.

The motivation for this change is to support sourcing of trigger
templates from Gerrit patchsets. Gerrit uses non-branch/-tag refs
extensively and specifically in this case stores change patchsets in
`refs/changes/[slice]/[change]/[patchset]`. While arbitrary refs are
kind of an obscure git feature, there very well may be other git based
systems utilizing them.