### PR TITLE
fix: Resource Event Source Example

### DIFF
--- a/examples/event-sources/resource.yaml
+++ b/examples/event-sources/resource.yaml
@@ -39,7 +39,7 @@ spec:
       group: argoproj.io
       version: v1alpha1
       resource: workflows
-      type: MODIFIED
+      type: UPDATE
       filter:
         prefix: "my-workflow"
 


### PR DESCRIPTION
Accorinding to https://github.com/argoproj/argo-events/blob/master/pkg/apis/eventsources/v1alpha1/types.go#L119, the only types for `type` are `ADD`, `DELETE`, and `UPDATE`. I assumed `MODIFIED` is suppose to be `UPDATE`