### PR TITLE
build: added clusterworkflowtemplate to argo-events rbac manifests, upgraded argo version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/apache/openwhisk-client-go v0.0.0-20190915054138-716c6f973eb2
-	github.com/argoproj/argo v2.5.2+incompatible
+	github.com/argoproj/argo v2.8.2
 	github.com/argoproj/argo-cd v1.5.1
 	github.com/argoproj/argo-rollouts v0.7.2
 	github.com/argoproj/pkg v0.0.0-20200319004004-f46beff7cd54 // indirect

--- a/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
+++ b/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
@@ -42,6 +42,15 @@ rules:
       - eventbus
       - eventbus/finalizers
   - apiGroups:
+      - argoproj.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - clusterworkflowtemplates
+      - clusterworkflowtemplates/finalizers
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -207,6 +207,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -114,6 +114,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  - clusterworkflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/manifests/namespace-install/rbac/argo-events-role.yaml
+++ b/manifests/namespace-install/rbac/argo-events-role.yaml
@@ -28,6 +28,15 @@ rules:
       - eventbus
       - eventbus/finalizers
   - apiGroups:
+      - argoproj.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - clusterworkflowtemplates
+      - clusterworkflowtemplates/finalizers
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/sensors/cmd/Dockerfile
+++ b/sensors/cmd/Dockerfile
@@ -1,13 +1,20 @@
 FROM centos:7
+
+ARG ARGO_VERSION=v2.8.2
+
 RUN yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl git
 
 # OpenFass CLI
 COPY assets/faas-cli /usr/local/bin/faas
 
 # Argo Workflow CLI
-COPY assets/argo-linux-amd64 /usr/local/bin/argo
+RUN curl -sSL -o /usr/local/bin/argo \
+    https://github.com/argoproj/argo/releases/download/${ARGO_VERSION}/argo-linux-amd64 \
+ && chmod +x /usr/local/bin/argo
 
-RUN argo version
+# added `|| true` to ignore "invalid configuration: no configuration has been provided"
+# TODO: argo version shouldn't rely on a cluster connection to execute
+RUN argo version || true
 RUN faas version
 
 RUN mkdir /.openfaas

--- a/sensors/cmd/Dockerfile
+++ b/sensors/cmd/Dockerfile
@@ -5,6 +5,7 @@ ARG ARGO_VERSION=v2.8.2
 RUN yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl git
 
 # OpenFass CLI
+# TODO: donwload faas instead of copying it from the svc, same as with argo-cli
 COPY assets/faas-cli /usr/local/bin/faas
 
 # Argo Workflow CLI


### PR DESCRIPTION
currently argo-events don't have any permissions over `clusterworkflowtemplates`, i assume due to the feature being relatively new

this won't do it by itself, we also need to upgrade the argo cli version argo-events is using to a version which supports `clusterworkflowtemplates`