### PR TITLE
docs: Fix link to Concepts in index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Follow these [instruction](https://argoproj.github.io/argo-events/installation/)
 
 ## Documentation
 
-- [Concepts](https://argoproj.github.io/argo-events/concepts/high_level_architecture/).
+- [Concepts](https://argoproj.github.io/argo-events/concepts/architecture/).
 - [Argo Events in action](https://argoproj.github.io/argo-events/quick_start/).
 - [Deploy gateways and sensors](https://argoproj.github.io/argo-events/setup/webhook/).
 - [Deep dive into Argo Events](https://argoproj.github.io/argo-events/tutorials/01-introduction/).  


### PR DESCRIPTION
:wave: noticed that the `Concepts` link in the index page linked to the wrong doc. Looks like it was renamed in 0220b694449d8ebd5cfc968216087361a3a92ff9. Thanks!