### PR TITLE
docs: workflow namespace

### DIFF
--- a/examples/sensors/complete-trigger-parameterization.yaml
+++ b/examples/sensors/complete-trigger-parameterization.yaml
@@ -64,6 +64,10 @@ spec:
           parameters:
             - src:
                 dependencyName: test-dep
+                dataKey: namespace
+              dest: metadata.namespace
+            - src:
+                dependencyName: test-dep
                 dataKey: image
               dest: spec.templates.0.container.image
       # Apply parameters at the template level.
@@ -72,10 +76,6 @@ spec:
             dependencyName: test-dep
             dataKey: name
           dest: name
-        - src:
-            dependencyName: test-dep
-            dataKey: namespace
-          dest: k8s.namespace
         - src:
             dependencyName: test-dep
             dataKey: bucket


### PR DESCRIPTION
to be able to modify workflows namespace key in it's spec it needs to be indented at "Apply parameters for workflow resource fetched from the S3 bucket" and the path is "metadata.namespace"