### PR TITLE
feat: Implemented Assume RoleARN for SQS and SNS

### DIFF
--- a/gateways/server/aws-sns/start.go
+++ b/gateways/server/aws-sns/start.go
@@ -145,7 +145,7 @@ func (router *Router) PostActivate() error {
 
 	snsEventSource := router.eventSource
 
-	awsSession, err := commonaws.CreateAWSSession(router.k8sClient, snsEventSource.Namespace, snsEventSource.Region, snsEventSource.AccessKey, snsEventSource.SecretKey)
+	awsSession, err := commonaws.CreateAWSSession(router.k8sClient, snsEventSource.Namespace, snsEventSource.Region, snsEventSource.RoleARN, snsEventSource.AccessKey, snsEventSource.SecretKey)
 	if err != nil {
 		return err
 	}

--- a/gateways/server/aws-sqs/start.go
+++ b/gateways/server/aws-sqs/start.go
@@ -73,7 +73,9 @@ func (listener *EventListener) listenEvents(eventSource *gateways.EventSource, c
 	logger.Infoln("setting up aws session...")
 
 	var awsSession *session.Session
-	awsSession, err := commonaws.CreateAWSSession(listener.K8sClient, sqsEventSource.Namespace, sqsEventSource.Region, sqsEventSource.AccessKey, sqsEventSource.SecretKey)
+
+	awsSession, err := commonaws.CreateAWSSession(listener.K8sClient, sqsEventSource.Namespace, sqsEventSource.Region, sqsEventSource.RoleARN, sqsEventSource.AccessKey, sqsEventSource.SecretKey)
+
 	if err != nil {
 		return errors.Wrapf(err, "failed to create aws session for %s", eventSource.Name)
 	}

--- a/gateways/server/common/aws/aws_test.go
+++ b/gateways/server/common/aws/aws_test.go
@@ -83,4 +83,13 @@ func TestAWS(t *testing.T) {
 			convey.So(session, convey.ShouldNotBeNil)
 		})
 	})
+
+	convey.Convey("create AWS credential using assume roleARN", t, func(){
+		convey.Convey("Get a new aws session", func() {
+			session, err := GetAWSAssumeRoleCreds("moke-roleARN", "mock-region")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(session, convey.ShouldNotBeNil)
+
+		})
+	})
 }

--- a/pkg/apis/eventsources/v1alpha1/types.go
+++ b/pkg/apis/eventsources/v1alpha1/types.go
@@ -227,6 +227,10 @@ type SNSEventSource struct {
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,5,opt,name=namespace"`
 	// Region is AWS region
 	Region string `json:"region" protobuf:"bytes,6,name=region"`
+	// RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+	// +optional
+	RoleARN string `json:"roleARN,omitempty" protobuf:"bytes,6,opt,name=roleARN"`
+
 }
 
 // SQSEventSource refers to event-source for AWS SQS related events
@@ -245,6 +249,9 @@ type SQSEventSource struct {
 	// Namespace refers to Kubernetes namespace to read access related secret from.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
+	// RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+	// +optional
+	RoleARN string `json:"roleARN,omitempty" protobuf:"bytes,6,opt,name=roleARN"`
 }
 
 // PubSubEventSource refers to event-source for GCP PubSub related events.

--- a/sensors/triggers/aws-lambda/aws-lambda.go
+++ b/sensors/triggers/aws-lambda/aws-lambda.go
@@ -93,7 +93,7 @@ func (t *AWSLambdaTrigger) Execute(resource interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	awsSession, err := commonaws.CreateAWSSession(t.K8sClient, trigger.Namespace, trigger.Region, trigger.AccessKey, trigger.SecretKey)
+	awsSession, err := commonaws.CreateAWSSession(t.K8sClient, trigger.Namespace, trigger.Region, "", trigger.AccessKey, trigger.SecretKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a AWS session")
 	}


### PR DESCRIPTION
This PR will fix #518. Added `roleARN` in SQS and SNS eventsource. Gateway will create the  AssumeRole Cred-Provider AWS session if the roleARN provided in the definition. 