### PR TITLE
feat: add AWS-SQS cross account queue monitoring

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -2372,5 +2372,5 @@ More info at <a href="https://stripe.com/docs/api/events/list">https://stripe.co
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7b0491d</code>.
+on git commit <code>f010086</code>.
 </em></p>

--- a/api/event-source.html
+++ b/api/event-source.html
@@ -2111,6 +2111,18 @@ bool
 source will be JSON</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>queueAccountId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>QueueAccountId is the ID of the account that created the queue to monitor</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="argoproj.io/v1alpha1.SlackEventSource">SlackEventSource
@@ -2360,5 +2372,5 @@ More info at <a href="https://stripe.com/docs/api/events/list">https://stripe.co
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>468aced</code>.
+on git commit <code>7b0491d</code>.
 </em></p>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -4170,6 +4170,29 @@ will be JSON
 
 </tr>
 
+<tr>
+
+<td>
+
+<code>queueAccountId</code></br> <em> string </em>
+
+</td>
+
+<td>
+
+<em>(Optional)</em>
+
+<p>
+
+QueueAccountId is the ID of the account that created the queue to
+monitor
+
+</p>
+
+</td>
+
+</tr>
+
 </tbody>
 
 </table>
@@ -4685,6 +4708,6 @@ all types of events will be processed. More info at
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>468aced</code>. </em>
+commit <code>7b0491d</code>. </em>
 
 </p>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -4708,6 +4708,6 @@ all types of events will be processed. More info at
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>7b0491d</code>. </em>
+commit <code>f010086</code>. </em>
 
 </p>

--- a/api/gateway.html
+++ b/api/gateway.html
@@ -671,5 +671,5 @@ Kubernetes meta/v1.MicroTime
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7b0491d</code>.
+on git commit <code>f010086</code>.
 </em></p>

--- a/api/gateway.html
+++ b/api/gateway.html
@@ -671,5 +671,5 @@ Kubernetes meta/v1.MicroTime
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>468aced</code>.
+on git commit <code>7b0491d</code>.
 </em></p>

--- a/api/gateway.md
+++ b/api/gateway.md
@@ -1323,6 +1323,6 @@ NATS refers to the subscribers over NATS protocol.
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>468aced</code>. </em>
+commit <code>7b0491d</code>. </em>
 
 </p>

--- a/api/gateway.md
+++ b/api/gateway.md
@@ -1323,6 +1323,6 @@ NATS refers to the subscribers over NATS protocol.
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>7b0491d</code>. </em>
+commit <code>f010086</code>. </em>
 
 </p>

--- a/api/sensor.html
+++ b/api/sensor.html
@@ -3008,5 +3008,5 @@ bool
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>468aced</code>.
+on git commit <code>7b0491d</code>.
 </em></p>

--- a/api/sensor.html
+++ b/api/sensor.html
@@ -3008,5 +3008,5 @@ bool
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7b0491d</code>.
+on git commit <code>f010086</code>.
 </em></p>

--- a/api/sensor.md
+++ b/api/sensor.md
@@ -6001,6 +6001,6 @@ VerifyCert decides whether the connection is secure or not
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>7b0491d</code>. </em>
+commit <code>f010086</code>. </em>
 
 </p>

--- a/api/sensor.md
+++ b/api/sensor.md
@@ -6001,6 +6001,6 @@ VerifyCert decides whether the connection is secure or not
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>468aced</code>. </em>
+commit <code>7b0491d</code>. </em>
 
 </p>

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -5,37 +5,8 @@ metadata:
 spec:
   type: "sqs"
   sqs:
-#    example:
-#      # accessKey contains information about K8s secret that stores the access key
-#      accessKey:
-#        # Key within the K8s secret whose corresponding value (must be base64 encoded) is access key
-#        key: accesskey
-#        # Name of the K8s secret that contains the access key
-#        name: aws-secret
-#      # secretKey contains information about K8s secret that stores the secret key
-#      secretKey:
-#        # Key within the K8s secret whose corresponding value (must be base64 encoded) is secret key
-#        key: secretkey
-#        # Name of the K8s secret that contains the secret key
-#        name: aws-secret
-#      # aws region
-#      region: "us-east-1"
-#      # name of the queue. The gateway resolves the url of the queue from the queue name.
-#      queue: "my-fake-queue-1"
-#      # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
-#      # MUST BE > 0 AND <= 20
-#      waitTimeSeconds: 20
-
-#    example-without-credentials:
-#      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
-#      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
-#      region: "us-east-1"
-#      queue: "my-fake-queue-2"
-#      waitTimeSeconds: 20
-
-    cross-account-sqs:
-      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
-      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
+    example:
+      # accessKey contains information about K8s secret that stores the access key
       accessKey:
         # Key within the K8s secret whose corresponding value (must be base64 encoded) is access key
         key: accesskey
@@ -48,10 +19,33 @@ spec:
         # Name of the K8s secret that contains the secret key
         name: aws-secret
       namespace: argo-events
-#      region: "us-east-1"
-#      queue: "sqs-gateway-test"
-#      queueAccountId: "372739525611"
-      region: "us-east-2"
-      queue: "sqs-other-account-queue"
-      queueAccountId: "236162914611"
+      # aws region
+      region: "us-east-1"
+      # name of the queue. The gateway resolves the url of the queue from the queue name.
+      queue: "my-fake-queue-1"
+      # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
+      # MUST BE > 0 AND <= 20
+      waitTimeSeconds: 20
+
+    example-without-credentials:
+      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
+      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
+      region: "us-east-1"
+      queue: "my-fake-queue-2"
+      waitTimeSeconds: 20
+
+    cross-aws-account:
+      # Make sure AWS access credentials have permissions to "GetQueueUrl", "ReceiveMessage", and "DeleteMessage" of cross account Queue
+      accessKey:
+        key: accesskey
+        name: aws-secret
+      secretKey:
+        key: secretkey
+        name: aws-secret
+      namespace: argo-events
+      region: "us-east-1"
+      # name of queue to monitor
+      queue: "other-queue-name-3"
+      # AWS Account Id that created the queue
+      queueAccountId: "12345678"
       waitTimeSeconds: 20

--- a/examples/event-sources/aws-sqs.yaml
+++ b/examples/event-sources/aws-sqs.yaml
@@ -5,8 +5,37 @@ metadata:
 spec:
   type: "sqs"
   sqs:
-    example:
-      # accessKey contains information about K8s secret that stores the access key
+#    example:
+#      # accessKey contains information about K8s secret that stores the access key
+#      accessKey:
+#        # Key within the K8s secret whose corresponding value (must be base64 encoded) is access key
+#        key: accesskey
+#        # Name of the K8s secret that contains the access key
+#        name: aws-secret
+#      # secretKey contains information about K8s secret that stores the secret key
+#      secretKey:
+#        # Key within the K8s secret whose corresponding value (must be base64 encoded) is secret key
+#        key: secretkey
+#        # Name of the K8s secret that contains the secret key
+#        name: aws-secret
+#      # aws region
+#      region: "us-east-1"
+#      # name of the queue. The gateway resolves the url of the queue from the queue name.
+#      queue: "my-fake-queue-1"
+#      # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
+#      # MUST BE > 0 AND <= 20
+#      waitTimeSeconds: 20
+
+#    example-without-credentials:
+#      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
+#      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
+#      region: "us-east-1"
+#      queue: "my-fake-queue-2"
+#      waitTimeSeconds: 20
+
+    cross-account-sqs:
+      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
+      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
       accessKey:
         # Key within the K8s secret whose corresponding value (must be base64 encoded) is access key
         key: accesskey
@@ -18,17 +47,11 @@ spec:
         key: secretkey
         # Name of the K8s secret that contains the secret key
         name: aws-secret
-      # aws region
-      region: "us-east-1"
-      # name of the queue. The gateway resolves the url of the queue from the queue name.
-      queue: "my-fake-queue-1"
-      # The duration (in seconds) for which the call waits for a message to arrive in the queue before returning.
-      # MUST BE > 0 AND <= 20
-      waitTimeSeconds: 20
-
-    example-without-credentials:
-      # If AWS access credentials are already present on the Pod's IAM role running the Gateway,
-      # the AWS session will utilize the existing config and hence we do not need to provide explicit credentials.
-      region: "us-east-1"
-      queue: "my-fake-queue-2"
+      namespace: argo-events
+#      region: "us-east-1"
+#      queue: "sqs-gateway-test"
+#      queueAccountId: "372739525611"
+      region: "us-east-2"
+      queue: "sqs-other-account-queue"
+      queueAccountId: "236162914611"
       waitTimeSeconds: 20

--- a/gateways/server/aws-sqs/start.go
+++ b/gateways/server/aws-sqs/start.go
@@ -18,8 +18,6 @@ package aws_sqs
 
 import (
 	"encoding/json"
-	"fmt"
-
 	"github.com/argoproj/argo-events/common"
 	"github.com/argoproj/argo-events/gateways"
 	"github.com/argoproj/argo-events/gateways/server"
@@ -71,7 +69,6 @@ func (listener *EventListener) listenEvents(eventSource *gateways.EventSource, c
 		return errors.Wrapf(err, "failed to parse the event source %s", eventSource.Name)
 	}
 
-	fmt.Printf("EventSource: %+v\n", sqsEventSource)
 	logger.Infoln("setting up aws session...")
 
 	var awsSession *session.Session
@@ -84,18 +81,13 @@ func (listener *EventListener) listenEvents(eventSource *gateways.EventSource, c
 
 	sqsClient := sqslib.New(awsSession)
 
-	accountId := "236162914611";
-
 	logger.Infoln("fetching queue url...")
 	getQueueUrlInput:= &sqslib.GetQueueUrlInput{
 		QueueName: &sqsEventSource.Queue,
-		QueueOwnerAWSAccountId: &accountId,
 	}
 	if sqsEventSource.QueueAccountId != "" {
 	getQueueUrlInput = getQueueUrlInput.SetQueueOwnerAWSAccountId(sqsEventSource.QueueAccountId)
 	}
-	logger.Infoln(getQueueUrlInput.String())
-	logger.Infof("QueueAccountId: %s\n", sqsEventSource.QueueAccountId)
 
 	queueURL, err := sqsClient.GetQueueUrl(getQueueUrlInput)
 	if err != nil {

--- a/pkg/apis/eventsources/v1alpha1/types.go
+++ b/pkg/apis/eventsources/v1alpha1/types.go
@@ -267,6 +267,9 @@ type SQSEventSource struct {
 	// source will be JSON
 	// +optional
 	JSONBody bool `json:"jsonBody,omitempty" protobuf:"bytes,8,opt,name=jsonBody"`
+	// QueueAccountId is the ID of the account that created the queue to monitor
+	// +optional
+	QueueAccountId string `json:"queueAccountId,omitempty" protobuf:"bytes,9,opt,name=queueAccountId"`
 }
 
 // PubSubEventSource refers to event-source for GCP PubSub related events.


### PR DESCRIPTION
Added the ability to monitor AWS-SQS queues from a different AWS account. Make sure AWS access credentials have permissions to "GetQueueUrl", "ReceiveMessage", and "DeleteMessage" of cross-account Queue, and provide queue name and AWS Account Id in aws-sqs-event-source.
 
Closing issue #464 