### PR TITLE
chore: Fix Calendar userPayload JSON Example

### DIFF
--- a/examples/event-sources/calendar.yaml
+++ b/examples/event-sources/calendar.yaml
@@ -17,14 +17,16 @@ spec:
       schedule: "30 * * * *"
       # userPayload is a static string that will be send to the the sensor with each event payload
       # whatever you put here is blindly delivered to sensor.
-      userPayload: "{\"hello\": \"world\"}"
+      # access in resourceParameters or templateParameters via the path userPayload.hello
+      userPayload: {"hello": "world"}
 
     schedule-in-specific-timezone:
       # creates an event every 20 seconds
       interval: "20s"
       # userPayload is a static string that will be send to the the sensor with each event payload
       # whatever you put here is blindly delivered to sensor.
-      userPayload: "{\"hello\": \"world\"}"
+      # access in resourceParameters or templateParameters via the path userPayload.hello
+      userPayload: {"hello": "world"}
       # timezone
       # more info: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
       timezone: "America/New_York"


### PR DESCRIPTION
If a user wants to treat the `userPayload` as JSON, it should be define as JSON not as a string.