### PR TITLE
Aggregate gateway and sensor permissions to admin/edit/view roles

### DIFF
--- a/hack/k8s/manifests/argo-events-cluster-roles.yaml
+++ b/hack/k8s/manifests/argo-events-cluster-roles.yaml
@@ -92,3 +92,70 @@ rules:
       - update
       - patch
       - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: argo-events-aggregate-to-admin
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - gateways
+      - gateways/finalizers
+      - sensors
+      - sensors/finalizers
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: argo-events-aggregate-to-edit
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - gateways
+      - gateways/finalizers
+      - sensors
+      - sensors/finalizers
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: argo-events-aggregate-to-view
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - gateways
+      - gateways/finalizers
+      - sensors
+      - sensors/finalizers
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
After installing argo-events into a cluster, it is convenient to have
anyone with the admin, edit, or view roles to be able to interact
with the sensors and gateways. A way to accomplish this is to create
a cluster role with the appropriate permissions, and aggregate them
to the respective cluster roles. Here is a link to the kubernetes doc:
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

This is very similar to what is done for argo workflows, as seen here:https://github.com/argoproj/argo/blob/fc1ec1a51462c9a114417db801e3a9715d3dc6b4/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml

This commit addresses the issue reported in #381