### PR TITLE
Pub/Sub: multi-project support

### DIFF
--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   example-1: |-
     # id of your project
-    projectId: "my-fake-project-id"
+    projectID: "my-fake-project-id"
     # topic name
     topic: "my-fake-topic"
     # Refers to the credential file that is mounted in the gateway pod.

--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -12,6 +12,8 @@ data:
   example-1: |-
     # id of your project
     projectID: "my-fake-project-id"
+    # (optional) id of project for topic, same as projectID by default
+    # topicProjectID: "my-fake-topic-project-id"
     # topic name
     topic: "my-fake-topic"
     # Refers to the credential file that is mounted in the gateway pod.

--- a/gateways/community/gcp-pubsub/config.go
+++ b/gateways/community/gcp-pubsub/config.go
@@ -32,6 +32,9 @@ type GcpPubSubEventSourceExecutor struct {
 type pubSubEventSource struct {
 	// ProjectID is the unique identifier for your project on GCP
 	ProjectID string `json:"projectID"`
+	// TopicProjectID identifies the project where the topic should exist or be created
+	// (assumed to be the same as ProjectID by default)
+	TopicProjectID string `json:"topicProjectID"`
 	// Topic on which a subscription will be created
 	Topic string `json:"topic"`
 	// CredentialsFile is the file that contains credentials to authenticate for GCP

--- a/gateways/community/gcp-pubsub/start.go
+++ b/gateways/community/gcp-pubsub/start.go
@@ -17,9 +17,10 @@ limitations under the License.
 package pubsub
 
 import (
-	"cloud.google.com/go/pubsub"
 	"context"
 	"fmt"
+
+	"cloud.google.com/go/pubsub"
 	"github.com/argoproj/argo-events/common"
 	"github.com/argoproj/argo-events/gateways"
 	"google.golang.org/api/option"
@@ -60,7 +61,12 @@ func (ese *GcpPubSubEventSourceExecutor) listenEvents(ctx context.Context, sc *p
 		return
 	}
 
-	topic := client.Topic(sc.Topic)
+	var topic *pubsub.Topic
+	if sc.TopicProjectID != "" {
+		topic = client.TopicInProject(sc.Topic, sc.TopicProjectID)
+	} else {
+		topic = client.Topic(sc.Topic)
+	}
 	exists, err := topic.Exists(ctx)
 	if err != nil {
 		errorCh <- err

--- a/gateways/community/gcp-pubsub/start.go
+++ b/gateways/community/gcp-pubsub/start.go
@@ -61,12 +61,16 @@ func (ese *GcpPubSubEventSourceExecutor) listenEvents(ctx context.Context, sc *p
 		return
 	}
 
-	var topic *pubsub.Topic
-	if sc.TopicProjectID != "" {
-		topic = client.TopicInProject(sc.Topic, sc.TopicProjectID)
-	} else {
-		topic = client.Topic(sc.Topic)
+	topicClient := client // use same client for topic and subscription by default
+	if sc.TopicProjectID != "" && sc.TopicProjectID != sc.ProjectID {
+		topicClient, err = pubsub.NewClient(ctx, sc.TopicProjectID, option.WithCredentialsFile(sc.CredentialsFile))
+		if err != nil {
+			errorCh <- err
+			return
+		}
 	}
+
+	topic := topicClient.Topic(sc.Topic)
 	exists, err := topic.Exists(ctx)
 	if err != nil {
 		errorCh <- err
@@ -74,7 +78,7 @@ func (ese *GcpPubSubEventSourceExecutor) listenEvents(ctx context.Context, sc *p
 	}
 	if !exists {
 		logger.Info("Creating GCP PubSub topic")
-		if _, err := client.CreateTopic(ctx, sc.Topic); err != nil {
+		if _, err := topicClient.CreateTopic(ctx, sc.Topic); err != nil {
 			errorCh <- err
 			return
 		}


### PR DESCRIPTION
The idea is to make it possible to subscribe to a topic in a different project by setting the `topicProjectID` field in the event source configuration. If the field isn't set, we continue to use the `projectID` field by default. We also still use the `projectID` field for the subscription.

Related issue: https://github.com/argoproj/argo-events/issues/329