### PR TITLE
fix: RBAC EventSource aggregation

### DIFF
--- a/hack/k8s/manifests/argo-events-cluster-roles.yaml
+++ b/hack/k8s/manifests/argo-events-cluster-roles.yaml
@@ -109,6 +109,8 @@ rules:
       - gateways/finalizers
       - sensors
       - sensors/finalizers
+      - eventsources
+      - eventsources/finalizers
     verbs:
       - create
       - delete
@@ -133,6 +135,8 @@ rules:
       - gateways/finalizers
       - sensors
       - sensors/finalizers
+      - eventsources
+      - eventsources/finalizers
     verbs:
       - create
       - delete
@@ -157,6 +161,8 @@ rules:
       - gateways/finalizers
       - sensors
       - sensors/finalizers
+      - eventsources
+      - eventsources/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
Fix missing `EventSource`s RBAC aggregation.

This should allow `EventSource` CRDs to be accessed with the same required permissions as other Argo-Events resource types. 