### PR TITLE
fix: gateway and sensor resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow these [instruction](https://argoproj.github.io/argo-events/installation/)
 [![asciicast](https://asciinema.org/a/AKkYwzEakSUsLqH8mMORA4kza.png)](https://asciinema.org/a/AKkYwzEakSUsLqH8mMORA4kza)
 
 ## Documentation
-- [Concepts](https://argoproj.github.io/argo-events/concepts/high_level_architecture/).
+- [Concepts](https://argoproj.github.io/argo-events/concepts/architecture/).
 - [Argo Events in action](https://argoproj.github.io/argo-events/quick_start/).
 - [Deploy gateways and sensors](https://argoproj.github.io/argo-events/setup/webhook/).
 - [Deep dive into Argo Events](https://argoproj.github.io/argo-events/tutorials/01-introduction/).  

--- a/controllers/gateway/informer.go
+++ b/controllers/gateway/informer.go
@@ -27,13 +27,18 @@ import (
 func (c *Controller) instanceIDReq() (*labels.Requirement, error) {
 	var instanceIDReq *labels.Requirement
 	var err error
+	var values []string
+
+	op := selection.DoesNotExist
+
 	if c.Config.InstanceID != "" {
-		instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, selection.Equals, []string{c.Config.InstanceID})
-	} else {
-		instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, selection.DoesNotExist, nil)
+		op = selection.Equals
+		values = []string{c.Config.InstanceID}
 	}
+
+	instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, op, values)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	c.logger.WithField("instance-id", instanceIDReq.String()).Infoln("instance id requirement")
 	return instanceIDReq, nil

--- a/controllers/gateway/resource.go
+++ b/controllers/gateway/resource.go
@@ -51,7 +51,7 @@ func (ctx *gatewayContext) buildServiceResource() (*corev1.Service, error) {
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-gateway-svc", ctx.gateway.Name),
+			Name: fmt.Sprintf("%s-svc", ctx.gateway.Name),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:    ctx.gateway.Spec.Service.Ports,
@@ -73,7 +73,7 @@ func (ctx *gatewayContext) buildLegacyServiceResource() (*corev1.Service, error)
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-gateway-svc", ctx.gateway.Name),
+			Name: fmt.Sprintf("%s-svc", ctx.gateway.Name),
 		},
 		Spec: *ctx.gateway.Spec.Service.Spec,
 	}
@@ -112,7 +112,9 @@ func (ctx *gatewayContext) makeDeploymentSpec() (*appv1.DeploymentSpec, error) {
 	}
 
 	if ctx.gateway.Spec.Template.Container != nil {
-		mergo.Merge(&eventContainer, ctx.gateway.Spec.Template.Container, mergo.WithOverride)
+		if err := mergo.Merge(&eventContainer, ctx.gateway.Spec.Template.Container, mergo.WithOverride); err != nil {
+			return nil, err
+		}
 	}
 
 	return &appv1.DeploymentSpec{
@@ -185,7 +187,7 @@ func (ctx *gatewayContext) buildDeploymentResource() (*appv1.Deployment, error) 
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    ctx.gateway.Namespace,
-			GenerateName: fmt.Sprintf("%s-gateway-%s-", ctx.gateway.Spec.Type, ctx.gateway.Name),
+			GenerateName: fmt.Sprintf("%s-", ctx.gateway.Name),
 			Labels:       deploymentSpec.Template.Labels,
 		},
 		Spec: *deploymentSpec,

--- a/controllers/gateway/resource.go
+++ b/controllers/gateway/resource.go
@@ -51,7 +51,7 @@ func (ctx *gatewayContext) buildServiceResource() (*corev1.Service, error) {
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-svc", ctx.gateway.Name),
+			Name: fmt.Sprintf("%s-gateway-svc", ctx.gateway.Name),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:    ctx.gateway.Spec.Service.Ports,
@@ -73,7 +73,7 @@ func (ctx *gatewayContext) buildLegacyServiceResource() (*corev1.Service, error)
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-svc", ctx.gateway.Name),
+			Name: fmt.Sprintf("%s-gateway-svc", ctx.gateway.Name),
 		},
 		Spec: *ctx.gateway.Spec.Service.Spec,
 	}
@@ -187,7 +187,7 @@ func (ctx *gatewayContext) buildDeploymentResource() (*appv1.Deployment, error) 
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    ctx.gateway.Namespace,
-			GenerateName: fmt.Sprintf("%s-", ctx.gateway.Name),
+			GenerateName: fmt.Sprintf("%s-gateway-", ctx.gateway.Name),
 			Labels:       deploymentSpec.Template.Labels,
 		},
 		Spec: *deploymentSpec,

--- a/controllers/gateway/resource_test.go
+++ b/controllers/gateway/resource_test.go
@@ -97,7 +97,7 @@ func TestResource_BuildServiceResource(t *testing.T) {
 		service, err := opCtx.buildServiceResource()
 		assert.Nil(t, err)
 		assert.NotNil(t, service)
-		assert.Equal(t, service.Name, gatewayObj.Name+"-svc")
+		assert.Equal(t, service.Name, gatewayObj.Name+"-gateway-svc")
 		assert.Equal(t, service.Namespace, opCtx.gateway.Namespace)
 
 		newSvc, err := controller.k8sClient.CoreV1().Services(service.Namespace).Create(service)

--- a/controllers/gateway/resource_test.go
+++ b/controllers/gateway/resource_test.go
@@ -97,7 +97,7 @@ func TestResource_BuildServiceResource(t *testing.T) {
 		service, err := opCtx.buildServiceResource()
 		assert.Nil(t, err)
 		assert.NotNil(t, service)
-		assert.Equal(t, service.Name, gatewayObj.Name+"-gateway-svc")
+		assert.Equal(t, service.Name, gatewayObj.Name+"-svc")
 		assert.Equal(t, service.Namespace, opCtx.gateway.Namespace)
 
 		newSvc, err := controller.k8sClient.CoreV1().Services(service.Namespace).Create(service)

--- a/controllers/sensor/informer.go
+++ b/controllers/sensor/informer.go
@@ -27,14 +27,20 @@ import (
 func (controller *Controller) instanceIDReq() (*labels.Requirement, error) {
 	var instanceIDReq *labels.Requirement
 	var err error
-	if controller.Config.InstanceID == "" {
-		instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, selection.DoesNotExist, nil)
-	} else {
-		instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, selection.Equals, []string{controller.Config.InstanceID})
+	var values []string
+
+	op := selection.DoesNotExist
+
+	if controller.Config.InstanceID != "" {
+		op = selection.Equals
+		values = []string{controller.Config.InstanceID}
 	}
+
+	instanceIDReq, err = labels.NewRequirement(LabelControllerInstanceID, op, values)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
+	controller.logger.WithField("instance-id", instanceIDReq.String()).Infoln("instance id requirement")
 	return instanceIDReq, nil
 }
 

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -41,7 +41,7 @@ func (ctx *sensorContext) generateServiceSpec() *corev1.Service {
 
 	serviceSpec := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-svc", ctx.sensor.Name),
+			Name:        fmt.Sprintf("%s-sensor-svc", ctx.sensor.Name),
 			Labels:      ctx.sensor.Spec.ServiceLabels,
 			Annotations: ctx.sensor.Spec.ServiceAnnotations,
 		},
@@ -150,7 +150,7 @@ func (ctx *sensorContext) deploymentBuilder() (*appv1.Deployment, error) {
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    ctx.sensor.Namespace,
-			GenerateName: fmt.Sprintf("%s-", ctx.sensor.Name),
+			GenerateName: fmt.Sprintf("%s-sensor-", ctx.sensor.Name),
 			Labels:       deploymentSpec.Template.Labels,
 		},
 		Spec: *deploymentSpec,


### PR DESCRIPTION
The latest changes to gateway and sensor controller construct the deployment name as `<gateway-name>-<gateway-type>-gateway-<random-char>`, e.b. webhook-gateway-webhook-gateway-12345 which is not correct naming. We should not add `<gateway-type>-gateway` to the deployment or service name. Let the user decide what they want to call their gateway and sensor.  