### PR TITLE
Allow watching of resources in all namespaces at once

### DIFF
--- a/examples/event-sources/resource.yaml
+++ b/examples/event-sources/resource.yaml
@@ -82,3 +82,14 @@ data:
       labels:
         workflows.argoproj.io/completed: "true"
       prefix: "hello"
+
+  # watch for completed workflows in any namespace
+  example-without-namespace: |-
+    # namespace: (omitted to match any namespace)
+    group: "k8s.io"
+    version: v1
+    kind: Workflow
+    type: ADDED
+    filter:
+      labels:
+        workflows.argoproj.io/completed: "true"

--- a/gateways/core/resource/validate.go
+++ b/gateways/core/resource/validate.go
@@ -37,9 +37,6 @@ func validateResource(config interface{}) error {
 	if res.Version == "" {
 		return fmt.Errorf("resource version must be specified")
 	}
-	if res.Namespace == "" {
-		return fmt.Errorf("resource namespace must be specified")
-	}
 	if res.Kind == "" {
 		return fmt.Errorf("resource kind must be specified")
 	}


### PR DESCRIPTION
The `namespace` field of a resource event source is now optional to
allow for configuration that would watch for resource related events in
all namespaces at once. Simply omitting the field works in this way
because the k8s dynamic client used in implementation can accept a
zero-length string for namespace.