### PR TITLE
docs(installation): adding name to helm command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ Make sure you have helm client installed and Tiller server is running. To instal
 
 2. Install `argo-events` chart
 
-        helm install argo/argo-events
+        helm install argo-events argo/argo-events
 
 ### Using kubectl
 


### PR DESCRIPTION
Helm 3 requires a name to be specified in the helm command or using the --generate-name flag. This PR adds a name arg to the `helm install` command.