### PR TITLE
chore: modify credentialsFile to be in sync with gateway

### DIFF
--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -16,7 +16,7 @@ spec:
       # topic name
       topic: test
       # Refers to path of the credential file that is mounted in the gateway pod.
-      credentialsFile: /creds/key.json
+      credentialsFile: /gcp-pubsub-creds-dir/key.json
 
 #    example-workload-identity:
 #      # jsonBody specifies that all event body payload coming from this


### PR DESCRIPTION
The example specified in gateway : https://github.com/argoproj/argo-events/blob/master/examples/gateways/gcp-pubsub.yaml has the secret mounted in /gcp-pubsub-creds-dir. Hence modifying the credentialsFile property to match it accordingly.