### PR TITLE
fix: gcp pubsub example

### DIFF
--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-pubsub-event-source
 spec:
   type: "pubsub"
-  pubsub:
+  pubSub:
     example-event-source:
       # id of your project
       projectID: "my-fake-project-id"

--- a/examples/gateways/gcp-pubsub.yaml
+++ b/examples/gateways/gcp-pubsub.yaml
@@ -7,7 +7,7 @@ metadata:
     gateways.argoproj.io/gateway-controller-instanceid: argo-events
 spec:
   replica: 1
-  type: "gcp-pubsub"
+  type: "pubsub"
   eventSourceRef:
     name: "gcp-pubsub-event-source"
     # optional, if event source is deployed in a different namespace than the gateway


### PR DESCRIPTION
Eventsource type is `pubsub` not `gcp-pubsub` also properties for a pubsub in the eventsource spec should be `pubSub` not `pubsub`. Once I fixed those submitting a message to the topic caused the sensor to trigger and all the right stuff to happen.

It seems like both of these incorrect names should probably have created more noise in my logs. I didn't see any errors but I might not have been looking in the right place. I can file an issue for that if you would like.