### PR TITLE
chore: Remove commit id from generated api-docs. Closes #614

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -2648,6 +2648,5 @@ string
 </table>
 <hr/>
 <p><em>
-Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+Generated with <code>gen-crd-api-reference-docs</code>.
 </em></p>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -5235,7 +5235,6 @@ ClientKeyPath refers the file path that contains client key.
 
 <p>
 
-<em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+<em> Generated with <code>gen-crd-api-reference-docs</code>. </em>
 
 </p>

--- a/api/gateway.html
+++ b/api/gateway.html
@@ -753,6 +753,5 @@ Optional: Defaults to empty.  See type description for default values of each fi
 </table>
 <hr/>
 <p><em>
-Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+Generated with <code>gen-crd-api-reference-docs</code>.
 </em></p>

--- a/api/gateway.md
+++ b/api/gateway.md
@@ -1499,7 +1499,6 @@ values of each field.
 
 <p>
 
-<em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+<em> Generated with <code>gen-crd-api-reference-docs</code>. </em>
 
 </p>

--- a/api/sensor.html
+++ b/api/sensor.html
@@ -3449,6 +3449,5 @@ bool
 </table>
 <hr/>
 <p><em>
-Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5172d79</code>.
+Generated with <code>gen-crd-api-reference-docs</code>.
 </em></p>

--- a/api/sensor.md
+++ b/api/sensor.md
@@ -6854,7 +6854,6 @@ VerifyCert decides whether the connection is secure or not
 
 <p>
 
-<em> Generated with <code>gen-crd-api-reference-docs</code> on git
-commit <code>5172d79</code>. </em>
+<em> Generated with <code>gen-crd-api-reference-docs</code>. </em>
 
 </p>

--- a/hack/api-docs-template/members.tpl
+++ b/hack/api-docs-template/members.tpl
@@ -1,0 +1,48 @@
+{{ define "members" }}
+
+{{ range .Members }}
+{{ if not (hiddenMember .)}}
+<tr>
+    <td>
+        <code>{{ fieldName . }}</code></br>
+        <em>
+            {{ if linkForType .Type }}
+                <a href="{{ linkForType .Type}}">
+                    {{ typeDisplayName .Type }}
+                </a>
+            {{ else }}
+                {{ typeDisplayName .Type }}
+            {{ end }}
+        </em>
+    </td>
+    <td>
+        {{ if fieldEmbedded . }}
+            <p>
+                (Members of <code>{{ fieldName . }}</code> are embedded into this type.)
+            </p>
+        {{ end}}
+
+        {{ if isOptionalMember .}}
+            <em>(Optional)</em>
+        {{ end }}
+
+        {{ safe (renderComments .CommentLines) }}
+
+    {{ if and (eq (.Type.Name.Name) "ObjectMeta") }}
+        Refer to the Kubernetes API documentation for the fields of the
+        <code>metadata</code> field.
+    {{ end }}
+
+    {{ if or (eq (fieldName .) "spec") }}
+        <br/>
+        <br/>
+        <table>
+            {{ template "members" .Type }}
+        </table>
+    {{ end }}
+    </td>
+</tr>
+{{ end }}
+{{ end }}
+
+{{ end }}

--- a/hack/api-docs-template/pkg.tpl
+++ b/hack/api-docs-template/pkg.tpl
@@ -1,0 +1,48 @@
+{{ define "packages" }}
+
+{{ with .packages}}
+<p>Packages:</p>
+<ul>
+    {{ range . }}
+    <li>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end}}
+
+{{ range .packages }}
+    <h2 id="{{- packageAnchorID . -}}">
+        {{- packageDisplayName . -}}
+    </h2>
+
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <p>
+            {{ safe (renderComments .) }}
+        </p>
+        {{ end }}
+    {{ end }}
+
+    Resource Types:
+    <ul>
+    {{- range (visibleTypes (sortedTypes .Types)) -}}
+        {{ if isExportedType . -}}
+        <li>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        </li>
+        {{- end }}
+    {{- end -}}
+    </ul>
+
+    {{ range (visibleTypes (sortedTypes .Types))}}
+        {{ template "type" .  }}
+    {{ end }}
+    <hr/>
+{{ end }}
+
+<p><em>
+    Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+
+{{ end }}

--- a/hack/api-docs-template/type.tpl
+++ b/hack/api-docs-template/type.tpl
@@ -1,0 +1,58 @@
+{{ define "type" }}
+
+<h3 id="{{ anchorIDForType . }}">
+    {{- .Name.Name }}
+    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
+</h3>
+{{ with (typeReferences .) }}
+    <p>
+        (<em>Appears on:</em>
+        {{- $prev := "" -}}
+        {{- range . -}}
+            {{- if $prev -}}, {{ end -}}
+            {{ $prev = . }}
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        {{- end -}}
+        )
+    </p>
+{{ end }}
+
+
+<p>
+    {{ safe (renderComments .CommentLines) }}
+</p>
+
+{{ if .Members }}
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ if isExportedType . }}
+        <tr>
+            <td>
+                <code>apiVersion</code></br>
+                string</td>
+            <td>
+                <code>
+                    {{apiGroup .}}
+                </code>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>kind</code></br>
+                string
+            </td>
+            <td><code>{{.Name.Name}}</code></td>
+        </tr>
+        {{ end }}
+        {{ template "members" .}}
+    </tbody>
+</table>
+{{ end }}
+
+{{ end }}

--- a/hack/update-api-docs.sh
+++ b/hack/update-api-docs.sh
@@ -11,21 +11,21 @@ ${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/gen-crd-api-reference
  -config "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/example-config.json" \
  -api-dir "github.com/argoproj/argo-events/pkg/apis/eventsources/v1alpha1" \
  -out-file "${GOPATH}/src/github.com/argoproj/argo-events/api/event-source.html" \
- -template-dir "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/template"
+ -template-dir "${GOPATH}/src/github.com/argoproj/argo-events/hack/api-docs-template"
 
 # Gateway
 ${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/gen-crd-api-reference-docs \
  -config "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/example-config.json" \
  -api-dir "github.com/argoproj/argo-events/pkg/apis/gateway/v1alpha1" \
  -out-file "${GOPATH}/src/github.com/argoproj/argo-events/api/gateway.html" \
- -template-dir "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/template"
+ -template-dir "${GOPATH}/src/github.com/argoproj/argo-events/hack/api-docs-template"
 
 # Sensor
 ${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/gen-crd-api-reference-docs \
  -config "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/example-config.json" \
  -api-dir "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1" \
  -out-file "${GOPATH}/src/github.com/argoproj/argo-events/api/sensor.html" \
- -template-dir "${GOPATH}/src/github.com/ahmetb/gen-crd-api-reference-docs/template"
+ -template-dir "${GOPATH}/src/github.com/argoproj/argo-events/hack/api-docs-template"
 
 # Setup at https://pandoc.org/installing.html
 


### PR DESCRIPTION
Anyone who runs `make codegen` or `make api-docs` will regenerate the api-docs with different commit id in it, this is quite annoying.

Use updated templates, to remove commit id part from it.

Closes #614 