### PR TITLE
Rename event-source of example gcp-pubsub to match gcp-pubsub gateway

### DIFF
--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gcp-pubsub-configmap
+  name: gcp-pubsub-event-source
   labels:
     # do not remove
     argo-events-event-source-version: v0.10


### PR DESCRIPTION
The example of pubsub configmap has the name `gcp-pubsub-configmap` while the example pubsub gateway uses `gcp-pubsub-event-source`. To keep it consistent with other examples and to make the example work out of the box, change the name of the the event source to `gcp-pubsub-event-source`. 