### PR TITLE
docs: fix calendar setup

### DIFF
--- a/docs/setup/calendar.md
+++ b/docs/setup/calendar.md
@@ -46,7 +46,7 @@ The structure of an event dispatched by the gateway to the sensor looks like fol
    for errors.
 
 2. If you inspect the gateway resource definition, you will notice it points to the event source called
-   `calendar-event-source`. Lets install event source in the `argo-events` namespace,
+   `calendar-source`. Lets install event source in the `argo-events` namespace,
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/event-sources/calendar.yaml
    

--- a/examples/gateways/calendar.yaml
+++ b/examples/gateways/calendar.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: calendar
   eventSourceRef:
-    name: calendar-event-source
+    name: calendar-source
   template:
     metadata:
       name: calendar-gateway


### PR DESCRIPTION
Docs and examples are still pointing to an event source named
`calendar-event-source` which has since been renamed to
`calendar-source`.