### PR TITLE
fix: Add git to Dockerfile yum packages for sensor image

### DIFF
--- a/sensors/cmd/Dockerfile
+++ b/sensors/cmd/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-RUN yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl
+RUN yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl git
 
 # OpenFass CLI
 COPY assets/faas-cli /usr/local/bin/faas


### PR DESCRIPTION
Without it, error is seen as follows when trying to specify an git sourced trigger:

` error="failed to clone repository. err: exec: \"git\": executable file not found in $PATH"`