### PR TITLE
fix(eventbus): NATS eventbus auto reconnect and code refactory

### DIFF
--- a/eventbus/driver/driver.go
+++ b/eventbus/driver/driver.go
@@ -14,11 +14,12 @@ type Driver interface {
 	// SubscribeEventSources is used to subscribe multiple event source dependencies
 	// Parameter - ctx, context
 	// Parameter - conn, eventbus connection
+	// Parameter - closeCh, channel to indicate to close the subscription
 	// Parameter - dependencyExpr, example: "(dep1 || dep2) && dep3"
 	// Parameter - dependencies, array of dependencies information
 	// Parameter - filter, a function used to filter the message
 	// Parameter - action, a function to be triggered after all conditions meet
-	SubscribeEventSources(ctx context.Context, conn Connection, dependencyExpr string, dependencies []Dependency, filter func(string, cloudevents.Event) bool, action func(map[string]cloudevents.Event)) error
+	SubscribeEventSources(ctx context.Context, conn Connection, closeCh <-chan struct{}, dependencyExpr string, dependencies []Dependency, filter func(string, cloudevents.Event) bool, action func(map[string]cloudevents.Event)) error
 
 	// Publish a message
 	Publish(conn Connection, message []byte) error

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -156,7 +156,6 @@ func (n *natsStreaming) SubscribeEventSources(ctx context.Context, conn Connecti
 			log.Info("closing subscription...")
 			_ = sub.Close()
 			log.Infof("subscription on subject %s closed", n.subject)
-		default:
 		}
 	}
 }

--- a/eventbus/eventbus.go
+++ b/eventbus/eventbus.go
@@ -47,6 +47,7 @@ func GetDriver(ctx context.Context, eventBusConfig eventbusv1alpha1.BusConfig, s
 		}
 		v.WatchConfig()
 		v.OnConfigChange(func(e fsnotify.Event) {
+			logger.Info("eventbus auth config file changed.")
 			err = v.Unmarshal(cred)
 			if err != nil {
 				logger.Errorf("failed to unmarshal auth.yaml after reloading, err: %v", err)

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -255,6 +255,7 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 	}
 	defer e.eventBusConn.Close()
 
+	// Daemon to reconnect
 	go func(ctx context.Context) {
 		logger.Info("starting eventbus connection daemon...")
 		for {
@@ -263,9 +264,10 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 				logger.Info("exiting eventbus connection daemon...")
 				return
 			default:
-				time.Sleep(2 * time.Second)
+				time.Sleep(3 * time.Second)
 			}
 			if e.eventBusConn == nil || e.eventBusConn.IsClosed() {
+				logger.Info("NATS connection lost, reconnecting...")
 				e.eventBusConn, err = driver.Connect()
 				if err != nil {
 					logger.WithError(err).Errorln("failed to reconnect to eventbus")

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -305,7 +305,6 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 				})
 				logger.WithField(logging.LabelEventSourceName, s.GetEventSourceName()).
 					WithField(logging.LabelEventName, s.GetEventName()).WithError(err).Errorln("failed to start service.")
-				// TODO: Need retry.
 			}(server)
 		}
 	}

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -53,7 +53,7 @@ type EventingServer interface {
 	GetEventSourceType() apicommon.EventSourceType
 
 	// Function to start listening events.
-	StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error
+	StartListening(ctx context.Context, dispatch func([]byte) error) error
 }
 
 // GetEventingServers returns the mapping of event source type and list of eventing servers
@@ -253,6 +253,29 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 		logger.WithError(err).Errorln("failed to connect to eventbus")
 		return err
 	}
+	defer e.eventBusConn.Close()
+
+	go func(ctx context.Context) {
+		logger.Info("starting eventbus connection daemon...")
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("exiting eventbus connection daemon...")
+				return
+			default:
+				time.Sleep(2 * time.Second)
+			}
+			if e.eventBusConn == nil || e.eventBusConn.IsClosed() {
+				e.eventBusConn, err = driver.Connect()
+				if err != nil {
+					logger.WithError(err).Errorln("failed to reconnect to eventbus")
+					continue
+				}
+				logger.Info("reconnected the NATS streaming server...")
+			}
+		}
+	}(cctx)
+
 	for _, ss := range servers {
 		for _, server := range ss {
 			err := server.ValidateEventSource(cctx)
@@ -261,7 +284,7 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 				return err
 			}
 			go func(s EventingServer) {
-				err := s.StartListening(cctx, stopCh, func(data []byte) error {
+				err := s.StartListening(cctx, func(data []byte) error {
 					event := cloudevents.NewEvent()
 					event.SetID(fmt.Sprintf("%x", uuid.New()))
 					event.SetType(string(s.GetEventSourceType()))

--- a/eventsources/sources/amqp/start.go
+++ b/eventsources/sources/amqp/start.go
@@ -54,7 +54,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -141,7 +141,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 			if err != nil {
 				log.WithError(err).Errorln("failed to dispatch event")
 			}
-		case <-stopCh:
+		case <-ctx.Done():
 			err = conn.Close()
 			if err != nil {
 				log.WithError(err).Info("failed to close connection")

--- a/eventsources/sources/awssns/start.go
+++ b/eventsources/sources/awssns/start.go
@@ -212,7 +212,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -58,7 +58,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -96,7 +96,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 	log.Infoln("listening for messages on the queue...")
 	for {
 		select {
-		case <-stopCh:
+		case <-ctx.Done():
 			log.Info("exiting SQS event listener...")
 			return nil
 		default:

--- a/eventsources/sources/azureeventshub/start.go
+++ b/eventsources/sources/azureeventshub/start.go
@@ -55,7 +55,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -123,7 +123,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		listenerHandles = append(listenerHandles, listenerHandle)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 	log.Infoln("stopping listener handlers")
 
 	for _, handler := range listenerHandles {

--- a/eventsources/sources/calendar/start.go
+++ b/eventsources/sources/calendar/start.go
@@ -54,7 +54,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -126,7 +126,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 			if err != nil {
 				log.WithError(err).Errorln("failed to dispatch event")
 			}
-		case <-stopCh:
+		case <-ctx.Done():
 			log.Info("exiting calendar event listener...")
 			return nil
 		}

--- a/eventsources/sources/emitter/start.go
+++ b/eventsources/sources/emitter/start.go
@@ -53,7 +53,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -130,7 +130,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		return errors.Wrapf(err, "failed to subscribe to channel %s", emitterEventSource.ChannelName)
 	}
 
-	<-stopCh
+	<-ctx.Done()
 
 	log.WithField("channel-name", emitterEventSource.ChannelName).Infoln("event source stopped, unsubscribe the channel")
 

--- a/eventsources/sources/gcppubsub/start.go
+++ b/eventsources/sources/gcppubsub/start.go
@@ -55,7 +55,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening listens to GCP PubSub events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	// In order to listen events from GCP PubSub,
 	// 1. Parse the event source that contains configuration to connect to GCP PubSub
 	// 2. Create a new PubSub client
@@ -169,7 +169,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		return errors.Wrapf(err, "failed to receive the messages for subscription %s and topic %s for %s", subscriptionName, pubsubEventSource.Topic, el.GetEventName())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 
 	log.Infoln("event source has been stopped")
 

--- a/eventsources/sources/github/start.go
+++ b/eventsources/sources/github/start.go
@@ -275,7 +275,7 @@ func (router *Router) PostInactivate() error {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/github/start.go
+++ b/eventsources/sources/github/start.go
@@ -274,7 +274,7 @@ func (router *Router) PostInactivate() error {
 	return nil
 }
 
-// StartListening starts an SNS event source
+// StartListening starts an event source
 func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{

--- a/eventsources/sources/gitlab/start.go
+++ b/eventsources/sources/gitlab/start.go
@@ -262,7 +262,7 @@ func (router *Router) PostInactivate() error {
 	return nil
 }
 
-// StartListening starts an SNS event source
+// StartListening starts an event source
 func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{

--- a/eventsources/sources/gitlab/start.go
+++ b/eventsources/sources/gitlab/start.go
@@ -263,7 +263,7 @@ func (router *Router) PostInactivate() error {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/hdfs/start.go
+++ b/eventsources/sources/hdfs/start.go
@@ -61,7 +61,7 @@ func (w *WatchableHDFS) GetFileID(fi os.FileInfo) interface{} {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -164,7 +164,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 			}
 		case err := <-watcher.Errors:
 			return errors.Wrapf(err, "failed to watch events for %s", el.GetEventName())
-		case <-stopCh:
+		case <-ctx.Done():
 			return nil
 		}
 	}

--- a/eventsources/sources/kafka/start.go
+++ b/eventsources/sources/kafka/start.go
@@ -63,7 +63,7 @@ func verifyPartitionAvailable(part int32, partitions []int32) bool {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -157,7 +157,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		case err := <-partitionConsumer.Errors():
 			return errors.Wrapf(err, "failed to consume messages for event source %s", el.GetEventName())
 
-		case <-stopCh:
+		case <-ctx.Done():
 			log.Infoln("event source is stopped, closing partition consumer")
 			err = partitionConsumer.Close()
 			if err != nil {

--- a/eventsources/sources/minio/start.go
+++ b/eventsources/sources/minio/start.go
@@ -52,7 +52,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -104,7 +104,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		}
 	}
 
-	<-stopCh
+	<-ctx.Done()
 	doneCh <- struct{}{}
 
 	log.Infoln("event source is stopped")

--- a/eventsources/sources/mqtt/start.go
+++ b/eventsources/sources/mqtt/start.go
@@ -54,7 +54,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -122,7 +122,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		return errors.Wrapf(token.Error(), "failed to subscribe to the topic %s for event source %s", mqttEventSource.Topic, el.GetEventName())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 	log.Infoln("event source is stopped, unsubscribing the client...")
 
 	token := client.Unsubscribe(mqttEventSource.Topic)

--- a/eventsources/sources/nats/start.go
+++ b/eventsources/sources/nats/start.go
@@ -54,7 +54,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -122,7 +122,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		return errors.Wrapf(err, "connection failure for event source %s", el.GetEventName())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 	log.Infoln("event source is stopped")
 	return nil
 }

--- a/eventsources/sources/nsq/start.go
+++ b/eventsources/sources/nsq/start.go
@@ -61,7 +61,7 @@ type messageHandler struct {
 }
 
 // StartListening listens NSQ events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -107,7 +107,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 		return errors.Wrapf(err, "lookup failed for host %s for event source %s", nsqEventSource.HostAddress, el.GetEventName())
 	}
 
-	<-stopCh
+	<-ctx.Done()
 	log.Infoln("event source has stopped")
 	consumer.Stop()
 	return nil

--- a/eventsources/sources/redis/start.go
+++ b/eventsources/sources/redis/start.go
@@ -53,7 +53,7 @@ func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
 }
 
 // StartListening listens events published by redis
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),
 		logging.LabelEventSourceName: el.GetEventSourceName(),
@@ -121,7 +121,7 @@ func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struc
 			if err != nil {
 				log.WithError(err).Errorln("failed to dispatch event")
 			}
-		case <-stopCh:
+		case <-ctx.Done():
 			log.Infoln("event source is stopped. unsubscribing the subscription")
 			if err := pubsub.Unsubscribe(redisEventSource.Channels...); err != nil {
 				log.WithError(err).Errorln("failed to unsubscribe")

--- a/eventsources/sources/slack/start.go
+++ b/eventsources/sources/slack/start.go
@@ -269,7 +269,7 @@ func (rc *Router) verifyRequest(request *http.Request) error {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/slack/start.go
+++ b/eventsources/sources/slack/start.go
@@ -268,7 +268,7 @@ func (rc *Router) verifyRequest(request *http.Request) error {
 	return nil
 }
 
-// StartListening starts an SNS event source
+// StartListening starts an event source
 func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{

--- a/eventsources/sources/storagegrid/start.go
+++ b/eventsources/sources/storagegrid/start.go
@@ -319,7 +319,7 @@ func (router *Router) PostInactivate() error {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/storagegrid/start.go
+++ b/eventsources/sources/storagegrid/start.go
@@ -318,7 +318,7 @@ func (router *Router) PostInactivate() error {
 	return nil
 }
 
-// StartListening starts an SNS event source
+// StartListening starts an event source
 func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{

--- a/eventsources/sources/stripe/start.go
+++ b/eventsources/sources/stripe/start.go
@@ -182,7 +182,7 @@ func filterEvent(event *stripe.Event, filters []string) bool {
 	return false
 }
 
-// StartListening starts an SNS event source
+// StartListening starts an event source
 func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{

--- a/eventsources/sources/stripe/start.go
+++ b/eventsources/sources/stripe/start.go
@@ -183,7 +183,7 @@ func filterEvent(event *stripe.Event, filters []string) bool {
 }
 
 // StartListening starts an SNS event source
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/eventsources/sources/webhook/start.go
+++ b/eventsources/sources/webhook/start.go
@@ -134,7 +134,7 @@ func (router *Router) PostInactivate() error {
 }
 
 // StartListening starts listening events
-func (el *EventListener) StartListening(ctx context.Context, stopCh <-chan struct{}, dispatch func([]byte) error) error {
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
 	logger := logging.FromContext(ctx)
 	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
 		logging.LabelEventSourceType: el.GetEventSourceType(),

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa // indirect
 	golang.org/x/tools v0.0.0-20200408132156-9ee5ef7a2c0d // indirect
 	google.golang.org/api v0.6.1-0.20190607001116-5213b8090861
-	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/appengine v1.6.5
 	google.golang.org/genproto v0.0.0-20200408120641-fbb3ad325eb7 // indirect
 	google.golang.org/grpc v1.28.1
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa // indirect
 	golang.org/x/tools v0.0.0-20200408132156-9ee5ef7a2c0d // indirect
 	google.golang.org/api v0.6.1-0.20190607001116-5213b8090861
-	google.golang.org/appengine v1.6.5
+	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20200408120641-fbb3ad325eb7 // indirect
 	google.golang.org/grpc v1.28.1
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/sensors/listener_test.go
+++ b/sensors/listener_test.go
@@ -119,7 +119,7 @@ func TestGetDependencyExpression(t *testing.T) {
 			{Name: "group-1", Dependencies: []string{"dep1", "dep1a"}},
 			{Name: "group-2", Dependencies: []string{"dep2"}},
 		}
-		obj.Spec.Circuit = "group-1 || group-2"
+		obj.Spec.Circuit = "((group-2) || group-1)"
 		trig := fakeTrigger.DeepCopy()
 		trig.Template.Switch = &v1alpha1.TriggerSwitch{
 			Any: []string{"group-1"},


### PR DESCRIPTION
1. Fixed a bug that `()` in sensor dependency expression was trimmed when converting group expr to dependency expr.
2. 2 layers of event bus auto reconnect: 
  a. utilize NATS reconnect feature - for short term connection lost such as NATS POD crash
  b. Extra Goroutins in eventsource and sensor service to auto reconnect - for long term connection lost
3. Code refactory to use `ctx.Done` instead of `stopCh`