### PR TITLE
docs: Add method attribute to all webhook-derived EventSource examples

### DIFF
--- a/examples/event-sources/aws-sns.yaml
+++ b/examples/event-sources/aws-sns.yaml
@@ -15,6 +15,8 @@ spec:
         endpoint: "/"
         # port to run HTTP server on
         port: "12000"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
         # url the gateway will use to register at AWS.
         # This url must be reachable from outside the cluster.
         # The gateway pod is backed by the service defined in the gateway spec. So get the URL for that service AWS can reach to.
@@ -40,6 +42,7 @@ spec:
         endpoint: "/"
         # gateway can run multiple HTTP servers, just define a unique port.
         port: "13000"
+        method: "POST"
         url: "http://mysecondfakeurl.fake"
         # path to file that is mounted in gateway pod which contains certs
         serverCertPath: "some path in pod"
@@ -60,5 +63,6 @@ spec:
       webhook:
         endpoint: "/"
         port: "13000"
+        method: "POST"
         url: "http://mysecondfakeurl.fake"
       region: "us-east-1"

--- a/examples/event-sources/github.yaml
+++ b/examples/event-sources/github.yaml
@@ -17,6 +17,8 @@ spec:
         endpoint: "/push"
         # port to run internal HTTP server on
         port: "12000"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
         # url the gateway will use to register at Github.
         # This url must be reachable from outside the cluster.
         # The gateway pod is backed by the service defined in the gateway spec. So get the URL for that service Github can reach to.
@@ -51,6 +53,7 @@ spec:
       webhook:
         endpoint: "/push"
         port: "13000"
+        method: "POST"
         url: "http://myargofakeurl.fake"
         # path to file that is mounted in gateway pod which contains certs
         serverCertPath: "some path in pod"

--- a/examples/event-sources/gitlab.yaml
+++ b/examples/event-sources/gitlab.yaml
@@ -15,6 +15,8 @@ spec:
         endpoint: "/push"
         # port to run internal HTTP server on
         port: "12000"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
         # url the gateway will use to register at Github.
         # This url must be reachable from outside the cluster.
         # The gateway pod is backed by the service defined in the gateway spec. So get the URL for that service Github can reach to.
@@ -38,6 +40,7 @@ spec:
       webhook:
         endpoint: "/push"
         port: "13000"
+        method: "POST"
         url: "http://mysecondfakeurl.fake"
         # path to file that is mounted in gateway pod which contains certs
         serverCertPath: "some path in pod"

--- a/examples/event-sources/slack.yaml
+++ b/examples/event-sources/slack.yaml
@@ -13,6 +13,8 @@ spec:
         endpoint: "/"
         # port to run HTTP server on
         port: "12000"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
       # token contains information about K8s secret that stores the token
       token:
         # Name of the K8s secret that contains the token
@@ -33,6 +35,7 @@ spec:
       webhook:
         endpoint: "/"
         port: "14000"
+        method: "POST"
         # path to file that is mounted in gateway pod which contains certs
         serverCertPath: "some path in pod"
         # path to file that is mounted in gateway pod which contains private key

--- a/examples/event-sources/storage-grid.yaml
+++ b/examples/event-sources/storage-grid.yaml
@@ -11,6 +11,8 @@ spec:
       webhook:
         # port to run HTTP server on
         port: "8080"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
         # endpoint to listen events on
         endpoint: "/"
       # List of supported events can be derived from AWS S3 events https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
@@ -22,6 +24,8 @@ spec:
       webhook:
         # port to run HTTP server on
         port: "8090"
+        # HTTP request method to allow. In this case, only POST requests are accepted
+        method: "POST"
         # endpoint to listen events on
         endpoint: "/"
         # path to file that is mounted in gateway pod which contains certs


### PR DESCRIPTION
Please let me know if I missed anything. This is intended to close #431 -- the EventSource documentation was missing the `method` key, which was causing 405 HTTP responses for things like Slack and GitHub webhooks.