### PR TITLE
fix: Revert CRD apiVersion

### DIFF
--- a/manifests/base/crds/eventsources-crd.yaml
+++ b/manifests/base/crds/eventsources-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io

--- a/manifests/base/crds/gateway-crd.yaml
+++ b/manifests/base/crds/gateway-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.argoproj.io

--- a/manifests/base/crds/kustomization.yaml
+++ b/manifests/base/crds/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - event-source-crd.yaml
+  - eventsources-crd.yaml
   - gateway-crd.yaml
   - sensor-crd.yaml

--- a/manifests/base/crds/sensor-crd.yaml
+++ b/manifests/base/crds/sensor-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - cdrs
+  - crds
   - gateway-controller
   - sensor-controller
 

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.argoproj.io
@@ -30,7 +30,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventsources.argoproj.io
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.argoproj.io
@@ -30,7 +30,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: sensors.argoproj.io


### PR DESCRIPTION
I was a bit reckless when upgrading CRD from `v1beta1` to `v1` in #607. I did two mistakes:

1. Simple versions (`version`) are no longer available, only the long form `versions` is supported
2. A `schema` field is a required in `v1`. That means, even enforcing `v1` api with an empty spec like this:
    ```
    schema:
      openAPIV3Schema:
        type: object
    ```
    would require users to create every object with `--validate=false` flag for now, and I don't think that's what we want.

Let's revert back to `v1beta1`.

Also.. fixing a typo `s/cdrs/crds/g` and making `event-source` CRD name consistent with `pkg/apis/eventsources/`

I've tried implementing the OpenAPIV3Schema in another PR https://github.com/argoproj/argo-events/pull/624, but I'm not much successful with that so far... Let's discuss that option there. 