### PR TITLE
feat: Use json log formatter if stdout isnt tty

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -19,6 +19,7 @@ package common
 import (
 	"os"
 
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 )
 
@@ -35,19 +36,31 @@ const (
 	LabelHTTPMethod  = "http-method"
 	LabelVersion     = "version"
 	LabelTime        = "time"
+	TimestampFormat  = "2006-01-02 15:04:05"
 )
 
 // NewArgoEventsLogger returns a new ArgoEventsLogger
 func NewArgoEventsLogger() *logrus.Logger {
-	log := &logrus.Logger{
-		Out:   os.Stdout,
-		Level: logrus.InfoLevel,
-		Formatter: &logrus.TextFormatter{
-			TimestampFormat:  "2006-01-02 15:04:05",
+	var formatter logrus.Formatter
+
+	// If out is term use textformatter
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		formatter = &logrus.TextFormatter{
+			TimestampFormat:  TimestampFormat,
 			FullTimestamp:    true,
 			ForceColors:      true,
 			QuoteEmptyFields: true,
-		},
+		}
+	} else {
+		formatter = &logrus.JSONFormatter{
+			TimestampFormat: TimestampFormat,
+		}
+	}
+
+	log := &logrus.Logger{
+		Out:       os.Stdout,
+		Level:     logrus.InfoLevel,
+		Formatter: formatter,
 	}
 
 	debugMode, ok := os.LookupEnv(EnvVarDebugLog)

--- a/controllers/sensor/config.go
+++ b/controllers/sensor/config.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/argoproj/argo-events/common"
 	"github.com/ghodss/yaml"
-	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -32,7 +31,7 @@ import (
 
 // watchControllerConfigMap watches updates to sensor controller configmap
 func (controller *Controller) watchControllerConfigMap() cache.Controller {
-	log.Info("watching controller config map updates")
+	controller.logger.Info("watching controller config map updates")
 	source := controller.newControllerConfigMapWatch()
 	_, ctrl := cache.NewInformer(
 		source,
@@ -41,19 +40,19 @@ func (controller *Controller) watchControllerConfigMap() cache.Controller {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				if cm, ok := obj.(*corev1.ConfigMap); ok {
-					log.Info("detected configuration update. updating the controller configuration")
+					controller.logger.Info("detected configuration update. updating the controller configuration")
 					err := controller.updateConfig(cm)
 					if err != nil {
-						log.Errorf("update of controller configuration failed due to: %v", err)
+						controller.logger.Errorf("update of controller configuration failed due to: %v", err)
 					}
 				}
 			},
 			UpdateFunc: func(old, new interface{}) {
 				if newCm, ok := new.(*corev1.ConfigMap); ok {
-					log.Info("detected configuration update. updating the controller configuration")
+					controller.logger.Info("detected configuration update. updating the controller configuration")
 					err := controller.updateConfig(newCm)
 					if err != nil {
-						log.Errorf("update of controller configuration failed due to: %v", err)
+						controller.logger.Errorf("update of controller configuration failed due to: %v", err)
 					}
 				}
 			},

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12
 	github.com/minio/minio-go v1.0.1-0.20190523192347-c6c2912aa552
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.0


### PR DESCRIPTION
Closes #630 

Uses json log formatter if stdout is not a tty. This will make it a lot easier to view logs in a log ingestor. It should be noted that this mr will change the default log formatter to JSON. This is because a tty is not allocated when executing any of the binaries. Should there be a way to force the log format to text?