### PR TITLE
docs: Use kubectl apply over kubectl create

### DIFF
--- a/docs/tutorials/01-introduction.md
+++ b/docs/tutorials/01-introduction.md
@@ -18,17 +18,17 @@ HTTP and executes an Argo workflow.
 
 * Create the webhook event source.
 
-        kubectl -n argo-events create -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/event-sources/webhook.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/event-sources/webhook.yaml
   
   
 * Create the webhook gateway.
 
-        kubectl -n argo-events create -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/gateways/webhook.yaml
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/gateways/webhook.yaml
 
 
 * Create the webhook sensor.
 
-        kubectl -n argo-events create -f https://github.com/argoproj/argo-events/tree/master/examples/sensors/webhook.yaml
+        kubectl -n argo-events apply -f https://github.com/argoproj/argo-events/tree/master/examples/sensors/webhook.yaml
   
 If the commands are executed successfully, the gateway and sensor pods will get created. You will
 also notice that a service is created for both the gateway and sensor. 


### PR DESCRIPTION
For some reason, `create`ing the webhook sensor instead of `apply`ing it causes the following err:

```
error: error parsing https://github.com/argoproj/argo-events/tree/master/examples/sensors/webhook.yaml: error converting YAML to JSON: yaml: line 114: mapping values are not allowed in this context
```

In any case, I suggest we can prefer the idempotent `apply`.