### PR TITLE
WIP: feat: Add schema validation to CRDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -475,6 +475,14 @@
   version = "v6.15.7"
 
 [[projects]]
+  digest = "1:eec9b9a9f07a9b0de09431545481e22c233181b1af40170d0bc1f50b83690738"
+  name = "github.com/gobuffalo/flect"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7a04ff140e0fd2ea77adfd5b8bd2b0c80ab739a9"
+  version = "v0.2.1"
+
+[[projects]]
   digest = "1:e5e45557e1871c967a6ccaa5b95d1233a2c01ab00615621825d1aca7383dc022"
   name = "github.com/gobwas/glob"
   packages = [
@@ -711,6 +719,14 @@
   pruneopts = "UT"
   revision = "66f88b4ae75f5edcc556623b96ff32c06360fbb7"
   version = "v0.3.9"
+
+[[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
 
 [[projects]]
   branch = "master"
@@ -1096,6 +1112,14 @@
   pruneopts = "UT"
   revision = "505e419363375c0dc132d3ac02632a4ee32199ca"
   version = "v1.6.4"
+
+[[projects]]
+  digest = "1:f6adcf4df6c030a53a14a8fdbb3fade7cac3d014ff78a4e0de500b4c0cf5154f"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
@@ -1762,6 +1786,14 @@
   version = "v2.2.8"
 
 [[projects]]
+  branch = "v3"
+  digest = "1:55d59c3399c684c4e3edc6c404e5dc85b072363918bf2a2c6b0e6e4807ea73bf"
+  name = "gopkg.in/yaml.v3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9f266ea9e77c4c7aab4cf02650570e7c7b3031a5"
+
+[[projects]]
   digest = "1:735ae15b76858155230553ed0845ba4cc1dbb7c2ca665ab33bfd2eb1509b219c"
   name = "honnef.co/go/tools"
   packages = [
@@ -1849,9 +1881,22 @@
   version = "v0.17.4"
 
 [[projects]]
+  digest = "1:c448c1f26c05377507a4e6ec87d0bfb92e93d49532982670ecaac68100e02c2b"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = [
+    "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1",
+    "pkg/apis/apiextensions/v1beta1",
+  ]
+  pruneopts = "UT"
+  revision = "6846325a18868b06d3566963cf87e399f38721fd"
+  version = "v0.18.2"
+
+[[projects]]
   digest = "1:4403949d51282e512c2d479be84a75abd7187e067a50ab7872ba8618cf4fdf15"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
@@ -2176,11 +2221,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2d3f59daa4b479ff4e100a2e1d8fea6780040fdadc177869531fe4cc29407f55"
+  digest = "1:73ab611e5de3af57d3571909942beadbfd5a8902e49a2366506a1c881dc517d8"
   name = "k8s.io/utils"
   packages = [
     "buffer",
     "integer",
+    "pointer",
     "trace",
   ]
   pruneopts = "UT"
@@ -2196,6 +2242,29 @@
   pruneopts = "UT"
   revision = "86a6a1998f1d2bf63262718644c1ef3a77fa8d28"
   version = "v0.12.5"
+
+[[projects]]
+  digest = "1:0f4b57df86c8e727bb629baac796b0a22353c2343977d9fef981c4d6b668e1d6"
+  name = "sigs.k8s.io/controller-tools"
+  packages = [
+    "cmd/controller-gen",
+    "pkg/crd",
+    "pkg/crd/markers",
+    "pkg/deepcopy",
+    "pkg/genall",
+    "pkg/genall/help",
+    "pkg/genall/help/pretty",
+    "pkg/loader",
+    "pkg/markers",
+    "pkg/rbac",
+    "pkg/schemapatcher",
+    "pkg/schemapatcher/internal/yaml",
+    "pkg/version",
+    "pkg/webhook",
+  ]
+  pruneopts = "UT"
+  revision = "44656d3c15ecaef499d9157825afd843415cbfea"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:36d2b2cb1fa6e4a731e38c3582c203213cdbc52c5f202af07db6dc6eeaec88dc"
@@ -2311,6 +2380,7 @@
     "k8s.io/gengo/examples/deepcopy-gen",
     "k8s.io/kube-openapi/cmd/openapi-gen",
     "k8s.io/kube-openapi/pkg/common",
+    "sigs.k8s.io/controller-tools/cmd/controller-gen",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,6 +2,7 @@ required = [
   "k8s.io/code-generator/cmd/client-gen",
   "k8s.io/kube-openapi/cmd/openapi-gen",
   "k8s.io/gengo/examples/deepcopy-gen",
+  "sigs.k8s.io/controller-tools/cmd/controller-gen",
   "github.com/golang/protobuf/protoc-gen-go",
   "github.com/gogo/protobuf/protoc-gen-gofast",
   "github.com/gogo/protobuf/protoc-gen-gogofast",

--- a/hack/update-crd.sh
+++ b/hack/update-crd.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT_ROOT=$(cd $(dirname "$0")/.. ; pwd)
+CONTROLLER_TOOLS_PKG=${PROJECT_ROOT}/vendor/sigs.k8s.io/controller-tools
+VERSION="v1alpha1"
+
+# Sensor
+go run ${CONTROLLER_TOOLS_PKG}/cmd/controller-gen/main.go crd:crdVersions=v1 \
+    paths=github.com/argoproj/argo-events/pkg/apis/sensor/${VERSION} \
+    output:stdout > ${PROJECT_ROOT}/manifests/base/crds/sensor-crd.yaml
+
+# Gateway
+go run ${CONTROLLER_TOOLS_PKG}/cmd/controller-gen/main.go crd:crdVersions=v1 \
+    paths=github.com/argoproj/argo-events/pkg/apis/gateway/${VERSION} \
+    output:stdout > ${PROJECT_ROOT}/manifests/base/crds/gateway-crd.yaml
+
+# EventSource
+go run ${CONTROLLER_TOOLS_PKG}/cmd/controller-gen/main.go crd:crdVersions=v1 \
+    paths=github.com/argoproj/argo-events/pkg/apis/eventsources/${VERSION} \
+    output:stdout > ${PROJECT_ROOT}/manifests/base/crds/eventsources-crd.yaml

--- a/manifests/base/crds/eventsources-crd.yaml
+++ b/manifests/base/crds/eventsources-crd.yaml
@@ -1,15 +1,1688 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
   name: eventsources.argoproj.io
 spec:
   group: argoproj.io
   names:
     kind: EventSource
+    listKind: EventSourceList
     plural: eventsources
     singular: eventsource
-    listKind: EventSourceList
-    shortNames:
-      - es
   scope: Namespaced
-  version: "v1alpha1"
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EventSource is the definition of a eventsource resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EventSourceSpec refers to specification of event-source resource
+            properties:
+              amqp:
+                additionalProperties:
+                  description: AMQPEventSource refers to an event-source for AMQP
+                    stream events
+                  properties:
+                    connectionBackoff:
+                      description: Backoff holds parameters applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    exchangeName:
+                      description: ExchangeName is the exchange name For more information,
+                        visit https://www.rabbitmq.com/tutorials/amqp-concepts.html
+                      type: string
+                    exchangeType:
+                      description: ExchangeType is rabbitmq exchange type
+                      type: string
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    routingKey:
+                      description: Routing key for bindings
+                      type: string
+                    tls:
+                      description: TLS configuration for the amqp client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    url:
+                      description: URL for rabbitmq service
+                      type: string
+                  required:
+                  - exchangeName
+                  - exchangeType
+                  - routingKey
+                  - url
+                  type: object
+                description: AMQP event sources
+                type: object
+              azureEventsHub:
+                additionalProperties:
+                  description: AzureEventsHubEventSource describes the event source
+                    for azure events hub More info at https://docs.microsoft.com/en-us/azure/event-hubs/
+                  properties:
+                    fqdn:
+                      description: FQDN of the EventHubs namespace you created More
+                        info at https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
+                      type: string
+                    hubName:
+                      description: Event Hub path/name
+                      type: string
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace which
+                        is used to retrieve the shared access key and name from.
+                      type: string
+                    sharedAccessKey:
+                      description: SharedAccessKey is the the generated value of the
+                        key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sharedAccessKeyName:
+                      description: SharedAccessKeyName is the name you chose for your
+                        application's SAS keys
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - fqdn
+                  - hubName
+                  - sharedAccessKey
+                  - sharedAccessKeyName
+                  type: object
+                description: AzureEventsHub event sources
+                type: object
+              calendar:
+                additionalProperties:
+                  description: CalendarEventSource describes a time based dependency.
+                    One of the fields (schedule, interval, or recurrence) must be
+                    passed. Schedule takes precedence over interval; interval takes
+                    precedence over recurrence
+                  properties:
+                    exclusionDates:
+                      description: ExclusionDates defines the list of DATE-TIME exceptions
+                        for recurring events.
+                      items:
+                        type: string
+                      type: array
+                    interval:
+                      description: Interval is a string that describes an interval
+                        duration, e.g. 1s, 30m, 2h...
+                      type: string
+                    schedule:
+                      description: 'Schedule is a cron-like expression. For reference,
+                        see: https://en.wikipedia.org/wiki/Cron'
+                      type: string
+                    timezone:
+                      description: Timezone in which to run the schedule
+                      type: string
+                    userPayload:
+                      description: UserPayload will be sent to sensor as extra data
+                        once the event is triggered
+                      format: byte
+                      type: string
+                  required:
+                  - interval
+                  - schedule
+                  type: object
+                description: Calendar event sources
+                type: object
+              emitter:
+                additionalProperties:
+                  description: EmitterEventSource describes the event source for emitter
+                    More info at https://emitter.io/develop/getting-started/
+                  properties:
+                    broker:
+                      description: Broker URI to connect to.
+                      type: string
+                    channelKey:
+                      description: ChannelKey refers to the channel key
+                      type: string
+                    channelName:
+                      description: ChannelName refers to the channel name
+                      type: string
+                    connectionBackoff:
+                      description: Backoff holds parameters applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    namespace:
+                      description: Namespace to use to retrieve the channel key and
+                        optional username/password
+                      type: string
+                    password:
+                      description: Password to use to connect to broker
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    tls:
+                      description: TLS configuration for the emitter client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    username:
+                      description: Username to use to connect to broker
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - broker
+                  - channelKey
+                  - channelName
+                  type: object
+                description: Emitter event source
+                type: object
+              file:
+                additionalProperties:
+                  description: FileEventSource describes an event-source for file
+                    related events.
+                  properties:
+                    eventType:
+                      description: Type of file operations to watch Refer https://github.com/fsnotify/fsnotify/blob/master/fsnotify.go
+                        for more information
+                      type: string
+                    watchPathConfig:
+                      description: WatchPathConfig contains configuration about the
+                        file path to watch
+                      properties:
+                        directory:
+                          description: Directory to watch for events
+                          type: string
+                        path:
+                          description: Path is relative path of object to watch with
+                            respect to the directory
+                          type: string
+                        pathRegexp:
+                          description: PathRegexp is regexp of relative path of object
+                            to watch with respect to the directory
+                          type: string
+                      required:
+                      - directory
+                      type: object
+                  required:
+                  - eventType
+                  - watchPathConfig
+                  type: object
+                description: File event sources
+                type: object
+              generic:
+                additionalProperties:
+                  description: GenericEventSource refers to a generic event source.
+                    It can be used to implement a custom event source.
+                  properties:
+                    value:
+                      description: Value of the event source
+                      type: string
+                  required:
+                  - value
+                  type: object
+                description: Generic event source
+                type: object
+              github:
+                additionalProperties:
+                  description: GithubEventSource refers to event-source for github
+                    related events
+                  properties:
+                    active:
+                      description: Active refers to status of the webhook for event
+                        deliveries. https://developer.github.com/webhooks/creating/#active
+                      type: boolean
+                    apiToken:
+                      description: APIToken refers to a K8s secret containing github
+                        api token
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    contentType:
+                      description: ContentType of the event delivery
+                      type: string
+                    deleteHookOnFinish:
+                      description: DeleteHookOnFinish determines whether to delete
+                        the GitHub hook for the repository once the event source is
+                        stopped.
+                      type: boolean
+                    events:
+                      description: Events refer to Github events to subscribe to which
+                        the gateway will subscribe
+                      items:
+                        type: string
+                      type: array
+                    githubBaseURL:
+                      description: GitHub base URL (for GitHub Enterprise)
+                      type: string
+                    githubUploadURL:
+                      description: GitHub upload URL (for GitHub Enterprise)
+                      type: string
+                    id:
+                      description: Id is the webhook's id
+                      format: int64
+                      type: integer
+                    insecure:
+                      description: Insecure tls verification
+                      type: boolean
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace which
+                        is used to retrieve webhook secret and api token from.
+                      type: string
+                    owner:
+                      description: Owner refers to GitHub owner name i.e. argoproj
+                      type: string
+                    repository:
+                      description: Repository refers to GitHub repo name i.e. argo-events
+                      type: string
+                    webhook:
+                      description: Webhook refers to the configuration required to
+                        run a http server
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                    webhookSecret:
+                      description: WebhookSecret refers to K8s secret containing GitHub
+                        webhook secret https://developer.github.com/webhooks/securing/
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - apiToken
+                  - events
+                  - id
+                  - owner
+                  - repository
+                  - webhook
+                  type: object
+                description: Github event sources
+                type: object
+              gitlab:
+                additionalProperties:
+                  description: GitlabEventSource refers to event-source related to
+                    Gitlab events
+                  properties:
+                    accessToken:
+                      description: AccessToken is reference to k8 secret which holds
+                        the gitlab api access information
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    allowDuplicate:
+                      description: AllowDuplicate allows the gateway to register the
+                        same webhook integrations for multiple event source configurations.
+                        Defaults to false.
+                      type: boolean
+                    deleteHookOnFinish:
+                      description: DeleteHookOnFinish determines whether to delete
+                        the GitLab hook for the project once the event source is stopped.
+                      type: boolean
+                    enableSSLVerification:
+                      description: EnableSSLVerification to enable ssl verification
+                      type: boolean
+                    event:
+                      description: Event is a gitlab event to listen to. Refer https://github.com/xanzy/go-gitlab/blob/bf34eca5d13a9f4c3f501d8a97b8ac226d55e4d9/projects.go#L794.
+                      type: string
+                    gitlabBaseURL:
+                      description: GitlabBaseURL is the base URL for API requests
+                        to a custom endpoint
+                      type: string
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace which
+                        is used to retrieve access token from.
+                      type: string
+                    projectId:
+                      description: ProjectId is the id of project for which integration
+                        needs to setup
+                      type: string
+                    webhook:
+                      description: Webhook holds configuration to run a http server
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                  required:
+                  - accessToken
+                  - event
+                  - gitlabBaseURL
+                  - projectId
+                  - webhook
+                  type: object
+                description: Gitlab event sources
+                type: object
+              hdfs:
+                additionalProperties:
+                  description: HDFSEventSource refers to event-source for HDFS related
+                    events
+                  properties:
+                    addresses:
+                      description: Addresses is accessible addresses of HDFS name
+                        nodes
+                      items:
+                        type: string
+                      type: array
+                    checkInterval:
+                      description: CheckInterval is a string that describes an interval
+                        duration to check the directory state, e.g. 1s, 30m, 2h...
+                        (defaults to 1m)
+                      type: string
+                    directory:
+                      description: Directory to watch for events
+                      type: string
+                    hdfsUser:
+                      description: HDFSUser is the user to access HDFS file system.
+                        It is ignored if either ccache or keytab is used.
+                      type: string
+                    krbCCacheSecret:
+                      description: KrbCCacheSecret is the secret selector for Kerberos
+                        ccache Either ccache or keytab can be set to use Kerberos.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    krbConfigConfigMap:
+                      description: KrbConfig is the configmap selector for Kerberos
+                        config as string It must be set if either ccache or keytab
+                        is used.
+                      properties:
+                        key:
+                          description: The key to select.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    krbKeytabSecret:
+                      description: KrbKeytabSecret is the secret selector for Kerberos
+                        keytab Either ccache or keytab can be set to use Kerberos.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    krbRealm:
+                      description: KrbRealm is the Kerberos realm used with Kerberos
+                        keytab It must be set if keytab is used.
+                      type: string
+                    krbServicePrincipalName:
+                      description: KrbServicePrincipalName is the principal name of
+                        Kerberos service It must be set if either ccache or keytab
+                        is used.
+                      type: string
+                    krbUsername:
+                      description: KrbUsername is the Kerberos username used with
+                        Kerberos keytab It must be set if keytab is used.
+                      type: string
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace which
+                        is used to retrieve cache secret and ket tab secret from.
+                      type: string
+                    path:
+                      description: Path is relative path of object to watch with respect
+                        to the directory
+                      type: string
+                    pathRegexp:
+                      description: PathRegexp is regexp of relative path of object
+                        to watch with respect to the directory
+                      type: string
+                    type:
+                      description: Type of file operations to watch
+                      type: string
+                  required:
+                  - addresses
+                  - directory
+                  - type
+                  type: object
+                description: HDFS event sources
+                type: object
+              kafka:
+                additionalProperties:
+                  description: KafkaEventSource refers to event-source for Kafka related
+                    events
+                  properties:
+                    connectionBackoff:
+                      description: Backoff holds parameters applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    partition:
+                      description: Partition name
+                      type: string
+                    tls:
+                      description: TLS configuration for the kafka client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    topic:
+                      description: Topic name
+                      type: string
+                    url:
+                      description: URL to kafka cluster
+                      type: string
+                  required:
+                  - partition
+                  - topic
+                  - url
+                  type: object
+                description: Kafka event sources
+                type: object
+              minio:
+                additionalProperties:
+                  description: S3Artifact contains information about an S3 connection
+                    and bucket
+                  properties:
+                    accessKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    bucket:
+                      description: S3Bucket contains information to describe an S3
+                        Bucket
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    endpoint:
+                      type: string
+                    events:
+                      items:
+                        type: string
+                      type: array
+                    filter:
+                      description: S3Filter represents filters to apply to bucket
+                        nofifications for specifying constraints on objects
+                      properties:
+                        prefix:
+                          type: string
+                        suffix:
+                          type: string
+                      required:
+                      - prefix
+                      - suffix
+                      type: object
+                    insecure:
+                      type: boolean
+                    region:
+                      type: string
+                    secretKey:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - accessKey
+                  - bucket
+                  - endpoint
+                  - secretKey
+                  type: object
+                description: Minio event sources
+                type: object
+              mqtt:
+                additionalProperties:
+                  description: MQTTEventSource refers to event-source for MQTT related
+                    events
+                  properties:
+                    clientId:
+                      description: ClientID is the id of the client
+                      type: string
+                    connectionBackoff:
+                      description: ConnectionBackoff holds backoff applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    tls:
+                      description: TLS configuration for the mqtt client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    topic:
+                      description: Topic name
+                      type: string
+                    url:
+                      description: URL to connect to broker
+                      type: string
+                  required:
+                  - clientId
+                  - topic
+                  - url
+                  type: object
+                description: MQTT event sources
+                type: object
+              nats:
+                additionalProperties:
+                  description: NATSEventSource refers to event-source for NATS related
+                    events
+                  properties:
+                    connectionBackoff:
+                      description: ConnectionBackoff holds backoff applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    subject:
+                      description: Subject holds the name of the subject onto which
+                        messages are published
+                      type: string
+                    tls:
+                      description: TLS configuration for the nats client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    url:
+                      description: URL to connect to NATS cluster
+                      type: string
+                  required:
+                  - subject
+                  - url
+                  type: object
+                description: NATS event sources
+                type: object
+              nsq:
+                additionalProperties:
+                  description: NSQEventSource describes the event source for NSQ PubSub
+                    More info at https://godoc.org/github.com/nsqio/go-nsq
+                  properties:
+                    channel:
+                      description: Channel used for subscription
+                      type: string
+                    connectionBackoff:
+                      description: Backoff holds parameters applied to connection.
+                      properties:
+                        duration:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        factor: {}
+                        jitter: {}
+                        steps:
+                          type: integer
+                      required:
+                      - duration
+                      - factor
+                      - jitter
+                      - steps
+                      type: object
+                    hostAddress:
+                      description: HostAddress is the address of the host for NSQ
+                        lookup
+                      type: string
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    tls:
+                      description: TLS configuration for the nsq client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                    topic:
+                      description: Topic to subscribe to.
+                      type: string
+                  required:
+                  - channel
+                  - hostAddress
+                  - topic
+                  type: object
+                description: NSQ event source
+                type: object
+              pubSub:
+                additionalProperties:
+                  description: PubSubEventSource refers to event-source for GCP PubSub
+                    related events.
+                  properties:
+                    credentialsFile:
+                      description: CredentialsFile is the file that contains credentials
+                        to authenticate for GCP
+                      type: string
+                    deleteSubscriptionOnFinish:
+                      description: DeleteSubscriptionOnFinish determines whether to
+                        delete the GCP PubSub subscription once the event source is
+                        stopped.
+                      type: boolean
+                    enableWorkflowIdentity:
+                      description: EnableWorkflowIdentity determines if your project
+                        authenticates to GCP with WorkflowIdentity or CredentialsFile.
+                        If true, authentication is done with WorkflowIdentity. If
+                        false or omited, authentication is done with CredentialsFile.
+                      type: boolean
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    projectID:
+                      description: ProjectID is the unique identifier for your project
+                        on GCP
+                      type: string
+                    topic:
+                      description: Topic on which a subscription will be created
+                      type: string
+                    topicProjectID:
+                      description: TopicProjectID identifies the project where the
+                        topic should exist or be created (assumed to be the same as
+                        ProjectID by default)
+                      type: string
+                  required:
+                  - credentialsFile
+                  - projectID
+                  - topic
+                  - topicProjectID
+                  type: object
+                description: PubSub eevnt sources
+                type: object
+              redis:
+                additionalProperties:
+                  description: RedisEventSource describes an event source for the
+                    Redis PubSub. More info at https://godoc.org/github.com/go-redis/redis#example-PubSub
+                  properties:
+                    channels:
+                      description: Channels to subscribe to listen events.
+                      items:
+                        type: string
+                      type: array
+                    db:
+                      description: DB to use. If not specified, default DB 0 will
+                        be used.
+                      type: integer
+                    hostAddress:
+                      description: HostAddress refers to the address of the Redis
+                        host/server
+                      type: string
+                    namespace:
+                      description: Namespace to use to retrieve the password from.
+                        It should only be specified if password is declared
+                      type: string
+                    password:
+                      description: Password required for authentication if any.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    tls:
+                      description: TLS configuration for the redis client.
+                      properties:
+                        caCertPath:
+                          description: CACertPath refers the file path that contains
+                            the CA cert.
+                          type: string
+                        clientCertPath:
+                          description: ClientCertPath refers the file path that contains
+                            client cert.
+                          type: string
+                        clientKeyPath:
+                          description: ClientKeyPath refers the file path that contains
+                            client key.
+                          type: string
+                      required:
+                      - caCertPath
+                      - clientCertPath
+                      - clientKeyPath
+                      type: object
+                  required:
+                  - channels
+                  - hostAddress
+                  type: object
+                description: Redis event source
+                type: object
+              resource:
+                additionalProperties:
+                  description: ResourceEventSource refers to a event-source for K8s
+                    resource related events.
+                  properties:
+                    eventTypes:
+                      description: EventTypes is the list of event type to watch.
+                        Possible values are - ADD, UPDATE and DELETE.
+                      items:
+                        description: ResourceEventType is the type of event for the
+                          K8s resource mutation
+                        type: string
+                      type: array
+                    filter:
+                      description: Filter is applied on the metadata of the resource
+                        If you apply filter, then the internal event informer will
+                        only monitor objects that pass the filter.
+                      properties:
+                        createdBy:
+                          description: If resource is created before the specified
+                            time then the event is treated as valid.
+                          format: date-time
+                          type: string
+                        fields:
+                          description: Fields provide listing options to K8s API to
+                            watch resource/s. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+                            for more info.
+                          items:
+                            description: Selector represents conditional operation
+                              to select K8s objects.
+                            properties:
+                              key:
+                                description: Key name
+                                type: string
+                              operation:
+                                description: Supported operations like ==, !=, <=,
+                                  >= etc. Defaults to ==. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                                  for more info.
+                                type: string
+                              value:
+                                description: Value
+                                type: string
+                            required:
+                            - key
+                            - value
+                            type: object
+                          type: array
+                        labels:
+                          description: Labels provide listing options to K8s API to
+                            watch resource/s. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/label-selectors/
+                            for more info.
+                          items:
+                            description: Selector represents conditional operation
+                              to select K8s objects.
+                            properties:
+                              key:
+                                description: Key name
+                                type: string
+                              operation:
+                                description: Supported operations like ==, !=, <=,
+                                  >= etc. Defaults to ==. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                                  for more info.
+                                type: string
+                              value:
+                                description: Value
+                                type: string
+                            required:
+                            - key
+                            - value
+                            type: object
+                          type: array
+                        prefix:
+                          description: Prefix filter is applied on the resource name.
+                          type: string
+                      type: object
+                    group:
+                      type: string
+                    namespace:
+                      description: Namespace where resource is deployed
+                      type: string
+                    resource:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - eventTypes
+                  - group
+                  - namespace
+                  - resource
+                  - version
+                  type: object
+                description: Resource event sources
+                type: object
+              slack:
+                additionalProperties:
+                  description: SlackEventSource refers to event-source for Slack related
+                    events
+                  properties:
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace which
+                        is used to retrieve token and signing secret from.
+                      type: string
+                    signingSecret:
+                      description: Slack App signing secret
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    token:
+                      description: Token for URL verification handshake
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    webhook:
+                      description: Webhook holds configuration for a REST endpoint
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                  required:
+                  - webhook
+                  type: object
+                description: Slack event sources
+                type: object
+              sns:
+                additionalProperties:
+                  description: SNSEventSource refers to event-source for AWS SNS related
+                    events
+                  properties:
+                    accessKey:
+                      description: AccessKey refers K8 secret containing aws access
+                        key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace to read
+                        access related secret from.
+                      type: string
+                    region:
+                      description: Region is AWS region
+                      type: string
+                    roleARN:
+                      description: RoleARN is the Amazon Resource Name (ARN) of the
+                        role to assume.
+                      type: string
+                    secretKey:
+                      description: SecretKey refers K8 secret containing aws secret
+                        key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    topicArn:
+                      description: TopicArn
+                      type: string
+                    webhook:
+                      description: Webhook configuration for http server
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                  required:
+                  - region
+                  - topicArn
+                  - webhook
+                  type: object
+                description: SNS event sources
+                type: object
+              sqs:
+                additionalProperties:
+                  description: SQSEventSource refers to event-source for AWS SQS related
+                    events
+                  properties:
+                    accessKey:
+                      description: AccessKey refers K8 secret containing aws access
+                        key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    jsonBody:
+                      description: JSONBody specifies that all event body payload
+                        coming from this source will be JSON
+                      type: boolean
+                    namespace:
+                      description: Namespace refers to Kubernetes namespace to read
+                        access related secret from.
+                      type: string
+                    queue:
+                      description: Queue is AWS SQS queue to listen to for messages
+                      type: string
+                    queueAccountId:
+                      description: QueueAccountId is the ID of the account that created
+                        the queue to monitor
+                      type: string
+                    region:
+                      description: Region is AWS region
+                      type: string
+                    roleARN:
+                      description: RoleARN is the Amazon Resource Name (ARN) of the
+                        role to assume.
+                      type: string
+                    secretKey:
+                      description: SecretKey refers K8 secret containing aws secret
+                        key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    waitTimeSeconds:
+                      description: WaitTimeSeconds is The duration (in seconds) for
+                        which the call waits for a message to arrive in the queue
+                        before returning.
+                      format: int64
+                      type: integer
+                  required:
+                  - queue
+                  - region
+                  - waitTimeSeconds
+                  type: object
+                description: SQS event sources
+                type: object
+              storageGrid:
+                additionalProperties:
+                  description: StorageGridEventSource refers to event-source for StorageGrid
+                    related events
+                  properties:
+                    events:
+                      description: Events are s3 bucket notification events. For more
+                        information on s3 notifications, follow https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations
+                        Note that storage grid notifications do not contain `s3:`
+                      items:
+                        type: string
+                      type: array
+                    filter:
+                      description: Filter on object key which caused the notification.
+                      properties:
+                        prefix:
+                          type: string
+                        suffix:
+                          type: string
+                      required:
+                      - prefix
+                      - suffix
+                      type: object
+                    webhook:
+                      description: Webhook holds configuration for a REST endpoint
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                  required:
+                  - webhook
+                  type: object
+                description: StorageGrid event sources
+                type: object
+              stripe:
+                additionalProperties:
+                  description: StripeEventSource describes the event source for stripe
+                    webhook notifications More info at https://stripe.com/docs/webhooks
+                  properties:
+                    apiKey:
+                      description: APIKey refers to K8s secret that holds Stripe API
+                        key. Used only if CreateWebhook is enabled.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    createWebhook:
+                      description: CreateWebhook if specified creates a new webhook
+                        programmatically.
+                      type: boolean
+                    eventFilter:
+                      description: EventFilter describes the type of events to listen
+                        to. If not specified, all types of events will be processed.
+                        More info at https://stripe.com/docs/api/events/list
+                      items:
+                        type: string
+                      type: array
+                    namespace:
+                      description: Namespace to retrieve the APIKey secret from. Must
+                        be specified in order to read API key from APIKey K8s secret.
+                      type: string
+                    webhook:
+                      description: Webhook holds configuration for a REST endpoint
+                      properties:
+                        endpoint:
+                          description: REST API endpoint
+                          type: string
+                        method:
+                          description: 'Method is HTTP request method that indicates
+                            the desired action to be performed for a given resource.
+                            See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics
+                            and Content'
+                          type: string
+                        port:
+                          description: Port on which HTTP server is listening for
+                            incoming events.
+                          type: string
+                        serverCertPath:
+                          description: ServerCertPath refers the file that contains
+                            the cert.
+                          type: string
+                        serverKeyPath:
+                          description: ServerKeyPath refers the file that contains
+                            private key
+                          type: string
+                        url:
+                          description: URL is the url of the server.
+                          type: string
+                      required:
+                      - endpoint
+                      - method
+                      - port
+                      - url
+                      type: object
+                  required:
+                  - webhook
+                  type: object
+                description: Stripe event sources
+                type: object
+              type:
+                description: Type of the event source
+                type: string
+              webhook:
+                additionalProperties:
+                  description: Context holds a general purpose REST API context
+                  properties:
+                    endpoint:
+                      description: REST API endpoint
+                      type: string
+                    method:
+                      description: 'Method is HTTP request method that indicates the
+                        desired action to be performed for a given resource. See RFC7231
+                        Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content'
+                      type: string
+                    port:
+                      description: Port on which HTTP server is listening for incoming
+                        events.
+                      type: string
+                    serverCertPath:
+                      description: ServerCertPath refers the file that contains the
+                        cert.
+                      type: string
+                    serverKeyPath:
+                      description: ServerKeyPath refers the file that contains private
+                        key
+                      type: string
+                    url:
+                      description: URL is the url of the server.
+                      type: string
+                  required:
+                  - endpoint
+                  - method
+                  - port
+                  - url
+                  type: object
+                description: Webhook event sources
+                type: object
+            required:
+            - type
+            type: object
+          status:
+            description: EventSourceStatus holds the status of the event-source resource
+            properties:
+              createdAt:
+                format: date-time
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/base/crds/gateway-crd.yaml
+++ b/manifests/base/crds/gateway-crd.yaml
@@ -1,6 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
   name: gateways.argoproj.io
 spec:
   group: argoproj.io
@@ -9,7 +14,6333 @@ spec:
     listKind: GatewayList
     plural: gateways
     singular: gateway
-    shortNames:
-      - gw
   scope: Namespaced
-  version: "v1alpha1"
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Gateway is the definition of a gateway resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GatewaySpec represents gateway specifications
+            properties:
+              eventSourceRef:
+                description: EventSourceRef refers to event-source that stores event
+                  source configurations for the gateway
+                properties:
+                  name:
+                    description: Name of the event source
+                    type: string
+                  namespace:
+                    description: Namespace of the event source Default value is the
+                      namespace where referencing gateway is deployed
+                    type: string
+                required:
+                - name
+                type: object
+              processorPort:
+                description: Port on which the gateway event source processor is running
+                  on.
+                type: string
+              replica:
+                description: Replica is the gateway deployment replicas
+                type: integer
+              service:
+                description: Service is the specifications of the service to expose
+                  the gateway Refer https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#service-v1-core
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly by the master. If an address
+                          is specified manually and is not in use by others, it will
+                          be allocated to the service; otherwise, creation of the
+                          service will fail. This field can not be changed through
+                          updates. Valid values are "None", empty string (""), or
+                          a valid IP address. "None" can be specified for headless
+                          services when proxying is not required. Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. Ignored if
+                          type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that kubedns
+                          or equivalent will return as a CNAME record for this service.
+                          No proxying will be involved. Must be a valid RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires Type
+                          to be ExternalName.
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. If not specified, HealthCheckNodePort
+                          is created by the service api backend with the allocated
+                          nodePort. Will use user-specified nodePort value if specified
+                          by the client. Only effects when Type is set to LoadBalancer
+                          and ExternalTrafficPolicy is set to Local.
+                        format: int32
+                        type: integer
+                      ipFamily:
+                        description: ipFamily specifies whether this Service has a
+                          preference for a particular IP family (e.g. IPv4 vs. IPv6).  If
+                          a specific IP family is requested, the clusterIP field will
+                          be allocated from that family, if it is available in the
+                          cluster.  If no IP family is requested, the cluster's primary
+                          IP family will be used. Other IP fields (loadBalancerIP,
+                          loadBalancerSourceRanges, externalIPs) and controllers which
+                          allocate external load-balancers should use the same IP
+                          family.  Endpoints for this Service will be of this family.  This
+                          field is immutable after creation. Assigning a ServiceIPFamily
+                          not available in the cluster (e.g. IPv6 in IPv4 only cluster)
+                          is an error condition and will fail during clusterIP assignment.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type=NodePort or LoadBalancer. Usually
+                                assigned by the system. If specified, it will be allocated
+                                to the service if unused or else creation of the service
+                                will fail. Default is to auto-allocate a port if the
+                                ServiceType of this Service requires one. More info:
+                                https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses, when set to true, indicates
+                          that DNS implementations must publish the notReadyAddresses
+                          of subsets for the Endpoints associated with the Service.
+                          The default value is false. The primary use case for setting
+                          this field is to use a StatefulSet's Headless Service to
+                          propagate SRV records for its Pods without respect to their
+                          readiness for purpose of peer discovery.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      topologyKeys:
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPolicy=Local. Topology
+                          keys must be valid label keys and at most 16 keys may be
+                          specified. Endpoints are chosen based on the first topology
+                          key with available backends. If this field is specified
+                          and all entries have no backends that match the topology
+                          of the client, the service has no backends for that client
+                          and connections should fail. The special value "*" may be
+                          used to mean "any topology". This catch-all value, if used,
+                          only makes sense as the last value in the list. If this
+                          is not specified or empty, no topology constraints will
+                          be applied.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ExternalName" maps to the specified
+                          externalName. "ClusterIP" allocates a cluster-internal IP
+                          address for load-balancing to endpoints. Endpoints are determined
+                          by the selector or if that is not specified, by manual construction
+                          of an Endpoints object. If clusterIP is "None", no virtual
+                          IP is allocated and the endpoints are published as a set
+                          of endpoints rather than a stable IP. "NodePort" builds
+                          on ClusterIP and allocates a port on every node which routes
+                          to the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                  status:
+                    description: 'Most recently observed status of the service. Populated
+                      by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer. Traffic intended for the service
+                              should be sent to these ingress points.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the service should be sent to an ingress point.'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balancers)
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              subscribers:
+                description: Subscribers holds the contexts of the subscribers/sinks
+                  to send events to.
+                properties:
+                  http:
+                    description: HTTP subscribers are HTTP endpoints to send events
+                      to.
+                    items:
+                      type: string
+                    type: array
+                  nats:
+                    description: NATS refers to the subscribers over NATS protocol.
+                    items:
+                      description: NATSSubscriber holds the context of subscriber
+                        over NATS.
+                      properties:
+                        name:
+                          description: Name of the subscription. Must be unique.
+                          type: string
+                        serverURL:
+                          description: ServerURL refers to the NATS server URL.
+                          type: string
+                        subject:
+                          description: Subject refers to the NATS subject name.
+                          type: string
+                      required:
+                      - name
+                      - serverURL
+                      - subject
+                      type: object
+                    type: array
+                type: object
+              template:
+                description: Template is the pod specification for the gateway Refer
+                  https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#pod-v1-core
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. This is an alpha
+                                feature enabled by the StartupProbe feature flag.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
+                          'Default' or 'None'. DNS parameters given in DNSConfig will
+                          be merged with the policy selected with DNSPolicy. To have
+                          DNS options set along with hostNetwork, you have to specify
+                          DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                          This field is alpha-level and is only honored by servers
+                          that enable the EphemeralContainers feature.
+                        items:
+                          description: An EphemeralContainer is a container that may
+                            be added temporarily to an existing pod for user-initiated
+                            activities such as debugging. Ephemeral containers have
+                            no resource or scheduling guarantees, and they will not
+                            be restarted when they exit or when a pod is removed or
+                            restarted. If an ephemeral container causes a pod to exceed
+                            its resource allocation, the pod may be evicted. Ephemeral
+                            containers may not be added by directly updating the pod
+                            spec. They must be added via the pod's ephemeralcontainers
+                            subresource, and they will appear in the pod spec once
+                            added. This is an alpha feature enabled by the EphemeralContainers
+                            feature flag.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: SecurityContext is not allowed for ephemeral
+                                containers.
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: If set, the name of the container from
+                                PodSpec that this ephemeral container targets. The
+                                ephemeral container will be run in the namespaces
+                                (IPC, PID, etc) of this container. If not set then
+                                the ephemeral container is run in whatever namespaces
+                                are shared for the pod. Note that the container runtime
+                                must support this feature.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          type: object
+                        type: array
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. For example, in the case of docker, only
+                          DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        type: array
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. This is an alpha
+                                feature enabled by the StartupProbe feature flag.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                          This field is alpha-level as of Kubernetes v1.16, and is
+                          only honored by servers that enable the PodOverhead feature.'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset. This field is
+                          alpha-level and is only honored by servers that enable the
+                          NonPreemptingPriority feature.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: 'Restart policy for all containers within the
+                          pod. One of Always, OnFailure, Never. Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                          This is a beta feature as of Kubernetes v1.14.'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow
+                              the Kubelet to change the ownership of that volume to
+                              be owned by the pod: \n 1. The owning GID will be the
+                              FSGroup 2. The setgid bit is set (new files created
+                              in the volume will be owned by FSGroup) 3. The permission
+                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
+                              will not modify the ownership and permissions of any
+                              volume."
+                            format: int64
+                            type: integer
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field. This
+                                  field is alpha-level and is only honored by servers
+                                  that enable the WindowsGMSA feature flag.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use. This field is alpha-level
+                                  and is only honored by servers that enable the WindowsGMSA
+                                  feature flag.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. This field is beta-level and may
+                                  be disabled with the WindowsRunAsUserName feature
+                                  flag.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          delete immediately. If this value is nil, the default grace
+                          period will be used instead. The grace period is the duration
+                          in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          This field is alpha-level and is only honored by clusters
+                          that enables the EvenPodsSpread feature. All topologySpreadConstraints
+                          are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. It''s the maximum
+                                permitted difference between the number of matching
+                                pods in any two topology domains of a given topology
+                                type. For example, in a 3-zone cluster, MaxSkew is
+                                set to 1, and pods with the same labelSelector spread
+                                as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                - if MaxSkew is 1, incoming pod can only be scheduled
+                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                                would make the ActualSkew(2-0) on zone1(zone2) violate
+                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
+                                scheduled onto any zone. It''s a required field. Default
+                                value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. It's
+                                a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal
+                                with a pod if it doesn''t satisfy the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not
+                                to schedule it - ScheduleAnyway tells the scheduler
+                                to still schedule it It''s considered as "Unsatisfiable"
+                                if and only if placing incoming pod on any topology
+                                violates "MaxSkew". For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
+                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
+                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
+                                incoming pod can only be scheduled to zone2(zone3)
+                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
+                                satisfies MaxSkew(1). In other words, the cluster
+                                can still be imbalanced, but scheduler won''t make
+                                it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'AWSElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'The partition in the volume that you
+                                    want to mount. If omitted, the default is to mount
+                                    by volume name. Examples: For volume /dev/sda1,
+                                    you specify the partition as "1". Similarly, the
+                                    volume partition for /dev/sda is "0" (or you can
+                                    leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'Specify "true" to force and set the
+                                    ReadOnly property in VolumeMounts to "true". If
+                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'Unique ID of the persistent disk resource
+                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: AzureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'Host Caching mode: None, Read Only,
+                                    Read Write.'
+                                  type: string
+                                diskName:
+                                  description: The Name of the data disk in the blob
+                                    storage
+                                  type: string
+                                diskURI:
+                                  description: The URI the data disk in the blob storage
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'Expected values Shared: multiple blob
+                                    disks per storage account  Dedicated: single blob
+                                    disk per storage account  Managed: azure managed
+                                    data disk (only in managed availability set).
+                                    defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: AzureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: the name of secret that contains Azure
+                                    Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: Share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: CephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'Required: Monitors is a collection
+                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'Optional: Used as the mounted root,
+                                    rather than the full Ceph tree, default is /'
+                                  type: string
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'Optional: SecretFile is the path to
+                                    key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'Optional: SecretRef is reference to
+                                    the authentication secret for User, default is
+                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'Optional: User is the rados user name,
+                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'Cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'Optional: points to a secret object
+                                    containing parameters used to connect to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volume id used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: ConfigMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: CSI (Container Storage Interface) represents
+                                storage that is handled by an external CSI driver
+                                (Alpha feature).
+                              properties:
+                                driver:
+                                  description: Driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Ex. "ext4",
+                                    "xfs", "ntfs". If not provided, the empty value
+                                    is passed to the associated CSI driver which will
+                                    determine the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: NodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: Specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: VolumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: DownwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'EmptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'What type of storage medium should
+                                    back this directory. The default is "" which means
+                                    to use the node''s default medium. Must be an
+                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'Total amount of local storage required
+                                    for this EmptyDir volume. The size limit is also
+                                    applicable for memory medium. The maximum usage
+                                    on memory medium EmptyDir would be the minimum
+                                    value between the SizeLimit specified here and
+                                    the sum of memory limits of all containers in
+                                    a pod. The default is nil which means that the
+                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            fc:
+                              description: FC represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. TODO: how
+                                    do we prevent errors in the filesystem from compromising
+                                    the machine'
+                                  type: string
+                                lun:
+                                  description: 'Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'Optional: FC target worldwide names
+                                    (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'Optional: FC volume world wide identifiers
+                                    (wwids) Either wwids or combination of targetWWNs
+                                    and lun must be set, but not both simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: FlexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: Driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". The default
+                                    filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Optional: Extra command options if
+                                    any.'
+                                  type: object
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'Optional: SecretRef is reference to
+                                    the secret object containing sensitive information
+                                    to pass to the plugin scripts. This may be empty
+                                    if no secret object is specified. If the secret
+                                    object contains more than one secret, all secrets
+                                    are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: Flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: Name of the dataset stored as metadata
+                                    -> name on the dataset for Flocker should be considered
+                                    as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: UUID of the dataset. This is unique
+                                    identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'GCEPersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'The partition in the volume that you
+                                    want to mount. If omitted, the default is to mount
+                                    by volume name. Examples: For volume /dev/sda1,
+                                    you specify the partition as "1". Similarly, the
+                                    volume partition for /dev/sda is "0" (or you can
+                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'Unique name of the PD resource in
+                                    GCE. Used to identify the disk in GCE. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'GitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: Target directory name. Must not contain
+                                    or start with '..'.  If '.' is supplied, the volume
+                                    directory will be the git repository.  Otherwise,
+                                    if specified, the volume will contain the git
+                                    repository in the subdirectory with the given
+                                    name.
+                                  type: string
+                                repository:
+                                  description: Repository URL
+                                  type: string
+                                revision:
+                                  description: Commit hash for the specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'Glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'EndpointsName is the endpoint name
+                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'Path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'HostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                --- TODO(jonesdl) We need to restrict who can use
+                                host directory mounts and who can/can not mount host
+                                directories as read/write.'
+                              properties:
+                                path:
+                                  description: 'Path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'Type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'ISCSI represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: whether support iSCSI Discovery CHAP
+                                    authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: whether support iSCSI Session CHAP
+                                    authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                initiatorName:
+                                  description: Custom iSCSI Initiator Name. If initiatorName
+                                    is specified with iscsiInterface simultaneously,
+                                    new iSCSI interface <target portal>:<volume name>
+                                    will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: Target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iSCSI Interface Name that uses an iSCSI
+                                    transport. Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: iSCSI Target Portal List. The portal
+                                    is either an IP or ip_addr:port if the port is
+                                    other than default (typically TCP ports 860 and
+                                    3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: CHAP Secret for iSCSI target and initiator
+                                    authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: iSCSI Target Portal. The Portal is
+                                    either an IP or ip_addr:port if the port is other
+                                    than default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: 'Volume''s name. Must be a DNS_LABEL and
+                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'NFS represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'Path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'Server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'PersistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: Will force the ReadOnly setting in
+                                    VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: PhotonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: ID that identifies Photon Controller
+                                    persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: PortworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: FSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: VolumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: Items for all in one resources secrets,
+                                configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: Mode bits to use on created files by
+                                    default. Must be a value between 0 and 0777. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: information about the configMap
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: If unspecified, each key-value
+                                              pair in the Data field of the referenced
+                                              ConfigMap will be projected into the
+                                              volume as a file whose name is the key
+                                              and content is the value. If specified,
+                                              the listed keys will be projected into
+                                              the specified paths, and unlisted keys
+                                              will not be present. If a key is specified
+                                              which is not present in the ConfigMap,
+                                              the volume setup will error unless it
+                                              is marked optional. Paths must be relative
+                                              and may not contain the '..' path or
+                                              start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of
+                                                    the file to map the key to. May
+                                                    not be an absolute path. May not
+                                                    contain the path element '..'.
+                                                    May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: information about the downwardAPI
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: information about the secret
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: If unspecified, each key-value
+                                              pair in the Data field of the referenced
+                                              Secret will be projected into the volume
+                                              as a file whose name is the key and
+                                              content is the value. If specified,
+                                              the listed keys will be projected into
+                                              the specified paths, and unlisted keys
+                                              will not be present. If a key is specified
+                                              which is not present in the Secret,
+                                              the volume setup will error unless it
+                                              is marked optional. Paths must be relative
+                                              and may not contain the '..' path or
+                                              start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of
+                                                    the file to map the key to. May
+                                                    not be an absolute path. May not
+                                                    contain the path element '..'.
+                                                    May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: information about the serviceAccountToken
+                                          data to project
+                                        properties:
+                                          audience:
+                                            description: Audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: ExpirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: Path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              required:
+                              - sources
+                              type: object
+                            quobyte:
+                              description: Quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: Group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: Registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: Tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: User to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: Volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'RBD represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                image:
+                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'Keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'A collection of Ceph monitors. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'The rados pool name. Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'SecretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'The rados user name. Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: ScaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Default is
+                                    "xfs".
+                                  type: string
+                                gateway:
+                                  description: The host address of the ScaleIO API
+                                    Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: The name of the ScaleIO Protection
+                                    Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: SecretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: Flag to enable/disable SSL communication
+                                    with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: Indicates whether the storage for a
+                                    volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: The ScaleIO Storage Pool associated
+                                    with the protection domain.
+                                  type: string
+                                system:
+                                  description: The name of the storage system as configured
+                                    in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: The name of a volume already created
+                                    in the ScaleIO system that is associated with
+                                    this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: 'Secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: Specify whether the Secret or its keys
+                                    must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'Name of the secret in the pod''s namespace
+                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: StorageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: SecretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: VolumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: VolumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: VsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: Storage Policy Based Management (SPBM)
+                                    profile ID associated with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: Storage Policy Based Management (SPBM)
+                                    profile name.
+                                  type: string
+                                volumePath:
+                                  description: Path that identifies vSphere volume
+                                    vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - containers
+                    type: object
+                type: object
+              type:
+                description: Type is the type of gateway. Used as metadata.
+                type: string
+            required:
+            - processorPort
+            - template
+            - type
+            type: object
+          status:
+            description: GatewayStatus contains information about the status of a
+              gateway.
+            properties:
+              message:
+                description: Message is a human readable string indicating details
+                  about a gateway in its phase
+                type: string
+              nodes:
+                additionalProperties:
+                  description: NodeStatus describes the status for an individual node
+                    in the gateway configurations. A single node can represent one
+                    configuration.
+                  properties:
+                    displayName:
+                      description: DisplayName is the human readable representation
+                        of the node
+                      type: string
+                    id:
+                      description: ID is a unique identifier of a node within a sensor
+                        It is a hash of the node name
+                      type: string
+                    message:
+                      description: Message store data or something to save for configuration
+                      type: string
+                    name:
+                      description: Name is a unique name in the node tree used to
+                        generate the node ID
+                      type: string
+                    phase:
+                      description: Phase of the node
+                      type: string
+                    startedAt:
+                      description: StartedAt is the time at which this node started
+                      format: date-time
+                      type: string
+                    updateTime:
+                      description: UpdateTime is the time when node(gateway configuration)
+                        was updated
+                      format: date-time
+                      type: string
+                  required:
+                  - displayName
+                  - id
+                  - name
+                  - phase
+                  type: object
+                description: Nodes is a mapping between a node ID and the node's status
+                  it records the states for the configurations of gateway.
+                type: object
+              phase:
+                description: Phase is the high-level summary of the gateway
+                type: string
+              resources:
+                description: Resources refers to the metadata about the gateway resources
+                properties:
+                  deployment:
+                    description: Metadata of the deployment for the gateway
+                    type: object
+                  service:
+                    description: Metadata of the service for the gateway
+                    type: object
+                required:
+                - deployment
+                type: object
+              startedAt:
+                description: StartedAt is the time at which this gateway was initiated
+                format: date-time
+                type: string
+            required:
+            - phase
+            - resources
+            type: object
+        required:
+        - metadata
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/base/crds/sensor-crd.yaml
+++ b/manifests/base/crds/sensor-crd.yaml
@@ -1,6 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
   name: sensors.argoproj.io
 spec:
   group: argoproj.io
@@ -9,7 +14,8689 @@ spec:
     listKind: SensorList
     plural: sensors
     singular: sensor
-    shortNames:
-      - sn
   scope: Namespaced
-  version: "v1alpha1"
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Sensor is the definition of a sensor resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SensorSpec represents desired sensor state
+            properties:
+              circuit:
+                description: Circuit is a boolean expression of dependency groups
+                type: string
+              dependencies:
+                description: Dependencies is a list of the events that this sensor
+                  is dependent on.
+                items:
+                  description: EventDependency describes a dependency
+                  properties:
+                    eventName:
+                      description: EventName is the name of the event
+                      type: string
+                    filters:
+                      description: Filters and rules governing toleration of success
+                        and constraints on the context and data of an event
+                      properties:
+                        context:
+                          description: Context filter constraints
+                          properties:
+                            dataContentType:
+                              description: DataContentType - A MIME (RFC2046) string
+                                describing the media type of `data`.
+                              type: string
+                            id:
+                              description: ID of the event; must be non-empty and
+                                unique within the scope of the producer.
+                              type: string
+                            source:
+                              description: Source - A URI describing the event producer.
+                              type: string
+                            specversion:
+                              description: SpecVersion - The version of the CloudEvents
+                                specification used by the event.
+                              type: string
+                            subject:
+                              description: Subject - The subject of the event in the
+                                context of the event producer
+                              type: string
+                            time:
+                              description: Time - A Timestamp when the event happened.
+                              format: date-time
+                              type: string
+                            type:
+                              description: Type - The type of the occurrence which
+                                has happened.
+                              type: string
+                          required:
+                          - dataContentType
+                          - id
+                          - source
+                          - specversion
+                          - subject
+                          - time
+                          - type
+                          type: object
+                        data:
+                          description: Data filter constraints with escalation
+                          items:
+                            description: 'DataFilter describes constraints and filters
+                              for event data Regular Expressions are purposefully
+                              not a feature as they are overkill for our uses here
+                              See Rob Pike''s Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html'
+                            properties:
+                              comparator:
+                                description: Comparator compares the event data with
+                                  a user given value. Can be ">=", ">", "=", "<",
+                                  or "<=". Is optional, and if left blank treated
+                                  as equality "=".
+                                type: string
+                              path:
+                                description: Path is the JSONPath of the event's (JSON
+                                  decoded) data key Path is a series of keys separated
+                                  by a dot. A key may contain wildcard characters
+                                  '*' and '?'. To access an array value use the index
+                                  as the key. The dot and wildcard characters can
+                                  be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                  for more information on how to use this.
+                                type: string
+                              type:
+                                description: Type contains the JSON type of the data
+                                type: string
+                              value:
+                                description: Value is the allowed string values for
+                                  this key Booleans are passed using strconv.ParseBool()
+                                  Numbers are parsed using as float64 using strconv.ParseFloat()
+                                  Strings are taken as is Nils this value is ignored
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - path
+                            - type
+                            - value
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the name of event filter
+                          type: string
+                        time:
+                          description: Time filter on the event with escalation
+                          properties:
+                            start:
+                              description: Start is the beginning of a time window.
+                                Before this time, events for this event are ignored
+                                and format is hh:mm:ss
+                              type: string
+                            stop:
+                              description: StopPattern is the end of a time window.
+                                After this time, events for this event are ignored
+                                and format is hh:mm:ss
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    gatewayName:
+                      description: GatewayName is the name of the gateway from whom
+                        the event is received
+                      type: string
+                    name:
+                      description: Name is a unique name of this dependency
+                      type: string
+                  required:
+                  - eventName
+                  - gatewayName
+                  - name
+                  type: object
+                type: array
+              dependencyGroups:
+                description: DependencyGroups is a list of the groups of events.
+                items:
+                  description: DependencyGroup is the group of dependencies
+                  properties:
+                    dependencies:
+                      description: Dependencies of events
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name of the group
+                      type: string
+                  required:
+                  - dependencies
+                  - name
+                  type: object
+                type: array
+              errorOnFailedRound:
+                description: ErrorOnFailedRound if set to true, marks sensor state
+                  as `error` if the previous trigger round fails. Once sensor state
+                  is set to `error`, no further triggers will be processed.
+                type: boolean
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                description: ServiceAnnotations refers to annotations to be set for
+                  the service generated
+                type: object
+              serviceLabels:
+                additionalProperties:
+                  type: string
+                description: ServiceLabels to be set for the service generated
+                type: object
+              subscription:
+                description: Subscription refers to the modes of events subscriptions
+                  for the sensor. At least one of the types of subscription must be
+                  defined in order for sensor to be meaningful.
+                properties:
+                  http:
+                    description: HTTP refers to the HTTP subscription of events for
+                      the sensor.
+                    properties:
+                      port:
+                        description: Port on which sensor server should run.
+                        type: integer
+                    required:
+                    - port
+                    type: object
+                  nats:
+                    description: NATS refers to the NATS subscription of events for
+                      the sensor
+                    properties:
+                      serverURL:
+                        description: ServerURL refers to NATS server url.
+                        type: string
+                      subject:
+                        description: Subject refers to NATS subject name.
+                        type: string
+                    required:
+                    - serverURL
+                    - subject
+                    type: object
+                type: object
+              template:
+                description: Template contains sensor pod specification. For more
+                  information, read https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#pod-v1-core.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty list
+                                            means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. This is an alpha
+                                feature enabled by the StartupProbe feature flag.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
+                          'Default' or 'None'. DNS parameters given in DNSConfig will
+                          be merged with the policy selected with DNSPolicy. To have
+                          DNS options set along with hostNetwork, you have to specify
+                          DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                          This field is alpha-level and is only honored by servers
+                          that enable the EphemeralContainers feature.
+                        items:
+                          description: An EphemeralContainer is a container that may
+                            be added temporarily to an existing pod for user-initiated
+                            activities such as debugging. Ephemeral containers have
+                            no resource or scheduling guarantees, and they will not
+                            be restarted when they exit or when a pod is removed or
+                            restarted. If an ephemeral container causes a pod to exceed
+                            its resource allocation, the pod may be evicted. Ephemeral
+                            containers may not be added by directly updating the pod
+                            spec. They must be added via the pod's ephemeralcontainers
+                            subresource, and they will appear in the pod spec once
+                            added. This is an alpha feature enabled by the EphemeralContainers
+                            feature flag.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: SecurityContext is not allowed for ephemeral
+                                containers.
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: If set, the name of the container from
+                                PodSpec that this ephemeral container targets. The
+                                ephemeral container will be run in the namespaces
+                                (IPC, PID, etc) of this container. If not set then
+                                the ephemeral container is run in whatever namespaces
+                                are shared for the pod. Note that the container runtime
+                                must support this feature.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          type: object
+                        type: array
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. For example, in the case of docker, only
+                          DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        type: array
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :latest tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The reason for termination is passed
+                                    to the handler. The Pod''s termination grace period
+                                    countdown begins before the PreStop hooked is
+                                    executed. Regardless of the outcome of the handler,
+                                    the container will eventually terminate within
+                                    the Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. This is an alpha
+                                feature enabled by the StartupProbe feature flag.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                          This field is alpha-level as of Kubernetes v1.16, and is
+                          only honored by servers that enable the PodOverhead feature.'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset. This field is
+                          alpha-level and is only honored by servers that enable the
+                          NonPreemptingPriority feature.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: 'Restart policy for all containers within the
+                          pod. One of Always, OnFailure, Never. Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                          This is a beta feature as of Kubernetes v1.14.'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow
+                              the Kubelet to change the ownership of that volume to
+                              be owned by the pod: \n 1. The owning GID will be the
+                              FSGroup 2. The setgid bit is set (new files created
+                              in the volume will be owned by FSGroup) 3. The permission
+                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
+                              will not modify the ownership and permissions of any
+                              volume."
+                            format: int64
+                            type: integer
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field. This
+                                  field is alpha-level and is only honored by servers
+                                  that enable the WindowsGMSA feature flag.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use. This field is alpha-level
+                                  and is only honored by servers that enable the WindowsGMSA
+                                  feature flag.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. This field is beta-level and may
+                                  be disabled with the WindowsRunAsUserName feature
+                                  flag.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          delete immediately. If this value is nil, the default grace
+                          period will be used instead. The grace period is the duration
+                          in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          This field is alpha-level and is only honored by clusters
+                          that enables the EvenPodsSpread feature. All topologySpreadConstraints
+                          are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. It''s the maximum
+                                permitted difference between the number of matching
+                                pods in any two topology domains of a given topology
+                                type. For example, in a 3-zone cluster, MaxSkew is
+                                set to 1, and pods with the same labelSelector spread
+                                as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                - if MaxSkew is 1, incoming pod can only be scheduled
+                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                                would make the ActualSkew(2-0) on zone1(zone2) violate
+                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
+                                scheduled onto any zone. It''s a required field. Default
+                                value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. It's
+                                a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal
+                                with a pod if it doesn''t satisfy the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not
+                                to schedule it - ScheduleAnyway tells the scheduler
+                                to still schedule it It''s considered as "Unsatisfiable"
+                                if and only if placing incoming pod on any topology
+                                violates "MaxSkew". For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
+                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
+                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
+                                incoming pod can only be scheduled to zone2(zone3)
+                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
+                                satisfies MaxSkew(1). In other words, the cluster
+                                can still be imbalanced, but scheduler won''t make
+                                it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'AWSElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'The partition in the volume that you
+                                    want to mount. If omitted, the default is to mount
+                                    by volume name. Examples: For volume /dev/sda1,
+                                    you specify the partition as "1". Similarly, the
+                                    volume partition for /dev/sda is "0" (or you can
+                                    leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'Specify "true" to force and set the
+                                    ReadOnly property in VolumeMounts to "true". If
+                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'Unique ID of the persistent disk resource
+                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: AzureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'Host Caching mode: None, Read Only,
+                                    Read Write.'
+                                  type: string
+                                diskName:
+                                  description: The Name of the data disk in the blob
+                                    storage
+                                  type: string
+                                diskURI:
+                                  description: The URI the data disk in the blob storage
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'Expected values Shared: multiple blob
+                                    disks per storage account  Dedicated: single blob
+                                    disk per storage account  Managed: azure managed
+                                    data disk (only in managed availability set).
+                                    defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: AzureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: the name of secret that contains Azure
+                                    Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: Share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: CephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'Required: Monitors is a collection
+                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'Optional: Used as the mounted root,
+                                    rather than the full Ceph tree, default is /'
+                                  type: string
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'Optional: SecretFile is the path to
+                                    key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'Optional: SecretRef is reference to
+                                    the authentication secret for User, default is
+                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'Optional: User is the rados user name,
+                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'Cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'Optional: points to a secret object
+                                    containing parameters used to connect to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volume id used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: ConfigMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: CSI (Container Storage Interface) represents
+                                storage that is handled by an external CSI driver
+                                (Alpha feature).
+                              properties:
+                                driver:
+                                  description: Driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Ex. "ext4",
+                                    "xfs", "ntfs". If not provided, the empty value
+                                    is passed to the associated CSI driver which will
+                                    determine the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: NodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: Specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: VolumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: DownwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'EmptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'What type of storage medium should
+                                    back this directory. The default is "" which means
+                                    to use the node''s default medium. Must be an
+                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'Total amount of local storage required
+                                    for this EmptyDir volume. The size limit is also
+                                    applicable for memory medium. The maximum usage
+                                    on memory medium EmptyDir would be the minimum
+                                    value between the SizeLimit specified here and
+                                    the sum of memory limits of all containers in
+                                    a pod. The default is nil which means that the
+                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            fc:
+                              description: FC represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type to mount. Must be
+                                    a filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. TODO: how
+                                    do we prevent errors in the filesystem from compromising
+                                    the machine'
+                                  type: string
+                                lun:
+                                  description: 'Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'Optional: FC target worldwide names
+                                    (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'Optional: FC volume world wide identifiers
+                                    (wwids) Either wwids or combination of targetWWNs
+                                    and lun must be set, but not both simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: FlexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: Driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". The default
+                                    filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Optional: Extra command options if
+                                    any.'
+                                  type: object
+                                readOnly:
+                                  description: 'Optional: Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'Optional: SecretRef is reference to
+                                    the secret object containing sensitive information
+                                    to pass to the plugin scripts. This may be empty
+                                    if no secret object is specified. If the secret
+                                    object contains more than one secret, all secrets
+                                    are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: Flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: Name of the dataset stored as metadata
+                                    -> name on the dataset for Flocker should be considered
+                                    as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: UUID of the dataset. This is unique
+                                    identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'GCEPersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'The partition in the volume that you
+                                    want to mount. If omitted, the default is to mount
+                                    by volume name. Examples: For volume /dev/sda1,
+                                    you specify the partition as "1". Similarly, the
+                                    volume partition for /dev/sda is "0" (or you can
+                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'Unique name of the PD resource in
+                                    GCE. Used to identify the disk in GCE. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'GitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: Target directory name. Must not contain
+                                    or start with '..'.  If '.' is supplied, the volume
+                                    directory will be the git repository.  Otherwise,
+                                    if specified, the volume will contain the git
+                                    repository in the subdirectory with the given
+                                    name.
+                                  type: string
+                                repository:
+                                  description: Repository URL
+                                  type: string
+                                revision:
+                                  description: Commit hash for the specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'Glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'EndpointsName is the endpoint name
+                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'Path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'HostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                --- TODO(jonesdl) We need to restrict who can use
+                                host directory mounts and who can/can not mount host
+                                directories as read/write.'
+                              properties:
+                                path:
+                                  description: 'Path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'Type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'ISCSI represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: whether support iSCSI Discovery CHAP
+                                    authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: whether support iSCSI Session CHAP
+                                    authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                initiatorName:
+                                  description: Custom iSCSI Initiator Name. If initiatorName
+                                    is specified with iscsiInterface simultaneously,
+                                    new iSCSI interface <target portal>:<volume name>
+                                    will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: Target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iSCSI Interface Name that uses an iSCSI
+                                    transport. Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: iSCSI Target Portal List. The portal
+                                    is either an IP or ip_addr:port if the port is
+                                    other than default (typically TCP ports 860 and
+                                    3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: CHAP Secret for iSCSI target and initiator
+                                    authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: iSCSI Target Portal. The Portal is
+                                    either an IP or ip_addr:port if the port is other
+                                    than default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: 'Volume''s name. Must be a DNS_LABEL and
+                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'NFS represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'Path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'Server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'PersistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: Will force the ReadOnly setting in
+                                    VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: PhotonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: ID that identifies Photon Controller
+                                    persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: PortworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: FSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: VolumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: Items for all in one resources secrets,
+                                configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: Mode bits to use on created files by
+                                    default. Must be a value between 0 and 0777. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: information about the configMap
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: If unspecified, each key-value
+                                              pair in the Data field of the referenced
+                                              ConfigMap will be projected into the
+                                              volume as a file whose name is the key
+                                              and content is the value. If specified,
+                                              the listed keys will be projected into
+                                              the specified paths, and unlisted keys
+                                              will not be present. If a key is specified
+                                              which is not present in the ConfigMap,
+                                              the volume setup will error unless it
+                                              is marked optional. Paths must be relative
+                                              and may not contain the '..' path or
+                                              start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of
+                                                    the file to map the key to. May
+                                                    not be an absolute path. May not
+                                                    contain the path element '..'.
+                                                    May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: information about the downwardAPI
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: information about the secret
+                                          data to project
+                                        properties:
+                                          items:
+                                            description: If unspecified, each key-value
+                                              pair in the Data field of the referenced
+                                              Secret will be projected into the volume
+                                              as a file whose name is the key and
+                                              content is the value. If specified,
+                                              the listed keys will be projected into
+                                              the specified paths, and unlisted keys
+                                              will not be present. If a key is specified
+                                              which is not present in the Secret,
+                                              the volume setup will error unless it
+                                              is marked optional. Paths must be relative
+                                              and may not contain the '..' path or
+                                              start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: The key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    to use on this file, must be a
+                                                    value between 0 and 0777. If not
+                                                    specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: The relative path of
+                                                    the file to map the key to. May
+                                                    not be an absolute path. May not
+                                                    contain the path element '..'.
+                                                    May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: information about the serviceAccountToken
+                                          data to project
+                                        properties:
+                                          audience:
+                                            description: Audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: ExpirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: Path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              required:
+                              - sources
+                              type: object
+                            quobyte:
+                              description: Quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: Group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: Registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: Tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: User to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: Volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'RBD represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'Filesystem type of the volume that
+                                    you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                image:
+                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'Keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'A collection of Ceph monitors. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'The rados pool name. Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'ReadOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'SecretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'The rados user name. Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: ScaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Default is
+                                    "xfs".
+                                  type: string
+                                gateway:
+                                  description: The host address of the ScaleIO API
+                                    Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: The name of the ScaleIO Protection
+                                    Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: SecretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: Flag to enable/disable SSL communication
+                                    with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: Indicates whether the storage for a
+                                    volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: The ScaleIO Storage Pool associated
+                                    with the protection domain.
+                                  type: string
+                                system:
+                                  description: The name of the storage system as configured
+                                    in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: The name of a volume already created
+                                    in the ScaleIO system that is associated with
+                                    this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: 'Secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a value between 0 and
+                                    0777. Defaults to 0644. Directories within the
+                                    path are not affected by this setting. This might
+                                    be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: Specify whether the Secret or its keys
+                                    must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'Name of the secret in the pod''s namespace
+                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: StorageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: Defaults to false (read/write). ReadOnly
+                                    here will force the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: SecretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: VolumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: VolumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: VsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: Filesystem type to mount. Must be a
+                                    filesystem type supported by the host operating
+                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: Storage Policy Based Management (SPBM)
+                                    profile ID associated with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: Storage Policy Based Management (SPBM)
+                                    profile name.
+                                  type: string
+                                volumePath:
+                                  description: Path that identifies vSphere volume
+                                    vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - containers
+                    type: object
+                type: object
+              triggers:
+                description: Triggers is a list of the things that this sensor evokes.
+                  These are the outputs from this sensor.
+                items:
+                  description: Trigger is an action taken, output produced, an event
+                    created, a message sent
+                  properties:
+                    parameters:
+                      description: Parameters is the list of parameters applied to
+                        the trigger template definition
+                      items:
+                        description: TriggerParameter indicates a passed parameter
+                          to a service template
+                        properties:
+                          dest:
+                            description: Dest is the JSONPath of a resource key. A
+                              path is a series of keys separated by a dot. The colon
+                              character can be escaped with '.' The -1 key can be
+                              used to append a value to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                              for more information about how this is used.
+                            type: string
+                          operation:
+                            description: Operation is what to do with the existing
+                              value at Dest, whether to 'prepend', 'overwrite', or
+                              'append' it.
+                            type: string
+                          src:
+                            description: Src contains a source reference to the value
+                              of the parameter from a dependency
+                            properties:
+                              contextKey:
+                                description: ContextKey is the JSONPath of the event's
+                                  (JSON decoded) context key ContextKey is a series
+                                  of keys separated by a dot. A key may contain wildcard
+                                  characters '*' and '?'. To access an array value
+                                  use the index as the key. The dot and wildcard characters
+                                  can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                  for more information on how to use this.
+                                type: string
+                              contextTemplate:
+                                description: ContextTemplate is a go-template for
+                                  extracting a string from the event's context. If
+                                  a ContextTemplate is provided with a ContextKey,
+                                  the template will be evaluated first and fallback
+                                  to the ContextKey. The templating follows the standard
+                                  go-template syntax as well as sprig's extra functions.
+                                  See https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                type: string
+                              dataKey:
+                                description: DataKey is the JSONPath of the event's
+                                  (JSON decoded) data key DataKey is a series of keys
+                                  separated by a dot. A key may contain wildcard characters
+                                  '*' and '?'. To access an array value use the index
+                                  as the key. The dot and wildcard characters can
+                                  be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                  for more information on how to use this.
+                                type: string
+                              dataTemplate:
+                                description: DataTemplate is a go-template for extracting
+                                  a string from the event's data. If a DataTemplate
+                                  is provided with a DataKey, the template will be
+                                  evaluated first and fallback to the DataKey. The
+                                  templating follows the standard go-template syntax
+                                  as well as sprig's extra functions. See https://pkg.go.dev/text/template
+                                  and https://masterminds.github.io/sprig/
+                                type: string
+                              dependencyName:
+                                description: DependencyName refers to the name of
+                                  the dependency. The event which is stored for this
+                                  dependency is used as payload for the parameterization.
+                                  Make sure to refer to one of the dependencies you
+                                  have defined under Dependencies list.
+                                type: string
+                              value:
+                                description: Value is the default literal value to
+                                  use for this parameter source This is only used
+                                  if the DataKey is invalid. If the DataKey is invalid
+                                  and this is not defined, this param source will
+                                  produce an error.
+                                type: string
+                            required:
+                            - dependencyName
+                            type: object
+                        required:
+                        - dest
+                        - src
+                        type: object
+                      type: array
+                    policy:
+                      description: Policy to configure backoff and execution criteria
+                        for the trigger
+                      properties:
+                        k8s:
+                          description: K8sResourcePolicy refers to the policy used
+                            to check the state of K8s based triggers using using labels
+                          properties:
+                            backoff:
+                              description: Backoff before checking resource state
+                              type: object
+                            errorOnBackoffTimeout:
+                              description: ErrorOnBackoffTimeout determines whether
+                                sensor should transition to error state if the trigger
+                                policy is unable to determine the state of the resource
+                              type: boolean
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels required to identify whether a resource
+                                is in success state
+                              type: object
+                          required:
+                          - backoff
+                          - errorOnBackoffTimeout
+                          - labels
+                          type: object
+                        status:
+                          description: Status refers to the policy used to check the
+                            state of the trigger using response status
+                          properties:
+                            allow:
+                              description: Allow refers to the list of allowed response
+                                statuses. If the response status of the the trigger
+                                is within the list, the trigger will marked as successful
+                                else it will result in trigger failure.
+                              items:
+                                type: integer
+                              type: array
+                          required:
+                          - allow
+                          type: object
+                      type: object
+                    template:
+                      description: Template describes the trigger specification.
+                      properties:
+                        argoWorkflow:
+                          description: ArgoWorkflow refers to the trigger that can
+                            perform various operations on an Argo workflow.
+                          properties:
+                            group:
+                              type: string
+                            operation:
+                              description: Operation refers to the type of operation
+                                performed on the argo workflow resource. Default value
+                                is Submit.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of parameters to
+                                pass to resolved Argo Workflow object
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            resource:
+                              type: string
+                            source:
+                              description: Source of the K8 resource file(s)
+                              properties:
+                                configmap:
+                                  description: Configmap that stores the minio
+                                  properties:
+                                    key:
+                                      description: Key within configmap data which
+                                        contains trigger resource definition
+                                      type: string
+                                    name:
+                                      description: Name of the configmap
+                                      type: string
+                                    namespace:
+                                      description: Namespace where configmap is deployed
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                file:
+                                  description: File minio is minio stored in a file
+                                  properties:
+                                    path:
+                                      type: string
+                                  type: object
+                                git:
+                                  description: Git repository hosting the minio
+                                  properties:
+                                    branch:
+                                      description: Branch to use to pull trigger resource
+                                      type: string
+                                    cloneDirectory:
+                                      description: Directory to clone the repository.
+                                        We clone complete directory because GitArtifact
+                                        is not limited to any specific Git service
+                                        providers. Hence we don't use any specific
+                                        git provider client.
+                                      type: string
+                                    creds:
+                                      description: Creds contain reference to git
+                                        username and password
+                                      properties:
+                                        password:
+                                          description: SecretKeySelector selects a
+                                            key of a Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        username:
+                                          description: SecretKeySelector selects a
+                                            key of a Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      required:
+                                      - password
+                                      - username
+                                      type: object
+                                    filePath:
+                                      description: Path to file that contains trigger
+                                        resource definition
+                                      type: string
+                                    namespace:
+                                      description: Namespace where creds are stored.
+                                      type: string
+                                    ref:
+                                      description: Ref to use to pull trigger resource.
+                                        Will result in a shallow clone and fetch.
+                                      type: string
+                                    remote:
+                                      description: Remote to manage set of tracked
+                                        repositories. Defaults to "origin". Refer
+                                        https://git-scm.com/docs/git-remote
+                                      properties:
+                                        name:
+                                          description: Name of the remote to fetch
+                                            from.
+                                          type: string
+                                        urls:
+                                          description: URLs the URLs of a remote repository.
+                                            It must be non-empty. Fetch will always
+                                            use the first URL, while push will use
+                                            all of them.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - name
+                                      - urls
+                                      type: object
+                                    sshKeyPath:
+                                      description: SSHKeyPath is path to your ssh
+                                        key path. Use this if you don't want to provide
+                                        username and password. ssh key path must be
+                                        mounted in sensor pod.
+                                      type: string
+                                    tag:
+                                      description: Tag to use to pull trigger resource
+                                      type: string
+                                    url:
+                                      description: Git URL
+                                      type: string
+                                  required:
+                                  - cloneDirectory
+                                  - filePath
+                                  - url
+                                  type: object
+                                inline:
+                                  description: Inline minio is embedded in sensor
+                                    spec as a string
+                                  type: string
+                                resource:
+                                  description: Resource is generic template for K8s
+                                    resource
+                                  type: object
+                                s3:
+                                  description: S3 compliant minio
+                                  properties:
+                                    accessKey:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    bucket:
+                                      description: S3Bucket contains information to
+                                        describe an S3 Bucket
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    endpoint:
+                                      type: string
+                                    events:
+                                      items:
+                                        type: string
+                                      type: array
+                                    filter:
+                                      description: S3Filter represents filters to
+                                        apply to bucket nofifications for specifying
+                                        constraints on objects
+                                      properties:
+                                        prefix:
+                                          type: string
+                                        suffix:
+                                          type: string
+                                      required:
+                                      - prefix
+                                      - suffix
+                                      type: object
+                                    insecure:
+                                      type: boolean
+                                    region:
+                                      type: string
+                                    secretKey:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  required:
+                                  - accessKey
+                                  - bucket
+                                  - endpoint
+                                  - secretKey
+                                  type: object
+                                url:
+                                  description: URL to fetch the minio from
+                                  properties:
+                                    path:
+                                      description: Path is the complete URL
+                                      type: string
+                                    verifyCert:
+                                      description: VerifyCert decides whether the
+                                        connection is secure or not
+                                      type: boolean
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            version:
+                              type: string
+                          required:
+                          - group
+                          - resource
+                          - source
+                          - version
+                          type: object
+                        awsLambda:
+                          description: AWSLambda refers to the trigger designed to
+                            invoke AWS Lambda function with with on-the-fly constructable
+                            payload.
+                          properties:
+                            accessKey:
+                              description: AccessKey refers K8 secret containing aws
+                                access key
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            functionName:
+                              description: FunctionName refers to the name of the
+                                function to invoke.
+                              type: string
+                            namespace:
+                              description: Namespace refers to Kubernetes namespace
+                                to read access related secret from. Defaults to sensor's
+                                namespace.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of key-value extracted
+                                from event's payload that are applied to the trigger
+                                resource.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the request payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            region:
+                              description: Region is AWS region
+                              type: string
+                            secretKey:
+                              description: SecretKey refers K8 secret containing aws
+                                secret key
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          required:
+                          - functionName
+                          - payload
+                          - region
+                          type: object
+                        custom:
+                          description: CustomTrigger refers to the trigger designed
+                            to connect to a gRPC trigger server and execute a custom
+                            trigger.
+                          properties:
+                            certFilePath:
+                              description: CertFilePath is path to the cert file within
+                                sensor for secure connection between sensor and custom
+                                trigger gRPC server.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of parameters that
+                                is applied to resolved custom trigger trigger object.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the request payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            secure:
+                              description: Secure refers to type of the connection
+                                between sensor to custom trigger gRPC
+                              type: boolean
+                            serverNameOverride:
+                              description: ServerNameOverride for the secure connection
+                                between sensor and custom trigger gRPC server.
+                              type: string
+                            serverURL:
+                              description: ServerURL is the url of the gRPC server
+                                that executes custom trigger
+                              type: string
+                            triggerBody:
+                              description: TriggerBody is the custom trigger resource
+                                specification that custom trigger gRPC server knows
+                                how to interpret.
+                              type: string
+                          required:
+                          - payload
+                          - secure
+                          - serverURL
+                          - triggerBody
+                          type: object
+                        http:
+                          description: HTTP refers to the trigger designed to dispatch
+                            a HTTP request with on-the-fly constructable payload.
+                          properties:
+                            basicAuth:
+                              description: BasicAuth configuration for the http request.
+                              properties:
+                                namespace:
+                                  description: Namespace to read the secrets from.
+                                    Defaults to sensor's namespace.
+                                  type: string
+                                password:
+                                  description: Password refers to the Kubernetes secret
+                                    that holds the password required for basic auth.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                username:
+                                  description: Username refers to the Kubernetes secret
+                                    that holds the username required for basic auth.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            method:
+                              description: Method refers to the type of the HTTP request.
+                                Refer https://golang.org/src/net/http/method.go for
+                                more info. Default value is POST.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of key-value extracted
+                                from event's payload that are applied to the HTTP
+                                trigger resource.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the HTTP request
+                                payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            timeout:
+                              description: Timeout refers to the HTTP request timeout
+                                in seconds. Default value is 60 seconds.
+                              type: integer
+                            tls:
+                              description: TLS configuration for the HTTP client.
+                              properties:
+                                caCertPath:
+                                  description: CACertPath refers the file path that
+                                    contains the CA cert.
+                                  type: string
+                                clientCertPath:
+                                  description: ClientCertPath refers the file path
+                                    that contains client cert.
+                                  type: string
+                                clientKeyPath:
+                                  description: ClientKeyPath refers the file path
+                                    that contains client key.
+                                  type: string
+                              required:
+                              - caCertPath
+                              - clientCertPath
+                              - clientKeyPath
+                              type: object
+                            url:
+                              description: URL refers to the URL to send HTTP request
+                                to.
+                              type: string
+                          required:
+                          - payload
+                          - url
+                          type: object
+                        k8s:
+                          description: StandardK8sTrigger refers to the trigger designed
+                            to create or update a generic Kubernetes resource.
+                          properties:
+                            group:
+                              type: string
+                            operation:
+                              description: Operation refers to the type of operation
+                                performed on the k8s resource. Default value is Create.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of parameters that
+                                is applied to resolved K8s trigger object.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            resource:
+                              type: string
+                            source:
+                              description: Source of the K8 resource file(s)
+                              properties:
+                                configmap:
+                                  description: Configmap that stores the minio
+                                  properties:
+                                    key:
+                                      description: Key within configmap data which
+                                        contains trigger resource definition
+                                      type: string
+                                    name:
+                                      description: Name of the configmap
+                                      type: string
+                                    namespace:
+                                      description: Namespace where configmap is deployed
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                file:
+                                  description: File minio is minio stored in a file
+                                  properties:
+                                    path:
+                                      type: string
+                                  type: object
+                                git:
+                                  description: Git repository hosting the minio
+                                  properties:
+                                    branch:
+                                      description: Branch to use to pull trigger resource
+                                      type: string
+                                    cloneDirectory:
+                                      description: Directory to clone the repository.
+                                        We clone complete directory because GitArtifact
+                                        is not limited to any specific Git service
+                                        providers. Hence we don't use any specific
+                                        git provider client.
+                                      type: string
+                                    creds:
+                                      description: Creds contain reference to git
+                                        username and password
+                                      properties:
+                                        password:
+                                          description: SecretKeySelector selects a
+                                            key of a Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        username:
+                                          description: SecretKeySelector selects a
+                                            key of a Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      required:
+                                      - password
+                                      - username
+                                      type: object
+                                    filePath:
+                                      description: Path to file that contains trigger
+                                        resource definition
+                                      type: string
+                                    namespace:
+                                      description: Namespace where creds are stored.
+                                      type: string
+                                    ref:
+                                      description: Ref to use to pull trigger resource.
+                                        Will result in a shallow clone and fetch.
+                                      type: string
+                                    remote:
+                                      description: Remote to manage set of tracked
+                                        repositories. Defaults to "origin". Refer
+                                        https://git-scm.com/docs/git-remote
+                                      properties:
+                                        name:
+                                          description: Name of the remote to fetch
+                                            from.
+                                          type: string
+                                        urls:
+                                          description: URLs the URLs of a remote repository.
+                                            It must be non-empty. Fetch will always
+                                            use the first URL, while push will use
+                                            all of them.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - name
+                                      - urls
+                                      type: object
+                                    sshKeyPath:
+                                      description: SSHKeyPath is path to your ssh
+                                        key path. Use this if you don't want to provide
+                                        username and password. ssh key path must be
+                                        mounted in sensor pod.
+                                      type: string
+                                    tag:
+                                      description: Tag to use to pull trigger resource
+                                      type: string
+                                    url:
+                                      description: Git URL
+                                      type: string
+                                  required:
+                                  - cloneDirectory
+                                  - filePath
+                                  - url
+                                  type: object
+                                inline:
+                                  description: Inline minio is embedded in sensor
+                                    spec as a string
+                                  type: string
+                                resource:
+                                  description: Resource is generic template for K8s
+                                    resource
+                                  type: object
+                                s3:
+                                  description: S3 compliant minio
+                                  properties:
+                                    accessKey:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    bucket:
+                                      description: S3Bucket contains information to
+                                        describe an S3 Bucket
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    endpoint:
+                                      type: string
+                                    events:
+                                      items:
+                                        type: string
+                                      type: array
+                                    filter:
+                                      description: S3Filter represents filters to
+                                        apply to bucket nofifications for specifying
+                                        constraints on objects
+                                      properties:
+                                        prefix:
+                                          type: string
+                                        suffix:
+                                          type: string
+                                      required:
+                                      - prefix
+                                      - suffix
+                                      type: object
+                                    insecure:
+                                      type: boolean
+                                    region:
+                                      type: string
+                                    secretKey:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  required:
+                                  - accessKey
+                                  - bucket
+                                  - endpoint
+                                  - secretKey
+                                  type: object
+                                url:
+                                  description: URL to fetch the minio from
+                                  properties:
+                                    path:
+                                      description: Path is the complete URL
+                                      type: string
+                                    verifyCert:
+                                      description: VerifyCert decides whether the
+                                        connection is secure or not
+                                      type: boolean
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            version:
+                              type: string
+                          required:
+                          - group
+                          - resource
+                          - source
+                          - version
+                          type: object
+                        kafka:
+                          description: Kafka refers to the trigger designed to place
+                            messages on Kafka topic.
+                          properties:
+                            compress:
+                              description: Compress determines whether to compress
+                                message or not. Defaults to false. If set to true,
+                                compresses message using snappy compression.
+                              type: boolean
+                            flushFrequency:
+                              description: FlushFrequency refers to the frequency
+                                in milliseconds to flush batches. Defaults to 500
+                                milliseconds.
+                              type: integer
+                            parameters:
+                              description: Parameters is the list of parameters that
+                                is applied to resolved Kafka trigger object.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            partition:
+                              description: Partition to write data to.
+                              type: integer
+                            partitioningKey:
+                              description: The partitioning key for the messages put
+                                on the Kafka topic. Defaults to broker url.
+                              type: string
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the request payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            requiredAcks:
+                              description: RequiredAcks used in producer to tell the
+                                broker how many replica acknowledgements Defaults
+                                to 1 (Only wait for the leader to ack).
+                              type: integer
+                            tls:
+                              description: TLS configuration for the Kafka producer.
+                              properties:
+                                caCertPath:
+                                  description: CACertPath refers the file path that
+                                    contains the CA cert.
+                                  type: string
+                                clientCertPath:
+                                  description: ClientCertPath refers the file path
+                                    that contains client cert.
+                                  type: string
+                                clientKeyPath:
+                                  description: ClientKeyPath refers the file path
+                                    that contains client key.
+                                  type: string
+                              required:
+                              - caCertPath
+                              - clientCertPath
+                              - clientKeyPath
+                              type: object
+                            topic:
+                              description: Name of the topic. More info at https://kafka.apache.org/documentation/#intro_topics
+                              type: string
+                            url:
+                              description: URL of the Kafka broker.
+                              type: string
+                          required:
+                          - partition
+                          - payload
+                          - topic
+                          - url
+                          type: object
+                        name:
+                          description: Name is a unique name of the action to take.
+                          type: string
+                        nats:
+                          description: NATS refers to the trigger designed to place
+                            message on NATS subject.
+                          properties:
+                            parameters:
+                              description: Parameters is the list of parameters that
+                                is applied to resolved NATS trigger object.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the request payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            subject:
+                              description: Name of the subject to put message on.
+                              type: string
+                            tls:
+                              description: TLS configuration for the NATS producer.
+                              properties:
+                                caCertPath:
+                                  description: CACertPath refers the file path that
+                                    contains the CA cert.
+                                  type: string
+                                clientCertPath:
+                                  description: ClientCertPath refers the file path
+                                    that contains client cert.
+                                  type: string
+                                clientKeyPath:
+                                  description: ClientKeyPath refers the file path
+                                    that contains client key.
+                                  type: string
+                              required:
+                              - caCertPath
+                              - clientCertPath
+                              - clientKeyPath
+                              type: object
+                            url:
+                              description: URL of the NATS cluster.
+                              type: string
+                          required:
+                          - payload
+                          - subject
+                          - url
+                          type: object
+                        openWhisk:
+                          description: OpenWhisk refers to the trigger designed to
+                            invoke OpenWhisk action.
+                          properties:
+                            actionName:
+                              description: Name of the action/function.
+                              type: string
+                            authToken:
+                              description: AuthToken for authentication.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            host:
+                              description: Host URL of the OpenWhisk.
+                              type: string
+                            namespace:
+                              description: Namespace for the action. Defaults to "_".
+                              type: string
+                            parameters:
+                              description: Parameters is the list of key-value extracted
+                                from event's payload that are applied to the trigger
+                                resource.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            payload:
+                              description: Payload is the list of key-value extracted
+                                from an event payload to construct the request payload.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            version:
+                              description: Version for the API. Defaults to v1.
+                              type: string
+                          required:
+                          - actionName
+                          - host
+                          - payload
+                          type: object
+                        slack:
+                          description: Slack refers to the trigger designed to send
+                            slack notification message.
+                          properties:
+                            channel:
+                              description: Channel refers to which Slack channel to
+                                send slack message.
+                              type: string
+                            message:
+                              description: Message refers to the message to send to
+                                the Slack channel.
+                              type: string
+                            namespace:
+                              description: Namespace to read the password secret from.
+                                This is required if the password secret selector is
+                                specified.
+                              type: string
+                            parameters:
+                              description: Parameters is the list of key-value extracted
+                                from event's payload that are applied to the trigger
+                                resource.
+                              items:
+                                description: TriggerParameter indicates a passed parameter
+                                  to a service template
+                                properties:
+                                  dest:
+                                    description: Dest is the JSONPath of a resource
+                                      key. A path is a series of keys separated by
+                                      a dot. The colon character can be escaped with
+                                      '.' The -1 key can be used to append a value
+                                      to an existing array. See https://github.com/tidwall/sjson#path-syntax
+                                      for more information about how this is used.
+                                    type: string
+                                  operation:
+                                    description: Operation is what to do with the
+                                      existing value at Dest, whether to 'prepend',
+                                      'overwrite', or 'append' it.
+                                    type: string
+                                  src:
+                                    description: Src contains a source reference to
+                                      the value of the parameter from a dependency
+                                    properties:
+                                      contextKey:
+                                        description: ContextKey is the JSONPath of
+                                          the event's (JSON decoded) context key ContextKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      contextTemplate:
+                                        description: ContextTemplate is a go-template
+                                          for extracting a string from the event's
+                                          context. If a ContextTemplate is provided
+                                          with a ContextKey, the template will be
+                                          evaluated first and fallback to the ContextKey.
+                                          The templating follows the standard go-template
+                                          syntax as well as sprig's extra functions.
+                                          See https://pkg.go.dev/text/template and
+                                          https://masterminds.github.io/sprig/
+                                        type: string
+                                      dataKey:
+                                        description: DataKey is the JSONPath of the
+                                          event's (JSON decoded) data key DataKey
+                                          is a series of keys separated by a dot.
+                                          A key may contain wildcard characters '*'
+                                          and '?'. To access an array value use the
+                                          index as the key. The dot and wildcard characters
+                                          can be escaped with '\\'. See https://github.com/tidwall/gjson#path-syntax
+                                          for more information on how to use this.
+                                        type: string
+                                      dataTemplate:
+                                        description: DataTemplate is a go-template
+                                          for extracting a string from the event's
+                                          data. If a DataTemplate is provided with
+                                          a DataKey, the template will be evaluated
+                                          first and fallback to the DataKey. The templating
+                                          follows the standard go-template syntax
+                                          as well as sprig's extra functions. See
+                                          https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                                        type: string
+                                      dependencyName:
+                                        description: DependencyName refers to the
+                                          name of the dependency. The event which
+                                          is stored for this dependency is used as
+                                          payload for the parameterization. Make sure
+                                          to refer to one of the dependencies you
+                                          have defined under Dependencies list.
+                                        type: string
+                                      value:
+                                        description: Value is the default literal
+                                          value to use for this parameter source This
+                                          is only used if the DataKey is invalid.
+                                          If the DataKey is invalid and this is not
+                                          defined, this param source will produce
+                                          an error.
+                                        type: string
+                                    required:
+                                    - dependencyName
+                                    type: object
+                                required:
+                                - dest
+                                - src
+                                type: object
+                              type: array
+                            slackToken:
+                              description: SlackToken refers to the Kubernetes secret
+                                that holds the slack token required to send messages.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          required:
+                          - slackToken
+                          type: object
+                        switch:
+                          description: Switch is the condition to execute the trigger.
+                          properties:
+                            all:
+                              description: All acts as a AND operator between dependencies
+                              items:
+                                type: string
+                              type: array
+                            any:
+                              description: Any acts as a OR operator between dependencies
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - policy
+                  - template
+                  type: object
+                type: array
+            required:
+            - dependencies
+            - subscription
+            - template
+            - triggers
+            type: object
+          status:
+            description: SensorStatus contains information about the status of a sensor.
+            properties:
+              completedAt:
+                description: CompletedAt is the time at which this sensor was completed
+                format: date-time
+                type: string
+              lastCycleTime:
+                description: LastCycleTime is the time when last trigger cycle completed
+                format: date-time
+                type: string
+              message:
+                description: Message is a human readable string indicating details
+                  about a sensor in its phase
+                type: string
+              nodes:
+                additionalProperties:
+                  description: NodeStatus describes the status for an individual node
+                    in the sensor's FSM. A single node can represent the status for
+                    event or a trigger.
+                  properties:
+                    completedAt:
+                      description: CompletedAt is the time at which this node completed
+                      format: date-time
+                      type: string
+                    displayName:
+                      description: DisplayName is the human readable representation
+                        of the node
+                      type: string
+                    event:
+                      description: Event stores the last seen event for this node
+                      properties:
+                        context:
+                          description: EventContext holds the context of the cloudevent
+                            received from a gateway.
+                          properties:
+                            dataContentType:
+                              description: DataContentType - A MIME (RFC2046) string
+                                describing the media type of `data`.
+                              type: string
+                            id:
+                              description: ID of the event; must be non-empty and
+                                unique within the scope of the producer.
+                              type: string
+                            source:
+                              description: Source - A URI describing the event producer.
+                              type: string
+                            specversion:
+                              description: SpecVersion - The version of the CloudEvents
+                                specification used by the event.
+                              type: string
+                            subject:
+                              description: Subject - The subject of the event in the
+                                context of the event producer
+                              type: string
+                            time:
+                              description: Time - A Timestamp when the event happened.
+                              format: date-time
+                              type: string
+                            type:
+                              description: Type - The type of the occurrence which
+                                has happened.
+                              type: string
+                          required:
+                          - dataContentType
+                          - id
+                          - source
+                          - specversion
+                          - subject
+                          - time
+                          - type
+                          type: object
+                        data:
+                          format: byte
+                          type: string
+                      required:
+                      - context
+                      - data
+                      type: object
+                    id:
+                      description: ID is a unique identifier of a node within a sensor
+                        It is a hash of the node name
+                      type: string
+                    message:
+                      description: store data or something to save for event notifications
+                        or trigger events
+                      type: string
+                    name:
+                      description: Name is a unique name in the node tree used to
+                        generate the node ID
+                      type: string
+                    phase:
+                      description: Phase of the node
+                      type: string
+                    resolvedAt:
+                      description: ResolvedAt refers to the time at which the node
+                        was resolved.
+                      format: date-time
+                      type: string
+                    startedAt:
+                      description: StartedAt is the time at which this node started
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the type of the node
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt refers to the time at which the node
+                        was updated.
+                      format: date-time
+                      type: string
+                  required:
+                  - displayName
+                  - id
+                  - name
+                  - phase
+                  - type
+                  type: object
+                description: Nodes is a mapping between a node ID and the node's status
+                  it records the states for the FSM of this sensor.
+                type: object
+              phase:
+                description: Phase is the high-level summary of the sensor.
+                type: string
+              resources:
+                description: Resources refers to metadata of the resources created
+                  for the sensor
+                properties:
+                  deployment:
+                    description: Deployment holds the metadata of the deployment for
+                      the sensor
+                    type: object
+                  service:
+                    description: Service holds the metadata of the service for the
+                      sensor
+                    type: object
+                required:
+                - deployment
+                type: object
+              startedAt:
+                description: StartedAt is the time at which this sensor was initiated
+                format: date-time
+                type: string
+              triggerCycleCount:
+                description: TriggerCycleCount is the count of sensor's trigger cycle
+                  runs.
+                format: int32
+                type: integer
+              triggerCycleStatus:
+                description: TriggerCycleState is the status from last cycle of triggers
+                  execution.
+                type: string
+            required:
+            - lastCycleTime
+            - phase
+            - resources
+            - triggerCycleStatus
+            type: object
+        required:
+        - metadata
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
I've tried to implement OpenAPI spec for CRDs using [`controller-gen`](sigs.k8s.io/controller-tools/cmd/controller-gen), but it seems that the field validation is not fully/properly implemented. Not sure how else this problem can be approached. Feel free to dismiss this PR if you don't like this approach...

- Added new dependency (`controller-gen`)
- Added `hack/update-crd.sh` script

I'm getting these errors:

Sensor:
```
home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/common/s3.go:32:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:209:2: encountered struct field "Duration" without JSON tag in type "Backoff"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:214:2: encountered struct field "Factor" without JSON tag in type "Backoff"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:218:2: encountered struct field "Jitter" without JSON tag in type "Backoff"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:224:2: encountered struct field "Steps" without JSON tag in type "Backoff"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:229:2: encountered struct field "Cap" without JSON tag in type "Backoff"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:256:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:211:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:131:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:315:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:318:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:789:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:333:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:346:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:357:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:369:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:417:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:422:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:493:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:496:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:436:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:455:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:470:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:473:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:505:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:539:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:544:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:269:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:631:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:134:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:198:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1/types.go:145:2: ListType must be either "map", "set" or "atomic"
Error: not all generators ran successfully
run `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1 output:stdout -w` to see all available markers, or `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1 output:stdout -h` for usage
exit status 1
```

Gateway:
```
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1/types.go:83:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1/types.go:87:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1/types.go:72:2: must apply listType to an array
Error: not all generators ran successfully
run `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1 output:stdout -w` to see all available markers, or `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1 output:stdout -h` for usage
exit status 1
```
EventSource:
```
/home/tcoufal/.go/src/github.com/argoproj/argo-events/common/retry.go:29:11: unsupported type "float64"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/common/retry.go:30:11: unsupported type "float64"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/common/s3.go:32:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:110:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:342:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:408:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:456:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:503:2: ListType must be either "map", "set" or "atomic"
/home/tcoufal/.go/src/github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1/types.go:552:2: ListType must be either "map", "set" or "atomic"
Error: not all generators ran successfully
run `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1 output:stdout -w` to see all available markers, or `controller-gen crd:crdVersions=v1 paths=github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1 output:stdout -h` for usage
exit status 1
```

Help welcomed.