### PR TITLE
Fix missing resource group

### DIFF
--- a/examples/event-sources/resource.yaml
+++ b/examples/event-sources/resource.yaml
@@ -34,7 +34,7 @@ data:
   # watch all namespace related events
   example-with-all-types-and-no-filter: |-
     namespace: argo-events
-    group: "k8s.io"
+    group: ""
     version: "v1"
     kind: "Namespace"
 
@@ -51,7 +51,7 @@ data:
   # create event if pod with specified annotation gets deleted
   example-with-annotations-filter: |-
     namespace: argo-events
-    group: "k8s.io"
+    group: ""
     version: v1
     kind: Pod
     type: DELETED
@@ -71,7 +71,7 @@ data:
 
   example-with-multi-filters: |-
     namespace: argo-events
-    group: "k8s.io"
+    group: ""
     version: v1
     kind: Pod
     type: ADDED

--- a/gateways/core/resource/config.go
+++ b/gateways/core/resource/config.go
@@ -39,8 +39,6 @@ type resource struct {
 	Namespace string `json:"namespace"`
 	// Filter is applied on the metadata of the resource
 	Filter *ResourceFilter `json:"filter,omitempty"`
-	// Version of the source
-	Version string `json:"version"`
 	// Group of the resource
 	metav1.GroupVersionKind `json:",inline"`
 	// Type is the event type. Refer https://github.com/kubernetes/apimachinery/blob/dcb391cde5ca0298013d43336817d20b74650702/pkg/watch/watch.go#L43

--- a/gateways/core/resource/config_test.go
+++ b/gateways/core/resource/config_test.go
@@ -35,9 +35,15 @@ filter:
 func TestParseConfig(t *testing.T) {
 	convey.Convey("Given a resource event source, parse it", t, func() {
 		ps, err := parseEventSource(es)
+
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(ps, convey.ShouldNotBeNil)
-		_, ok := ps.(*resource)
+
+		resource, ok := ps.(*resource)
 		convey.So(ok, convey.ShouldEqual, true)
+
+		convey.So(resource.Group, convey.ShouldEqual, "")
+		convey.So(resource.Version, convey.ShouldEqual, "v1")
+		convey.So(resource.Kind, convey.ShouldEqual, "Pod")
 	})
 }

--- a/gateways/core/resource/start.go
+++ b/gateways/core/resource/start.go
@@ -217,7 +217,7 @@ func (ese *ResourceEventSourceExecutor) canWatchResource(apiResource *metav1.API
 }
 
 func (ese *ResourceEventSourceExecutor) resolveGroupVersion(obj *resource) string {
-	if obj.Version == "v1" {
+	if obj.Group == "" {
 		return obj.Version
 	}
 	return obj.Group + "/" + obj.Version

--- a/gateways/core/resource/start_test.go
+++ b/gateways/core/resource/start_test.go
@@ -71,15 +71,36 @@ func TestResolveGroupVersion(t *testing.T) {
 		convey.So(err, convey.ShouldBeNil)
 		gv := ese.resolveGroupVersion(ps.(*resource))
 		convey.So(gv, convey.ShouldEqual, "v1")
+
+		// Resource with defined both Group & Version
 		gv = ese.resolveGroupVersion(&resource{
 			GroupVersionKind: metav1.GroupVersionKind{
 				Group:   "argoproj.io",
 				Kind:    "Fake",
 				Version: "v1alpha1",
 			},
-			Version: "v1alpha1",
 		})
 		convey.So(gv, convey.ShouldEqual, "argoproj.io/v1alpha1")
+
+		// Resource with undefined Group & defined Version
+		gv = ese.resolveGroupVersion(&resource{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "",
+				Kind:    "Fake",
+				Version: "v1alpha1",
+			},
+		})
+		convey.So(gv, convey.ShouldEqual, "v1alpha1")
+
+		// Resource with Version == "v1"
+		gv = ese.resolveGroupVersion(&resource{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "argoproj.io",
+				Kind:    "Fake",
+				Version: "v1",
+			},
+		})
+		convey.So(gv, convey.ShouldEqual, "argoproj.io/v1")
 	})
 }
 
@@ -93,7 +114,7 @@ func TestFilter(t *testing.T) {
 				Namespace: "fake",
 				Labels: map[string]string{
 					"workflows.argoproj.io/phase": "Succeeded",
-					"name": "my-workflow",
+					"name":                        "my-workflow",
 				},
 			},
 		}

--- a/gateways/core/resource/validate.go
+++ b/gateways/core/resource/validate.go
@@ -43,8 +43,5 @@ func validateResource(config interface{}) error {
 	if res.Kind == "" {
 		return fmt.Errorf("resource kind must be specified")
 	}
-	if res.Group == "" {
-		return fmt.Errorf("resource group must be specified")
-	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes the `Group` being removed whenever `Version` == `v1` and relates to #328 

In the issue, the API group `build.openshift.io/v1` was originally transformed to just `v1` which caused `Build` resource to be undetected.

Additional changes:
- Kubernetes core API group can now be denoted as empty string `""` and is therefore implicit if not provided