### PR TITLE
fix(documentation): use secret key referred in eventsource

### DIFF
--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -51,7 +51,7 @@ The structure of an event dispatched by the gateway to the sensor looks like fol
           name: github-access
         type: Opaque
         data:
-          access: <base64-encoded-api-token-from-previous-step>
+          token: <base64-encoded-api-token-from-previous-step>
 
 4. Deploy the secret into K8s cluster
 


### PR DESCRIPTION
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: github-access
type: Opaque
data:
  access: <base64-encoded-api-token-from-previous-step>
```

[vs.](https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/github.yaml)

```yaml
...
      # apiToken refers to K8s secret that stores the github api token
      apiToken:
        # Name of the K8s secret that contains the access token
        name: github-access
        # Key within the K8s secret whose corresponding value (must be base64 encoded) is access token
        key: token
...
```