### PR TITLE
fix: Add missing path on tutorials

### DIFF
--- a/docs/tutorials/02-parameterization.md
+++ b/docs/tutorials/02-parameterization.md
@@ -54,7 +54,7 @@ the gateway, lets see how we can use the event context to parameterize the Argo 
 
 1. Update the `Webhook Sensor` and add the `contextKey` for the parameter at index 0.
 
-        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/sensor-01.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/02-parameterization/sensor-01.yaml
 
 2. Send a HTTP request to the gateway.
 
@@ -91,7 +91,7 @@ print the message.
 
 1. Update the `Webhook Sensor` and add the `dataKey` in the parameter at index 0.
 
-        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/sensor-02.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/02-parameterization/sensor-02.yaml
 
 2. Send a HTTP request to the gateway.
 
@@ -132,7 +132,7 @@ important when the `key` you defined in the parameter doesn't exist in the event
 1. Update the `Webhook Sensor` and add the `value` for the parameter at index 0.
    We will also update the `dataKey` to an unknown event key.
 
-        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/sensor-03.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/02-parameterization/sensor-03.yaml
 
 2. Send a HTTP request to the gateway.
 
@@ -167,7 +167,7 @@ a parameter comes handy.
 1. Update the `Webhook Sensor` and add the `operation` in the parameter at index 0.
    We will prepend the message to an existing value.
 
-        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/sensor-04.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/02-parameterization/sensor-04.yaml
 
 
 2. Send a HTTP request to the gateway.
@@ -211,7 +211,7 @@ applying a parameter at the trigger template level.
 
 1. Update the `Webhook Sensor` and add parameters at trigger level.
 
-        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/sensor-05.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/tutorials/02-parameterization/sensor-05.yaml
 
 2. Send a HTTP request to the gateway.
 


### PR DESCRIPTION
Add `02-parameterization` in `example/tutorials` path