### PR TITLE
getting_started.md: Change/fix manual port-forward cmd

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -36,7 +36,7 @@ Lets deploy a webhook gateway and sensor,
         
    Open another terminal window and enter 
    
-        kubectl port-forward -n argo-events <name_of_the_webhook_gateway_pod> 9003:9330
+        kubectl port-forward -n argo-events svc/webhook-gateway-svc 9003:12000
    
    You can now use `localhost:9003` to query webhook gateway
    


### PR DESCRIPTION
Changes `kubectl port-forward` to point to service instead of pod.

Reason:
I was not able to make this work using port-forwarding to the pod as per the docs. I also don't understand enough of the architecture to troubleshoot effectively. However, just port-forwarding to the service worked flawlessly.