### PR TITLE
feat: Support for using a live K8s resource in standard K8s triggers

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2034,6 +2034,10 @@
         "source"
       ],
       "properties": {
+        "liveObject": {
+          "description": "LiveObject specifies whether the resource should be directly fetched from K8s instead of being marshaled from the resource artifact. If set to true, the resource artifact must contain the information required to uniquely identify the resource in the cluster, that is, you must specify \"apiVersion\", \"kind\" as well as \"name\" and \"namespace\" meta data. Only valid for operation type `update`",
+          "type": "boolean"
+        },
         "operation": {
           "description": "Operation refers to the type of operation performed on the k8s resource. Default value is Create.",
           "type": "string"

--- a/api/sensor.html
+++ b/api/sensor.html
@@ -2678,6 +2678,23 @@ possible values:
 Defaults to &ldquo;application/merge-patch+json&rdquo;</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>liveObject</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LiveObject specifies whether the resource should be directly fetched from K8s instead
+of being marshaled from the resource artifact. If set to true, the resource artifact
+must contain the information required to uniquely identify the resource in the cluster,
+that is, you must specify &ldquo;apiVersion&rdquo;, &ldquo;kind&rdquo; as well as &ldquo;name&rdquo; and &ldquo;namespace&rdquo; meta
+data.
+Only valid for operation type <code>update</code></p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="argoproj.io/v1alpha1.StatusPolicy">StatusPolicy

--- a/api/sensor.md
+++ b/api/sensor.md
@@ -5278,6 +5278,33 @@ operation is specified as patch. possible values:
 
 </tr>
 
+<tr>
+
+<td>
+
+<code>liveObject</code></br> <em> bool </em>
+
+</td>
+
+<td>
+
+<em>(Optional)</em>
+
+<p>
+
+LiveObject specifies whether the resource should be directly fetched
+from K8s instead of being marshaled from the resource artifact. If set
+to true, the resource artifact must contain the information required to
+uniquely identify the resource in the cluster, that is, you must specify
+“apiVersion”, “kind” as well as “name” and “namespace” meta data. Only
+valid for operation type <code>update</code>
+
+</p>
+
+</td>
+
+</tr>
+
 </tbody>
 
 </table>

--- a/pkg/apis/sensor/v1alpha1/openapi_generated.go
+++ b/pkg/apis/sensor/v1alpha1/openapi_generated.go
@@ -1914,6 +1914,13 @@ func schema_pkg_apis_sensor_v1alpha1_StandardK8sTrigger(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"liveObject": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LiveObject specifies whether the resource should be directly fetched from K8s instead of being marshaled from the resource artifact. If set to true, the resource artifact must contain the information required to uniquely identify the resource in the cluster, that is, you must specify \"apiVersion\", \"kind\" as well as \"name\" and \"namespace\" meta data. Only valid for operation type `update`",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"source"},
 			},

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -366,6 +366,14 @@ type StandardK8sTrigger struct {
 	// Defaults to "application/merge-patch+json"
 	// +optional
 	PatchStrategy k8stypes.PatchType `json:"patchStrategy,omitempty" protobuf:"bytes,5,opt,name=patchStrategy"`
+	// LiveObject specifies whether the resource should be directly fetched from K8s instead
+	// of being marshaled from the resource artifact. If set to true, the resource artifact
+	// must contain the information required to uniquely identify the resource in the cluster,
+	// that is, you must specify "apiVersion", "kind" as well as "name" and "namespace" meta
+	// data.
+	// Only valid for operation type `update`
+	// +optional
+	LiveObject bool `json:"liveObject,omitempty" protobuf:"bytes,6,opt,name=liveObject"`
 }
 
 // ArgoWorkflowTrigger is the trigger for the Argo Workflow

--- a/sensors/triggers/standard-k8s/starndard-k8s.go
+++ b/sensors/triggers/standard-k8s/starndard-k8s.go
@@ -145,6 +145,15 @@ func (k8sTrigger *StandardK8sTrigger) Execute(resource interface{}) (interface{}
 		op = trigger.Template.K8s.Operation
 	}
 
+	// We might have a client from FetchResource() already, or we might not have one yet.
+	if k8sTrigger.namespableDynamicClient == nil {
+		k8sTrigger.namespableDynamicClient = k8sTrigger.DynamicClient.Resource(schema.GroupVersionResource{
+			Group:    trigger.Template.K8s.GroupVersionResource.Group,
+			Version:  trigger.Template.K8s.GroupVersionResource.Version,
+			Resource: trigger.Template.K8s.GroupVersionResource.Resource,
+		})
+	}
+
 	switch op {
 	case v1alpha1.Create:
 		k8sTrigger.Logger.Infoln("creating the object...")


### PR DESCRIPTION
This change enables the standard K8s trigger to use a live resource from the K8s cluster as artefact, instead of using the definition of `source`. 

A new option `liveObject` (of type `bool`) is introduced on the trigger template, and if set to true, the specified artefact is used to uniquely identify the resource to fetch from the cluster

```yaml
  triggers:
    - template:
        name: webhook-pod-trigger
        k8s:
          group: apps
          version: v1
          resource: deployments
          operation: update
          liveObject: true
          source:
            resource:
              apiVersion: apps/v1
              kind: Deployment
              metadata:
                name: web-deployment
                namespace: web
          parameters:
            - src:
                dependencyName: test-dep
                contextKey: time
              dest: spec.template.metadata.annotations.events\.argoproj\.io/restartedAt
```
This will fetch the resource of type `deployment` in  `apps/v1` with the name `web-deployment` in namespace `web` from the cluster and then update (or set) the annotation specified in `dest`.

I was initially thinking about implementing it as dedicated artefact store, but since it's really only valuable for the standard K8s trigger, chose to implement it within the trigger.