### PR TITLE
fix(controller): Make gateway and sensor controllers backward compatible

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -2649,5 +2649,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+on git commit <code>fb46335</code>.
 </em></p>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -5236,6 +5236,6 @@ ClientKeyPath refers the file path that contains client key.
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+commit <code>fb46335</code>. </em>
 
 </p>

--- a/api/gateway.html
+++ b/api/gateway.html
@@ -630,6 +630,24 @@ Kubernetes meta/v1.MicroTime
 <p>The list of ports that are exposed by this service.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicespec-v1-core">
+Kubernetes core/v1.ServiceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec holds the gateway service spec.
+DEPRECATED: Use Ports to declare the ports to be exposed.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="argoproj.io/v1alpha1.Subscribers">Subscribers
@@ -749,10 +767,28 @@ Kubernetes core/v1.PodSecurityContext
 Optional: Defaults to empty.  See type description for default values of each field.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podspec-v1-core">
+Kubernetes core/v1.PodSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec holds the gateway deployment spec.
+DEPRECATED: Use Container instead.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+on git commit <code>fb46335</code>.
 </em></p>

--- a/api/gateway.md
+++ b/api/gateway.md
@@ -1250,6 +1250,35 @@ The list of ports that are exposed by this service.
 
 </tr>
 
+<tr>
+
+<td>
+
+<code>spec</code></br> <em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicespec-v1-core">
+Kubernetes core/v1.ServiceSpec </a> </em>
+
+</td>
+
+<td>
+
+<p>
+
+Spec holds the gateway service spec. DEPRECATED: Use Ports to declare
+the ports to be exposed.
+
+</p>
+
+<br/> <br/>
+
+<table>
+
+</table>
+
+</td>
+
+</tr>
+
 </tbody>
 
 </table>
@@ -1491,6 +1520,35 @@ values of each field.
 
 </tr>
 
+<tr>
+
+<td>
+
+<code>spec</code></br> <em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podspec-v1-core">
+Kubernetes core/v1.PodSpec </a> </em>
+
+</td>
+
+<td>
+
+<p>
+
+Spec holds the gateway deployment spec. DEPRECATED: Use Container
+instead.
+
+</p>
+
+<br/> <br/>
+
+<table>
+
+</table>
+
+</td>
+
+</tr>
+
 </tbody>
 
 </table>
@@ -1500,6 +1558,6 @@ values of each field.
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+commit <code>fb46335</code>. </em>
 
 </p>

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -912,6 +912,10 @@
           "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "port",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "spec": {
+          "description": "Spec holds the gateway service spec. DEPRECATED: Use Ports to declare the ports to be exposed.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceSpec"
         }
       }
     },
@@ -951,6 +955,10 @@
         "serviceAccountName": {
           "description": "ServiceAccountName is the name of the ServiceAccount to use to run gateway pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
           "type": "string"
+        },
+        "spec": {
+          "description": "Spec holds the gateway deployment spec. DEPRECATED: Use Container instead.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
         },
         "volumes": {
           "description": "Volumes is a list of volumes that can be mounted by containers in a workflow.",
@@ -2089,6 +2097,10 @@
         "serviceAccountName": {
           "description": "ServiceAccountName is the name of the ServiceAccount to use to run gateway pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
           "type": "string"
+        },
+        "spec": {
+          "description": "Spec holds the sensor deployment spec. DEPRECATED: Use Container instead.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
         },
         "volumes": {
           "description": "Volumes is a list of volumes that can be mounted by containers in a workflow.",

--- a/api/sensor.html
+++ b/api/sensor.html
@@ -2855,6 +2855,24 @@ Kubernetes core/v1.PodSecurityContext
 Optional: Defaults to empty.  See type description for default values of each field.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podspec-v1-core">
+Kubernetes core/v1.PodSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec holds the sensor deployment spec.
+DEPRECATED: Use Container instead.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="argoproj.io/v1alpha1.TimeFilter">TimeFilter
@@ -3450,5 +3468,5 @@ bool
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+on git commit <code>fb46335</code>.
 </em></p>

--- a/api/sensor.md
+++ b/api/sensor.md
@@ -5665,6 +5665,35 @@ values of each field.
 
 </tr>
 
+<tr>
+
+<td>
+
+<code>spec</code></br> <em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podspec-v1-core">
+Kubernetes core/v1.PodSpec </a> </em>
+
+</td>
+
+<td>
+
+<p>
+
+Spec holds the sensor deployment spec. DEPRECATED: Use Container
+instead.
+
+</p>
+
+<br/> <br/>
+
+<table>
+
+</table>
+
+</td>
+
+</tr>
+
 </tbody>
 
 </table>
@@ -6855,6 +6884,6 @@ VerifyCert decides whether the connection is secure or not
 <p>
 
 <em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+commit <code>fb46335</code>. </em>
 
 </p>

--- a/pkg/apis/gateway/v1alpha1/openapi_generated.go
+++ b/pkg/apis/gateway/v1alpha1/openapi_generated.go
@@ -441,11 +441,17 @@ func schema_pkg_apis_gateway_v1alpha1_Service(ref common.ReferenceCallback) comm
 							},
 						},
 					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds the gateway service spec. DEPRECATED: Use Ports to declare the ports to be exposed.",
+							Ref:         ref("k8s.io/api/core/v1.ServiceSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ServicePort"},
+			"k8s.io/api/core/v1.ServicePort", "k8s.io/api/core/v1.ServiceSpec"},
 	}
 }
 
@@ -545,10 +551,16 @@ func schema_pkg_apis_gateway_v1alpha1_Template(ref common.ReferenceCallback) com
 							Ref:         ref("k8s.io/api/core/v1.PodSecurityContext"),
 						},
 					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds the gateway deployment spec. DEPRECATED: Use Container instead.",
+							Ref:         ref("k8s.io/api/core/v1.PodSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Volume"},
+			"k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.PodSpec", "k8s.io/api/core/v1.Volume"},
 	}
 }

--- a/pkg/apis/gateway/v1alpha1/types.go
+++ b/pkg/apis/gateway/v1alpha1/types.go
@@ -94,6 +94,9 @@ type Template struct {
 	// Optional: Defaults to empty.  See type description for default values of each field.
 	// +optional
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty" protobuf:"bytes,4,opt,name=securityContext"`
+	// Spec holds the gateway deployment spec.
+	// DEPRECATED: Use Container instead.
+	Spec *corev1.PodSpec `json:"spec,omitempty" protobuf:"bytes,5,opt,name=spec"`
 }
 
 // Service holds the service information gateway exposes
@@ -105,6 +108,9 @@ type Service struct {
 	// +listMapKey=port
 	// +listMapKey=protocol
 	Ports []corev1.ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
+	// Spec holds the gateway service spec.
+	// DEPRECATED: Use Ports to declare the ports to be exposed.
+	Spec *corev1.ServiceSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
 type Subscribers struct {

--- a/pkg/apis/gateway/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gateway/v1alpha1/zz_generated.deepcopy.go
@@ -232,6 +232,11 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = make([]corev1.ServicePort, len(*in))
 		copy(*out, *in)
 	}
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(corev1.ServiceSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -289,6 +294,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(corev1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(corev1.PodSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/apis/sensor/v1alpha1/openapi_generated.go
+++ b/pkg/apis/sensor/v1alpha1/openapi_generated.go
@@ -2034,11 +2034,17 @@ func schema_pkg_apis_sensor_v1alpha1_Template(ref common.ReferenceCallback) comm
 							Ref:         ref("k8s.io/api/core/v1.PodSecurityContext"),
 						},
 					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds the sensor deployment spec. DEPRECATED: Use Container instead.",
+							Ref:         ref("k8s.io/api/core/v1.PodSpec"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.Volume"},
+			"k8s.io/api/core/v1.Container", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.PodSpec", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -171,6 +171,9 @@ type Template struct {
 	// Optional: Defaults to empty.  See type description for default values of each field.
 	// +optional
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty" protobuf:"bytes,4,opt,name=securityContext"`
+	// Spec holds the sensor deployment spec.
+	// DEPRECATED: Use Container instead.
+	Spec *corev1.PodSpec `json:"spec,omitempty" protobuf:"bytes,5,opt,name=spec"`
 }
 
 // Subscription holds different modes of subscription available for sensor to consume events.

--- a/pkg/apis/sensor/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sensor/v1alpha1/zz_generated.deepcopy.go
@@ -1018,6 +1018,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(v1.PodSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
This PR makes both gateway and sensor controllers backward compatible with deprecated spec.

The old spec will be unsupported in few releases.