### PR TITLE
fix: wrong name of Sensor

### DIFF
--- a/docs/triggers/k8s-object-trigger.md
+++ b/docs/triggers/k8s-object-trigger.md
@@ -30,7 +30,7 @@ set up event-driven pipelines for existing workloads.
         apiVersion: argoproj.io/v1alpha1
         kind: Sensor
         metadata:
-          name: webhook-sensor
+          name: webhook
         spec:
           template:
             serviceAccountName: argo-events-sa


### PR DESCRIPTION
if the name of Sensor is "webhook-sensor", the gate-way client cannot send request to the desired sensor, so the name should be changed into "webhook".

---
```
apiVersion: argoproj.io/v1alpha1
kind: Gateway
metadata:
  name: webhook
spec:
  replica: 1
  type: webhook
  eventSourceRef:
    name: webhook-event-source
  template:
    serviceAccountName: argo-events-sa
  service:
    ports:
      - port: 12000
        targetPort: 12000
  subscribers:
    http:
      - "http://webhook-sensor.argo-events.svc:9300/"
```
The above code is for the `Gateway` which is introduced at [triggers/k8s-object-trigger page](https://argoproj.github.io/argo-events/triggers/k8s-object-trigger/)

That says the endpoint of subscriber is "http://webhook-sensor.argo-events.svc:9300/". That means the name of a `Sensor` should be `webhook` not `webhook-sensor`.


But at the body(which is saying "To trigger a pod, we need to create a sensor as defined below,.... blah blah ... "), the code is saying the name of a `Sensor` is `webhook-sensor`

if we set the name of the `Sensor` as `webhook-sensor`, the endpoint of subscriber would be `"http://webhook-sensor-sensor.argo-events.svc:9300/"`.

With the following code, we can guess the name of the `Sensor`is wrong.
```
$ kubectl describe webhook-sensor
...
Self Link:               /api/v1/namespaces/argo-events/services/webhook-sensor-sensor
...
```

So I fixed the name of `Sensor` at the body, from webhook-sensor to webhook.

Please take a look at this . Thank you.