### PR TITLE
service account is neccessary when create a pod in 2.6.3

### DIFF
--- a/examples/sensors/gitlab.yaml
+++ b/examples/sensors/gitlab.yaml
@@ -43,6 +43,7 @@ spec:
                     value: hello world
                 templates:
                 - name: whalesay
+                  serviceAccountName: argo-events-sa
                   inputs:
                     parameters:
                     - name: message


### PR DESCRIPTION
This cause gitlab trigger failed when create pod