### PR TITLE
fix: Sensor Dockerfile is based on Ubuntu 7 which has a few vulnerabilities

### DIFF
--- a/sensors/cmd/Dockerfile
+++ b/sensors/cmd/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
-RUN yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl git
+FROM centos:8
+RUN yum -y update && yum -y install ca-certificates openssh openssh-server openssh-clients openssl-libs curl git
 
 # OpenFass CLI
 COPY assets/faas-cli /usr/local/bin/faas


### PR DESCRIPTION
Opening a PR to bump the version of Sensor docker image and also add a `yum update` to allow patching of the vulnerabilities present in a few of the installed packages. Bellow is a [trivy](https://github.com/aquasecurity/trivy) report executed against the latest sensor image from DockerHub: (all other argo images are vulnerability free as they're not based on Ubuntu)

`trivy --exit-code 0 --severity CRITICAL,HIGH,MEDIUM --ignore-unfixed argoproj/sensor:v0.16.0`

```2020-07-08T15:36:15.139+0200    INFO    Detecting RHEL/CentOS vulnerabilities...
argoproj/sensor:v0.16.0 (centos 7.6.1810)
=========================================
Total: 84 (UNKNOWN: 0, LOW: 0, MEDIUM: 53, HIGH: 31, CRITICAL: 0)

+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
|      LIBRARY       | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |      FIXED VERSION      |                  TITLE                  |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| bash               | CVE-2019-9924    | MEDIUM   | 4.2.46-31.el7     | 4.2.46-34.el7           | bash: BASH_CMD is writable in           |
|                    |                  |          |                   |                         | restricted bash shells                  |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| bind-license       | CVE-2018-5743    | HIGH     | 32:9.9.4-72.el7   | 32:9.9.4-74.el7_6.1     | bind: Limiting simultaneous             |
|                    |                  |          |                   |                         | TCP clients is ineffective              |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2020-8616    |          |                   | 32:9.11.4-16.P2.el7_8.6 | bind: BIND does not                     |
|                    |                  |          |                   |                         | sufficiently limit the number           |
|                    |                  |          |                   |                         | of fetches performed when...            |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2020-8617    |          |                   |                         | bind: A logic error in code             |
|                    |                  |          |                   |                         | which checks TSIG validity can          |
|                    |                  |          |                   |                         | be...                                   |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-5741    | MEDIUM   |                   | 32:9.11.4-9.P2.el7      | bind: Incorrect documentation           |
|                    |                  |          |                   |                         | of krb5-subdomain and                   |
|                    |                  |          |                   |                         | ms-subdomain update policies            |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-5742    |          |                   | 32:9.9.4-73.el7_6       | bind: Crash from assertion              |
|                    |                  |          |                   |                         | error when debug log level is           |
|                    |                  |          |                   |                         | 10 and...                               |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-6477    |          |                   | 32:9.11.4-16.P2.el7     | bind: TCP Pipelining doesn't            |
|                    |                  |          |                   |                         | limit TCP clients on a single           |
|                    |                  |          |                   |                         | connection                              |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| binutils           | CVE-2018-1000876 |          | 2.27-34.base.el7  | 2.27-41.base.el7        | binutils: integer overflow              |
|                    |                  |          |                   |                         | leads to heap-based buffer              |
|                    |                  |          |                   |                         | overflow in objdump                     |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| expat              | CVE-2015-2716    |          | 2.1.0-10.el7_3    | 2.1.0-11.el7            | expat: Integer overflow                 |
|                    |                  |          |                   |                         | leading to buffer overflow in           |
|                    |                  |          |                   |                         | XML_GetBuffer()                         |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| git                | CVE-2020-11008   | HIGH     | 1.8.3.1-21.el7_7  | 1.8.3.1-23.el7_8        | git: Crafted URL containing             |
|                    |                  |          |                   |                         | new lines, empty host or lacks          |
|                    |                  |          |                   |                         | a scheme...                             |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2020-5260    |          |                   | 1.8.3.1-22.el7_8        | git: Crafted URL containing             |
|                    |                  |          |                   |                         | new lines can cause credential          |
|                    |                  |          |                   |                         | leak                                    |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| glibc              | CVE-2016-10739   | MEDIUM   | 2.17-260.el7      | 2.17-292.el7            | glibc: getaddrinfo should               |
|                    |                  |          |                   |                         | reject IP addresses with                |
|                    |                  |          |                   |                         | trailing characters                     |
+--------------------+                  +          +                   +                         +                                         +
| glibc-common       |                  |          |                   |                         |                                         |
|                    |                  |          |                   |                         |                                         |
|                    |                  |          |                   |                         |                                         |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| krb5-libs          | CVE-2018-20217   |          | 1.15.1-34.el7     | 1.15.1-37.el7_7.2       | krb5: Reachable assertion               |
|                    |                  |          |                   |                         | in the KDC using S4U2Self               |
|                    |                  |          |                   |                         | requests                                |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| libxml2            | CVE-2016-5131    | HIGH     | 2.9.1-6.el7_2.3   | 2.9.1-6.el7.4           | libxml2: Use after free                 |
|                    |                  |          |                   |                         | triggered by XPointer paths             |
|                    |                  |          |                   |                         | beginning with range-to                 |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2017-15412   |          |                   |                         | libxml2: Use after free in              |
|                    |                  |          |                   |                         | xmlXPathCompOpEvalPositionalPredicate() |
|                    |                  |          |                   |                         | function in xpath.c                     |
+                    +------------------+----------+                   +                         +-----------------------------------------+
|                    | CVE-2015-8035    | MEDIUM   |                   |                         | libxml2: DoS caused by                  |
|                    |                  |          |                   |                         | incorrect error detection               |
|                    |                  |          |                   |                         | during XZ decompression                 |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-14404   |          |                   |                         | libxml2: NULL pointer                   |
|                    |                  |          |                   |                         | dereference in                          |
|                    |                  |          |                   |                         | xmlXPathCompOpEval() function           |
|                    |                  |          |                   |                         | in xpath.c                              |
+--------------------+------------------+----------+                   +                         +-----------------------------------------+
| libxml2-python     | CVE-2016-5131    | HIGH     |                   |                         | libxml2: Use after free                 |
|                    |                  |          |                   |                         | triggered by XPointer paths             |
|                    |                  |          |                   |                         | beginning with range-to                 |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2017-15412   |          |                   |                         | libxml2: Use after free in              |
|                    |                  |          |                   |                         | xmlXPathCompOpEvalPositionalPredicate() |
|                    |                  |          |                   |                         | function in xpath.c                     |
+                    +------------------+----------+                   +                         +-----------------------------------------+
|                    | CVE-2015-8035    | MEDIUM   |                   |                         | libxml2: DoS caused by                  |
|                    |                  |          |                   |                         | incorrect error detection               |
|                    |                  |          |                   |                         | during XZ decompression                 |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-14404   |          |                   |                         | libxml2: NULL pointer                   |
|                    |                  |          |                   |                         | dereference in                          |
|                    |                  |          |                   |                         | xmlXPathCompOpEval() function           |
|                    |                  |          |                   |                         | in xpath.c                              |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| nspr               | CVE-2018-0495    |          | 4.19.0-1.el7_5    | 4.21.0-1.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| nss                | CVE-2019-11745   | HIGH     | 3.36.0-7.el7_5    | 3.44.0-7.el7_7          | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-4.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-7.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| nss-softokn        | CVE-2019-11745   | HIGH     | 3.36.0-5.el7_5    | 3.44.0-8.el7_7          | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-5.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-8.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+                   +                         +-----------------------------------------+
| nss-softokn-freebl | CVE-2019-11745   | HIGH     |                   |                         | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-5.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-8.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| nss-sysinit        | CVE-2019-11745   | HIGH     | 3.36.0-7.el7_5    | 3.44.0-7.el7_7          | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-4.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-7.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+                   +                         +-----------------------------------------+
| nss-tools          | CVE-2019-11745   | HIGH     |                   |                         | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-4.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-7.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| nss-util           | CVE-2019-11745   | HIGH     | 3.36.0-1.el7_5    | 3.44.0-4.el7_7          | nss: Out-of-bounds write                |
|                    |                  |          |                   |                         | when passing an output buffer           |
|                    |                  |          |                   |                         | smaller than the block...               |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-0495    | MEDIUM   |                   | 3.44.0-3.el7            | ROHNP: Key Extraction Side              |
|                    |                  |          |                   |                         | Channel in Multiple Crypto              |
|                    |                  |          |                   |                         | Libraries                               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-12404   |          |                   |                         | nss: Cache side-channel                 |
|                    |                  |          |                   |                         | variant of the Bleichenbacher           |
|                    |                  |          |                   |                         | attack                                  |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-11729   |          |                   | 3.44.0-4.el7_7          | nss: Empty or malformed                 |
|                    |                  |          |                   |                         | p256-ECDH public keys may               |
|                    |                  |          |                   |                         | trigger a segmentation                  |
|                    |                  |          |                   |                         | fault...                                |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| perl-Git           | CVE-2020-11008   | HIGH     | 1.8.3.1-21.el7_7  | 1.8.3.1-23.el7_8        | git: Crafted URL containing             |
|                    |                  |          |                   |                         | new lines, empty host or lacks          |
|                    |                  |          |                   |                         | a scheme...                             |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2020-5260    |          |                   | 1.8.3.1-22.el7_8        | git: Crafted URL containing             |
|                    |                  |          |                   |                         | new lines can cause credential          |
|                    |                  |          |                   |                         | leak                                    |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| procps-ng          | CVE-2018-1122    | MEDIUM   | 3.3.10-23.el7     | 3.3.10-26.el7           | procps-ng, procps: Local                |
|                    |                  |          |                   |                         | privilege escalation in top             |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| python             | CVE-2019-10160   | HIGH     | 2.7.5-76.el7      | 2.7.5-80.el7_6          | python: regression of                   |
|                    |                  |          |                   |                         | CVE-2019-9636 due to                    |
|                    |                  |          |                   |                         | functional fix to allow port            |
|                    |                  |          |                   |                         | numbers...                              |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-9636    |          |                   | 2.7.5-77.el7_6          | python: Information Disclosure          |
|                    |                  |          |                   |                         | due to urlsplit improper NFKC           |
|                    |                  |          |                   |                         | normalization                           |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-14647   | MEDIUM   |                   | 2.7.5-86.el7            | python: Missing salt                    |
|                    |                  |          |                   |                         | initialization in                       |
|                    |                  |          |                   |                         | _elementtree.c module                   |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-20852   |          |                   | 2.7.5-88.el7            | python: Cookie domain check             |
|                    |                  |          |                   |                         | returns incorrect results               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-16056   |          |                   |                         | python: email.utils.parseaddr           |
|                    |                  |          |                   |                         | wrongly parses email addresses          |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-5010    |          |                   | 2.7.5-86.el7            | python: NULL pointer                    |
|                    |                  |          |                   |                         | dereference using a specially           |
|                    |                  |          |                   |                         | crafted X509 certificate                |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9740    |          |                   |                         | python: CRLF injection via the          |
|                    |                  |          |                   |                         | query part of the url passed            |
|                    |                  |          |                   |                         | to...                                   |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9947    |          |                   |                         | python: CRLF injection via the          |
|                    |                  |          |                   |                         | path part of the url passed             |
|                    |                  |          |                   |                         | to...                                   |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9948    |          |                   |                         | python: Undocumented                    |
|                    |                  |          |                   |                         | local_file protocol allows              |
|                    |                  |          |                   |                         | remote attackers to bypass              |
|                    |                  |          |                   |                         | protection mechanisms                   |
+--------------------+------------------+----------+                   +-------------------------+-----------------------------------------+
| python-libs        | CVE-2019-10160   | HIGH     |                   | 2.7.5-80.el7_6          | python: regression of                   |
|                    |                  |          |                   |                         | CVE-2019-9636 due to                    |
|                    |                  |          |                   |                         | functional fix to allow port            |
|                    |                  |          |                   |                         | numbers...                              |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-9636    |          |                   | 2.7.5-77.el7_6          | python: Information Disclosure          |
|                    |                  |          |                   |                         | due to urlsplit improper NFKC           |
|                    |                  |          |                   |                         | normalization                           |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-14647   | MEDIUM   |                   | 2.7.5-86.el7            | python: Missing salt                    |
|                    |                  |          |                   |                         | initialization in                       |
|                    |                  |          |                   |                         | _elementtree.c module                   |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-20852   |          |                   | 2.7.5-88.el7            | python: Cookie domain check             |
|                    |                  |          |                   |                         | returns incorrect results               |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-16056   |          |                   |                         | python: email.utils.parseaddr           |
|                    |                  |          |                   |                         | wrongly parses email addresses          |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-5010    |          |                   | 2.7.5-86.el7            | python: NULL pointer                    |
|                    |                  |          |                   |                         | dereference using a specially           |
|                    |                  |          |                   |                         | crafted X509 certificate                |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9740    |          |                   |                         | python: CRLF injection via the          |
|                    |                  |          |                   |                         | query part of the url passed            |
|                    |                  |          |                   |                         | to...                                   |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9947    |          |                   |                         | python: CRLF injection via the          |
|                    |                  |          |                   |                         | path part of the url passed             |
|                    |                  |          |                   |                         | to...                                   |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2019-9948    |          |                   |                         | python: Undocumented                    |
|                    |                  |          |                   |                         | local_file protocol allows              |
|                    |                  |          |                   |                         | remote attackers to bypass              |
|                    |                  |          |                   |                         | protection mechanisms                   |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| shared-mime-info   | CVE-2019-3820    |          | 1.8-4.el7         | 1.8-5.el7               | gnome-shell: partial lock               |
|                    |                  |          |                   |                         | screen bypass                           |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| sqlite             | CVE-2019-13734   | HIGH     | 3.7.17-8.el7      | 3.7.17-8.el7_7.1        | sqlite: fts3: improve shadow            |
|                    |                  |          |                   |                         | table corruption detection              |
+--------------------+------------------+          +-------------------+-------------------------+-----------------------------------------+
| systemd            | CVE-2018-15688   |          | 219-62.el7        | 219-62.el7_6.2          | systemd: Out-of-bounds heap             |
|                    |                  |          |                   |                         | write in systemd-networkd               |
|                    |                  |          |                   |                         | dhcpv6 option handling                  |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16864   |          |                   |                         | systemd: stack overflow when            |
|                    |                  |          |                   |                         | calling syslog from a command           |
|                    |                  |          |                   |                         | with long cmdline...                    |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16865   |          |                   |                         | systemd: stack overflow                 |
|                    |                  |          |                   |                         | when receiving many journald            |
|                    |                  |          |                   |                         | entries                                 |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-6454    |          |                   | 219-62.el7_6.5          | systemd: Insufficient                   |
|                    |                  |          |                   |                         | input validation in                     |
|                    |                  |          |                   |                         | bus_process_object() resulting          |
|                    |                  |          |                   |                         | in PID 1 crash                          |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-15686   | MEDIUM   |                   | 219-67.el7              | systemd: line splitting via             |
|                    |                  |          |                   |                         | fgets() allows for state                |
|                    |                  |          |                   |                         | injection during daemon-reexec          |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16866   |          |                   |                         | systemd: out-of-bounds read             |
|                    |                  |          |                   |                         | when parsing a crafted syslog           |
|                    |                  |          |                   |                         | message                                 |
+--------------------+------------------+----------+                   +-------------------------+-----------------------------------------+
| systemd-libs       | CVE-2018-15688   | HIGH     |                   | 219-62.el7_6.2          | systemd: Out-of-bounds heap             |
|                    |                  |          |                   |                         | write in systemd-networkd               |
|                    |                  |          |                   |                         | dhcpv6 option handling                  |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16864   |          |                   |                         | systemd: stack overflow when            |
|                    |                  |          |                   |                         | calling syslog from a command           |
|                    |                  |          |                   |                         | with long cmdline...                    |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16865   |          |                   |                         | systemd: stack overflow                 |
|                    |                  |          |                   |                         | when receiving many journald            |
|                    |                  |          |                   |                         | entries                                 |
+                    +------------------+          +                   +-------------------------+-----------------------------------------+
|                    | CVE-2019-6454    |          |                   | 219-62.el7_6.5          | systemd: Insufficient                   |
|                    |                  |          |                   |                         | input validation in                     |
|                    |                  |          |                   |                         | bus_process_object() resulting          |
|                    |                  |          |                   |                         | in PID 1 crash                          |
+                    +------------------+----------+                   +-------------------------+-----------------------------------------+
|                    | CVE-2018-15686   | MEDIUM   |                   | 219-67.el7              | systemd: line splitting via             |
|                    |                  |          |                   |                         | fgets() allows for state                |
|                    |                  |          |                   |                         | injection during daemon-reexec          |
+                    +------------------+          +                   +                         +-----------------------------------------+
|                    | CVE-2018-16866   |          |                   |                         | systemd: out-of-bounds read             |
|                    |                  |          |                   |                         | when parsing a crafted syslog           |
|                    |                  |          |                   |                         | message                                 |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+
| vim-minimal        | CVE-2019-12735   | HIGH     | 2:7.4.160-5.el7   | 2:7.4.160-6.el7_6       | vim/neovim: ':source!' command          |
|                    |                  |          |                   |                         | allows arbitrary command                |
|                    |                  |          |                   |                         | execution via modelines                 |
+--------------------+------------------+----------+-------------------+-------------------------+-----------------------------------------+```