### PR TITLE
chore: mark some files as auto-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/api/**/swagger.json    linguist-generated=true
+/api/*.html             linguist-generated=true
+/api/*.md               linguist-generated=true
+/manifests/install.yaml linguist-generated=true
+/pkg/**/generated.proto linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 /api/**/swagger.json    linguist-generated=true
 /api/*.html             linguist-generated=true
 /api/*.md               linguist-generated=true
-/manifests/install.yaml linguist-generated=true
 /pkg/**/generated.proto linguist-generated=true


### PR DESCRIPTION
Those files are auto-generated by `make codegen`, so their diffs should be minimized to make reviewers' life easier!

refs:

- How to mark files as "auto-generated": [Customizing how changed files appear on GitHub - GitHub Docs](https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github)
- How to confirm a file is marked as intended: [Git - git-check-attr Documentation](https://git-scm.com/docs/git-check-attr)