### PR TITLE
Omit duplicate CRD for workflows

### DIFF
--- a/hack/k8s/manifests/kustomization.yaml
+++ b/hack/k8s/manifests/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
   - ./sensor-controller-configmap.yaml
   - ./sensor-controller-deployment.yaml
   - ./sensor-crd.yaml
-  - ./workflow-crd.yaml


### PR DESCRIPTION
When `argoproj/argo-events` is installed alongside `argoproj/argo` via Kustomize,
there is a collision between the workflow CRD defined by the argo project
and the one which is duplicated in this project. An example of this
issue in action would be a kustomization file which looks like this:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
bases:
  - github.com/argoproj/argo//manifests/cluster-install
  - github.com/argoproj/argo-events//hack/k8s/manifests/
```

A `kustomize build` with that kustomization.yml results in the following error with kustomize v3.2.0:

```
Error: accumulating resources: recursed merging from path 'github.com/argoproj/argo-events//hack/k8s/manifests/': may not add resource with an already registered id: apiextensions.k8s.io_v1beta1_CustomResourceDefinition|~X|workflows.argoproj.io
```

This is due to both `argoproj/argo` and `argoproj/argo-events`
defining a CRD for `workflows.argoproj.io`. Removing the reference to this CRD
from the kustomization.yml in this project will allow both projects to be deployed
alongside each other more easily with kustomize. The workflow CRD
perhaps should be removed from this project entirely.

This commit addresses the issue reported in #367