### PR TITLE
feat: Different deployment update strategy for different event sources

### DIFF
--- a/controllers/eventsource/cmd/main.go
+++ b/controllers/eventsource/cmd/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 	// A controller with DefaultControllerRateLimiter
 	c, err := controller.New(eventsource.ControllerName, mgr, controller.Options{
-		Reconciler: eventsource.NewReconciler(mgr.GetClient(), mgr.GetScheme(), namespace, eventSourceImage, log.WithName("reconciler")),
+		Reconciler: eventsource.NewReconciler(mgr.GetClient(), mgr.GetScheme(), eventSourceImage, log.WithName("reconciler")),
 	})
 	if err != nil {
 		mainLog.Error(err, "unable to set up individual controller")

--- a/controllers/eventsource/controller.go
+++ b/controllers/eventsource/controller.go
@@ -28,14 +28,12 @@ type reconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
 
-	// controller namespace
-	namespace        string
 	eventSourceImage string
 	logger           logr.Logger
 }
 
 // NewReconciler returns a new reconciler
-func NewReconciler(client client.Client, scheme *runtime.Scheme, namespace, eventSourceImage string, logger logr.Logger) reconcile.Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, eventSourceImage string, logger logr.Logger) reconcile.Reconciler {
 	return &reconciler{client: client, scheme: scheme, eventSourceImage: eventSourceImage, logger: logger}
 }
 
@@ -82,7 +80,6 @@ func (r *reconciler) reconcile(ctx context.Context, eventSource *v1alpha1.EventS
 		return err
 	}
 	args := &AdaptorArgs{
-		Namespace:   r.namespace,
 		Image:       r.eventSourceImage,
 		EventSource: eventSource,
 		Labels: map[string]string{

--- a/controllers/eventsource/controller_test.go
+++ b/controllers/eventsource/controller_test.go
@@ -1,0 +1,181 @@
+package eventsource
+
+import (
+	"context"
+	"testing"
+
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testEventSourceName = "test-name"
+	testNamespace       = "test-ns"
+	testSecretName      = "test-secret"
+	testSecretKey       = "test-secret-key"
+	testConfigMapName   = "test-cm"
+	testConfigMapKey    = "test-cm-key"
+)
+
+var (
+	testSecretSelector = &corev1.SecretKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: testSecretName,
+		},
+		Key: testSecretKey,
+	}
+
+	testConfigMapSelector = &corev1.ConfigMapKeySelector{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: testConfigMapName,
+		},
+		Key: testConfigMapKey,
+	}
+
+	fakeEventBus = &eventbusv1alpha1.EventBus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: eventbusv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "EventBus",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "default",
+		},
+		Spec: eventbusv1alpha1.EventBusSpec{
+			NATS: &eventbusv1alpha1.NATSBus{
+				Native: &eventbusv1alpha1.NativeStrategy{
+					Auth: &eventbusv1alpha1.AuthStrategyToken,
+				},
+			},
+		},
+		Status: eventbusv1alpha1.EventBusStatus{
+			Config: eventbusv1alpha1.BusConfig{
+				NATS: &eventbusv1alpha1.NATSConfig{
+					URL:  "nats://xxxx",
+					Auth: &eventbusv1alpha1.AuthStrategyToken,
+					AccessSecret: &corev1.SecretKeySelector{
+						Key: "test-key",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-name",
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func fakeEmptyEventSource() *v1alpha1.EventSource {
+	return &v1alpha1.EventSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testEventSourceName,
+		},
+		Spec: v1alpha1.EventSourceSpec{},
+	}
+}
+
+func fakeCalendarEventSourceMap(name string) map[string]v1alpha1.CalendarEventSource {
+	return map[string]v1alpha1.CalendarEventSource{name: {Schedule: "*/5 * * * *"}}
+}
+
+func fakeWebhookEventSourceMap(name string) map[string]v1alpha1.WebhookContext {
+	return map[string]v1alpha1.WebhookContext{
+		name: {
+			URL:      "http://a.b",
+			Endpoint: "/abc",
+			Port:     "1234",
+		},
+	}
+}
+
+func fakeKafkaEventSourceMap(name string) map[string]v1alpha1.KafkaEventSource {
+	return map[string]v1alpha1.KafkaEventSource{
+		name: {
+			URL:       "a.b",
+			Partition: "abc",
+			Topic:     "topic",
+		},
+	}
+}
+
+func fakeMQTTEventSourceMap(name string) map[string]v1alpha1.MQTTEventSource {
+	return map[string]v1alpha1.MQTTEventSource{
+		name: {
+			URL:      "a.b",
+			ClientID: "cid",
+			Topic:    "topic",
+		},
+	}
+}
+
+func fakeHDFSEventSourceMap(name string) map[string]v1alpha1.HDFSEventSource {
+	return map[string]v1alpha1.HDFSEventSource{
+		name: {
+			Type:                    "t",
+			CheckInterval:           "aa",
+			Addresses:               []string{"ad1"},
+			HDFSUser:                "user",
+			KrbCCacheSecret:         testSecretSelector,
+			KrbKeytabSecret:         testSecretSelector,
+			KrbUsername:             "user",
+			KrbRealm:                "llss",
+			KrbConfigConfigMap:      testConfigMapSelector,
+			KrbServicePrincipalName: "name",
+		},
+	}
+}
+
+func init() {
+	_ = v1alpha1.AddToScheme(scheme.Scheme)
+	_ = eventbusv1alpha1.AddToScheme(scheme.Scheme)
+	_ = appv1.AddToScheme(scheme.Scheme)
+	_ = corev1.AddToScheme(scheme.Scheme)
+}
+
+func TestReconcile(t *testing.T) {
+	t.Run("test reconcile without eventbus", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Calendar = fakeCalendarEventSourceMap("test")
+		ctx := context.TODO()
+		cl := fake.NewFakeClient(testEventSource)
+		r := &reconciler{
+			client:           cl,
+			scheme:           scheme.Scheme,
+			eventSourceImage: "test-image",
+			logger:           ctrl.Log.WithName("test"),
+		}
+		err := r.reconcile(ctx, testEventSource)
+		assert.Error(t, err)
+		assert.False(t, testEventSource.Status.IsReady())
+	})
+
+	t.Run("test reconcile with eventbus", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Calendar = fakeCalendarEventSourceMap("test")
+		ctx := context.TODO()
+		cl := fake.NewFakeClient(testEventSource)
+		testBus := fakeEventBus.DeepCopy()
+		testBus.Status.MarkDeployed("test", "test")
+		testBus.Status.MarkConfigured()
+		err := cl.Create(ctx, testBus)
+		assert.Nil(t, err)
+		r := &reconciler{
+			client:           cl,
+			scheme:           scheme.Scheme,
+			eventSourceImage: "test-image",
+			logger:           ctrl.Log.WithName("test"),
+		}
+		err = r.reconcile(ctx, testEventSource)
+		assert.NoError(t, err)
+		assert.True(t, testEventSource.Status.IsReady())
+	})
+}

--- a/controllers/eventsource/resource.go
+++ b/controllers/eventsource/resource.go
@@ -34,8 +34,6 @@ var (
 
 // AdaptorArgs are the args needed to create a sensor deployment
 type AdaptorArgs struct {
-	// controller namespace
-	Namespace   string
 	Image       string
 	EventSource *v1alpha1.EventSource
 	Labels      map[string]string
@@ -398,7 +396,14 @@ func envFromSources(eventSource *v1alpha1.EventSource, t reflect.Type) []corev1.
 	r := []corev1.EnvFromSource{}
 	keys := make(map[string]bool)
 	for _, e := range result {
-		entry := e.SecretRef.Name
+		var entry string
+		switch t {
+		case secretKeySelectorType:
+			entry = e.SecretRef.Name
+		case configMapKeySelectorType:
+			entry = e.ConfigMapRef.Name
+		default:
+		}
 		if _, value := keys[entry]; !value {
 			keys[entry] = true
 			r = append(r, e)

--- a/controllers/eventsource/resource_test.go
+++ b/controllers/eventsource/resource_test.go
@@ -1,0 +1,106 @@
+package eventsource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testImage = "test-image"
+)
+
+var (
+	testLabels = map[string]string{"controller": "test-controller"}
+)
+
+func Test_BuildDeployment(t *testing.T) {
+	testEventSource := fakeEmptyEventSource()
+	testEventSource.Spec.HDFS = fakeHDFSEventSourceMap("test")
+	t.Run("test build HDFS", func(t *testing.T) {
+		args := &AdaptorArgs{
+			Image:       testImage,
+			EventSource: testEventSource,
+			Labels:      testLabels,
+		}
+		deployment, err := buildDeployment(args, fakeEventBus)
+		assert.Nil(t, err)
+		assert.NotNil(t, deployment)
+		volumes := deployment.Spec.Template.Spec.Volumes
+		assert.True(t, len(volumes) > 0)
+		hasAuthVolume := false
+		for _, vol := range volumes {
+			if vol.Name == "auth-volume" {
+				hasAuthVolume = true
+				break
+			}
+		}
+		assert.True(t, hasAuthVolume)
+		envFroms := deployment.Spec.Template.Spec.Containers[0].EnvFrom
+		assert.True(t, len(envFroms) > 0)
+		cmRefs, secretRefs := 0, 0
+		for _, ef := range envFroms {
+			if ef.ConfigMapRef != nil {
+				cmRefs++
+			} else if ef.SecretRef != nil {
+				secretRefs++
+			}
+		}
+		assert.True(t, cmRefs > 0)
+		assert.True(t, secretRefs > 0)
+	})
+}
+
+func TestResourceReconcile(t *testing.T) {
+	testEventSource := fakeEmptyEventSource()
+	testEventSource.Spec.HDFS = fakeHDFSEventSourceMap("test")
+	t.Run("test resource reconcile without eventbus", func(t *testing.T) {
+		cl := fake.NewFakeClient(testEventSource)
+		args := &AdaptorArgs{
+			Image:       testImage,
+			EventSource: testEventSource,
+			Labels:      testLabels,
+		}
+		err := Reconcile(cl, args, ctrl.Log.WithName("test"))
+		assert.Error(t, err)
+		assert.False(t, testEventSource.Status.IsReady())
+	})
+
+	t.Run("test resource reconcile with eventbus", func(t *testing.T) {
+		ctx := context.TODO()
+		cl := fake.NewFakeClient(testEventSource)
+		testBus := fakeEventBus.DeepCopy()
+		testBus.Status.MarkDeployed("test", "test")
+		testBus.Status.MarkConfigured()
+		err := cl.Create(ctx, testBus)
+		assert.Nil(t, err)
+		args := &AdaptorArgs{
+			Image:       testImage,
+			EventSource: testEventSource,
+			Labels:      testLabels,
+		}
+		err = Reconcile(cl, args, ctrl.Log.WithName("test"))
+		assert.Nil(t, err)
+		assert.True(t, testEventSource.Status.IsReady())
+
+		deployList := &appv1.DeploymentList{}
+		err = cl.List(ctx, deployList, &client.ListOptions{
+			Namespace: testNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(deployList.Items))
+
+		svcList := &corev1.ServiceList{}
+		err = cl.List(ctx, svcList, &client.ListOptions{
+			Namespace: testNamespace,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(svcList.Items))
+	})
+}

--- a/controllers/eventsource/validate.go
+++ b/controllers/eventsource/validate.go
@@ -51,7 +51,7 @@ func ValidateEventSource(eventSource *v1alpha1.EventSource) error {
 	if rollingUpdates > 0 && recreates > 0 {
 		// We don't allow this as if we use recreate strategy for the deployment it will have downtime
 		eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", "Some types of event sources can not be put in one spec")
-		return errors.New("eventsources in the spec require both rolling update and recreate update strategy")
+		return errors.New("event sources with rolling update and recreate update strategy can not put together")
 	}
 
 	eventSource.Status.MarkSourcesProvided()

--- a/controllers/eventsource/validate.go
+++ b/controllers/eventsource/validate.go
@@ -4,19 +4,34 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/argoproj/argo-events/eventsources"
-	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
 	"github.com/pkg/errors"
+
+	"github.com/argoproj/argo-events/eventsources"
+	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
 )
 
 // ValidateEventSource validates if the eventSource is valid
 func ValidateEventSource(eventSource *v1alpha1.EventSource) error {
 	servers := eventsources.GetEventingServers(eventSource)
-	if len(servers) != 1 {
-		// We don't allow multiple types of event sources in one EventSource for now.
-		eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", "Either no event source or multiple types of event sources found")
-		return errors.New("either no event source or multiple types of event sources found")
+	recreateTypes := make(map[apicommon.EventSourceType]bool)
+	for _, esType := range apicommon.RecreateStrategyEventSources {
+		recreateTypes[esType] = true
 	}
+	rollingUpdates, recreates := 0, 0
+	for eventType := range servers {
+		if _, ok := recreateTypes[eventType]; ok {
+			recreates++
+		} else {
+			rollingUpdates++
+		}
+	}
+	if rollingUpdates > 0 && recreates > 0 {
+		// We don't allow this as if we use recreate strategy for the deployment it will have downtime
+		eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", "Some types of event sources can not be put in one spec")
+		return errors.New("eventsources in the spec require both rolling update and recreate update strategy")
+	}
+
 	ctx := context.Background()
 	for _, ss := range servers {
 		for _, server := range ss {

--- a/controllers/eventsource/validate.go
+++ b/controllers/eventsource/validate.go
@@ -13,28 +13,33 @@ import (
 
 // ValidateEventSource validates if the eventSource is valid
 func ValidateEventSource(eventSource *v1alpha1.EventSource) error {
-	servers := eventsources.GetEventingServers(eventSource)
 	recreateTypes := make(map[apicommon.EventSourceType]bool)
 	for _, esType := range apicommon.RecreateStrategyEventSources {
 		recreateTypes[esType] = true
 	}
+
+	servers := eventsources.GetEventingServers(eventSource)
+
+	eventNames := make(map[string]bool)
 	rollingUpdates, recreates := 0, 0
-	for eventType := range servers {
+	ctx := context.Background()
+	for eventType, ss := range servers {
 		if _, ok := recreateTypes[eventType]; ok {
 			recreates++
 		} else {
 			rollingUpdates++
 		}
-	}
-	if rollingUpdates > 0 && recreates > 0 {
-		// We don't allow this as if we use recreate strategy for the deployment it will have downtime
-		eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", "Some types of event sources can not be put in one spec")
-		return errors.New("eventsources in the spec require both rolling update and recreate update strategy")
-	}
 
-	ctx := context.Background()
-	for _, ss := range servers {
 		for _, server := range ss {
+			eName := server.GetEventName()
+			if _, ok := eventNames[eName]; !ok {
+				eventNames[eName] = true
+			} else {
+				// Duplicated event name not allowed in one EventSource, even they are in different EventSourceType.
+				eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", fmt.Sprintf("more than one \"%s\" found", eName))
+				return errors.Errorf("more than one \"%s\" found in the spec", eName)
+			}
+
 			err := server.ValidateEventSource(ctx)
 			if err != nil {
 				eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", fmt.Sprintf("Invalid spec: %s - %s", server.GetEventSourceName(), server.GetEventName()))
@@ -42,6 +47,13 @@ func ValidateEventSource(eventSource *v1alpha1.EventSource) error {
 			}
 		}
 	}
+
+	if rollingUpdates > 0 && recreates > 0 {
+		// We don't allow this as if we use recreate strategy for the deployment it will have downtime
+		eventSource.Status.MarkSourcesNotProvided("InvalidEventSource", "Some types of event sources can not be put in one spec")
+		return errors.New("eventsources in the spec require both rolling update and recreate update strategy")
+	}
+
 	eventSource.Status.MarkSourcesProvided()
 	return nil
 }

--- a/controllers/eventsource/validate_test.go
+++ b/controllers/eventsource/validate_test.go
@@ -1,0 +1,42 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	t.Run("validate calendar eventsource", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Calendar = fakeCalendarEventSourceMap("test")
+		err := ValidateEventSource(testEventSource)
+		assert.NoError(t, err)
+	})
+
+	t.Run("validate good mixed types eventsource", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Kafka = fakeKafkaEventSourceMap("test1")
+		testEventSource.Spec.MQTT = fakeMQTTEventSourceMap("test2")
+		err := ValidateEventSource(testEventSource)
+		assert.NoError(t, err)
+	})
+
+	t.Run("validate bad mixed types eventsource", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Kafka = fakeKafkaEventSourceMap("test1")
+		testEventSource.Spec.Webhook = fakeWebhookEventSourceMap("test2")
+		err := ValidateEventSource(testEventSource)
+		assert.Error(t, err)
+		assert.Equal(t, "event sources with rolling update and recreate update strategy can not put together", err.Error())
+	})
+
+	t.Run("validate bad mixed types eventsource - duplicated name", func(t *testing.T) {
+		testEventSource := fakeEmptyEventSource()
+		testEventSource.Spec.Kafka = fakeKafkaEventSourceMap("test")
+		testEventSource.Spec.MQTT = fakeMQTTEventSourceMap("test")
+		err := ValidateEventSource(testEventSource)
+		assert.Error(t, err)
+		assert.Equal(t, "more than one \"test\" found in the spec", err.Error())
+	})
+}

--- a/controllers/sensor/cmd/main.go
+++ b/controllers/sensor/cmd/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 	// A controller with DefaultControllerRateLimiter
 	c, err := controller.New(sensor.ControllerName, mgr, controller.Options{
-		Reconciler: sensor.NewReconciler(mgr.GetClient(), mgr.GetScheme(), namespace, sensorImage, log.WithName("reconciler")),
+		Reconciler: sensor.NewReconciler(mgr.GetClient(), mgr.GetScheme(), sensorImage, log.WithName("reconciler")),
 	})
 	if err != nil {
 		mainLog.Error(err, "unable to set up individual controller")

--- a/controllers/sensor/controller.go
+++ b/controllers/sensor/controller.go
@@ -44,14 +44,12 @@ type reconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
 
-	// controller namespace
-	namespace   string
 	sensorImage string
 	logger      logr.Logger
 }
 
 // NewReconciler returns a new reconciler
-func NewReconciler(client client.Client, scheme *runtime.Scheme, namespace, sensorImage string, logger logr.Logger) reconcile.Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, sensorImage string, logger logr.Logger) reconcile.Reconciler {
 	return &reconciler{client: client, scheme: scheme, sensorImage: sensorImage, logger: logger}
 }
 
@@ -97,9 +95,8 @@ func (r *reconciler) reconcile(ctx context.Context, sensor *v1alpha1.Sensor) err
 		log.Error(err, "validation error")
 	}
 	args := &AdaptorArgs{
-		Namespace: r.namespace,
-		Image:     r.sensorImage,
-		Sensor:    sensor,
+		Image:  r.sensorImage,
+		Sensor: sensor,
 		Labels: map[string]string{
 			"controller":           "sensor-controller",
 			common.LabelSensorName: sensor.Name,

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -42,11 +42,9 @@ import (
 
 // AdaptorArgs are the args needed to create a sensor deployment
 type AdaptorArgs struct {
-	// controller namespace
-	Namespace string
-	Image     string
-	Sensor    *v1alpha1.Sensor
-	Labels    map[string]string
+	Image  string
+	Sensor *v1alpha1.Sensor
+	Labels map[string]string
 }
 
 // Reconcile does the real logic

--- a/eventbus/driver/mocks/Driver.go
+++ b/eventbus/driver/mocks/Driver.go
@@ -53,13 +53,13 @@ func (_m *Driver) Publish(conn driver.Connection, message []byte) error {
 	return r0
 }
 
-// SubscribeEventSources provides a mock function with given fields: ctx, conn, dependencyExpr, dependencies, filter, action
-func (_m *Driver) SubscribeEventSources(ctx context.Context, conn driver.Connection, dependencyExpr string, dependencies []driver.Dependency, filter func(string, event.Event) bool, action func(map[string]event.Event)) error {
-	ret := _m.Called(ctx, conn, dependencyExpr, dependencies, filter, action)
+// SubscribeEventSources provides a mock function with given fields: ctx, conn, closeCh, dependencyExpr, dependencies, filter, action
+func (_m *Driver) SubscribeEventSources(ctx context.Context, conn driver.Connection, closeCh <-chan struct{}, dependencyExpr string, dependencies []driver.Dependency, filter func(string, event.Event) bool, action func(map[string]event.Event)) error {
+	ret := _m.Called(ctx, conn, closeCh, dependencyExpr, dependencies, filter, action)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, driver.Connection, string, []driver.Dependency, func(string, event.Event) bool, func(map[string]event.Event)) error); ok {
-		r0 = rf(ctx, conn, dependencyExpr, dependencies, filter, action)
+	if rf, ok := ret.Get(0).(func(context.Context, driver.Connection, <-chan struct{}, string, []driver.Dependency, func(string, event.Event) bool, func(map[string]event.Event)) error); ok {
+		r0 = rf(ctx, conn, closeCh, dependencyExpr, dependencies, filter, action)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/eventsources/cmd/main.go
+++ b/eventsources/cmd/main.go
@@ -7,8 +7,6 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/argoproj/argo-events/common"
@@ -19,12 +17,6 @@ import (
 )
 
 func main() {
-	kubeConfig, _ := os.LookupEnv(common.EnvVarKubeConfig)
-	restConfig, err := common.GetClientConfig(kubeConfig)
-	if err != nil {
-		panic(err)
-	}
-	kubeClient := kubernetes.NewForConfigOrDie(restConfig)
 	encodedEventSourceSpec, defined := os.LookupEnv(common.EnvVarEventSourceObject)
 	if !defined {
 		panic(errors.Errorf("required environment variable '%s' not defined", common.EnvVarEventSourceObject))
@@ -60,9 +52,7 @@ func main() {
 		panic(errors.New("required environment variable 'POD_NAME' not defined"))
 	}
 
-	dynamicClient := dynamic.NewForConfigOrDie(restConfig)
-
-	adaptor := eventsources.NewEventSourceAdaptor(kubeClient, dynamicClient, eventSource, busConfig, ebSubject, hostname)
+	adaptor := eventsources.NewEventSourceAdaptor(eventSource, busConfig, ebSubject, hostname)
 	logger := logging.NewArgoEventsLogger()
 	ctx := logging.WithLogger(context.Background(), logger)
 	stopCh := signals.SetupSignalHandler()

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/eventbus"
@@ -30,6 +28,7 @@ import (
 	"github.com/argoproj/argo-events/eventsources/sources/nats"
 	"github.com/argoproj/argo-events/eventsources/sources/nsq"
 	"github.com/argoproj/argo-events/eventsources/sources/redis"
+	"github.com/argoproj/argo-events/eventsources/sources/resource"
 	"github.com/argoproj/argo-events/eventsources/sources/slack"
 	"github.com/argoproj/argo-events/eventsources/sources/storagegrid"
 	"github.com/argoproj/argo-events/eventsources/sources/stripe"
@@ -206,16 +205,18 @@ func GetEventingServers(eventSource *v1alpha1.EventSource) map[apicommon.EventSo
 		}
 		result[apicommon.WebhookEvent] = servers
 	}
+	if len(eventSource.Spec.Resource) != 0 {
+		servers := []EventingServer{}
+		for k, v := range eventSource.Spec.Resource {
+			servers = append(servers, &resource.EventListener{EventSourceName: eventSource.Name, EventName: k, ResourceEventSource: v})
+		}
+		result[apicommon.ResourceEvent] = servers
+	}
 	return result
 }
 
 // EventSourceAdaptor is the adaptor for eventsource service
 type EventSourceAdaptor struct {
-	// kubeClient is the kubernetes client
-	kubeClient kubernetes.Interface
-	// clientPool manages a pool of dynamic clients.
-	dynamicClient dynamic.Interface
-
 	eventSource     *v1alpha1.EventSource
 	eventBusConfig  *eventbusv1alpha1.BusConfig
 	eventBusSubject string
@@ -225,10 +226,8 @@ type EventSourceAdaptor struct {
 }
 
 // NewEventSourceAdaptor returns a new EventSourceAdaptor
-func NewEventSourceAdaptor(kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, eventSource *v1alpha1.EventSource, eventBusConfig *eventbusv1alpha1.BusConfig, eventBusSubject, hostname string) *EventSourceAdaptor {
+func NewEventSourceAdaptor(eventSource *v1alpha1.EventSource, eventBusConfig *eventbusv1alpha1.BusConfig, eventBusSubject, hostname string) *EventSourceAdaptor {
 	return &EventSourceAdaptor{
-		kubeClient:      kubeClient,
-		dynamicClient:   dynamicClient,
 		eventSource:     eventSource,
 		eventBusConfig:  eventBusConfig,
 		eventBusSubject: eventBusSubject,

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 
 	"github.com/argoproj/argo-events/common/logging"
@@ -36,7 +37,6 @@ import (
 	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
 	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 // EventingServer is the server API for Eventing service.

--- a/eventsources/sources/resource/start.go
+++ b/eventsources/sources/resource/start.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2018 BlackRock, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/argoproj/argo-events/common"
+	"github.com/argoproj/argo-events/common/logging"
+	"github.com/argoproj/argo-events/eventsources/sources"
+	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
+	"github.com/argoproj/argo-events/pkg/apis/events"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+)
+
+// InformerEvent holds event generated from resource state change
+type InformerEvent struct {
+	Obj    interface{}
+	OldObj interface{}
+	Type   v1alpha1.ResourceEventType
+}
+
+// EventListener implements Eventing
+type EventListener struct {
+	EventSourceName     string
+	EventName           string
+	ResourceEventSource v1alpha1.ResourceEventSource
+}
+
+// GetEventSourceName returns name of event source
+func (el *EventListener) GetEventSourceName() string {
+	return el.EventSourceName
+}
+
+// GetEventName returns name of event
+func (el *EventListener) GetEventName() string {
+	return el.EventName
+}
+
+// GetEventSourceType return type of event server
+func (el *EventListener) GetEventSourceType() apicommon.EventSourceType {
+	return apicommon.ResourceEvent
+}
+
+// StartListening watches resource updates and consume those events
+func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byte) error) error {
+	log := logging.FromContext(ctx).WithFields(map[string]interface{}{
+		logging.LabelEventSourceType: el.GetEventSourceType(),
+		logging.LabelEventSourceName: el.GetEventSourceName(),
+		logging.LabelEventName:       el.GetEventName(),
+	})
+	log.Infoln("started processing the Redis event source...")
+	defer sources.Recover(el.GetEventName())
+
+	log.Infoln("setting up a K8s client")
+	kubeConfig, _ := os.LookupEnv(common.EnvVarKubeConfig)
+	restConfig, err := common.GetClientConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get a K8s rest config for the event source %s", el.GetEventName())
+	}
+	client, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set up a dynamic K8s client for the event source %s", el.GetEventName())
+	}
+
+	resourceEventSource := &el.ResourceEventSource
+
+	gvr := schema.GroupVersionResource{
+		Group:    resourceEventSource.Group,
+		Version:  resourceEventSource.Version,
+		Resource: resourceEventSource.Resource,
+	}
+
+	client.Resource(gvr)
+
+	options := &metav1.ListOptions{}
+
+	log.Infoln("configuring label selectors if filters are selected...")
+	if resourceEventSource.Filter != nil && resourceEventSource.Filter.Labels != nil {
+		sel, err := LabelSelector(resourceEventSource.Filter.Labels)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create the label selector for the event source %s", el.GetEventName())
+		}
+		options.LabelSelector = sel.String()
+	}
+
+	if resourceEventSource.Filter != nil && resourceEventSource.Filter.Fields != nil {
+		sel, err := FieldSelector(resourceEventSource.Filter.Fields)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create the field selector for the event source %s", el.GetEventName())
+		}
+		options.FieldSelector = sel.String()
+	}
+
+	tweakListOptions := func(op *metav1.ListOptions) {
+		*op = *options
+	}
+
+	log.Infoln("setting up informer factory...")
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(client, 0, resourceEventSource.Namespace, tweakListOptions)
+
+	informer := factory.ForResource(gvr)
+
+	informerEventCh := make(chan *InformerEvent)
+	stopCh := make(chan struct{})
+	startTime := time.Now()
+
+	go func() {
+		log.Infoln("listening to resource events...")
+		for {
+			select {
+			case event := <-informerEventCh:
+				objBody, err := json.Marshal(event.Obj)
+				if err != nil {
+					log.WithError(err).Errorln("failed to marshal the resource, rejecting the event...")
+					continue
+				}
+
+				eventData := &events.ResourceEventData{
+					EventType: string(event.Type),
+					Body:      (*json.RawMessage)(&objBody),
+					Group:     resourceEventSource.Group,
+					Version:   resourceEventSource.Version,
+					Resource:  resourceEventSource.Resource,
+				}
+				eventBody, err := json.Marshal(eventData)
+				if err != nil {
+					log.WithError(err).Errorln("failed to marshal the event. rejecting the event...")
+					continue
+				}
+				if !passFilters(event, resourceEventSource.Filter, startTime, log) {
+					continue
+				}
+				if err = dispatch(eventBody); err != nil {
+					log.WithError(err).Errorln("failed to dispatch event")
+				}
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	handlerFuncs := cache.ResourceEventHandlerFuncs{}
+
+	for _, eventType := range resourceEventSource.EventTypes {
+		switch eventType {
+		case v1alpha1.ADD:
+			handlerFuncs.AddFunc = func(obj interface{}) {
+				log.Infoln("detected create event")
+				informerEventCh <- &InformerEvent{
+					Obj:  obj,
+					Type: v1alpha1.ADD,
+				}
+			}
+		case v1alpha1.UPDATE:
+			handlerFuncs.UpdateFunc = func(oldObj, newObj interface{}) {
+				log.Infoln("detected update event")
+				informerEventCh <- &InformerEvent{
+					Obj:    newObj,
+					OldObj: oldObj,
+					Type:   v1alpha1.UPDATE,
+				}
+			}
+		case v1alpha1.DELETE:
+			handlerFuncs.DeleteFunc = func(obj interface{}) {
+				log.Infoln("detected delete event")
+				informerEventCh <- &InformerEvent{
+					Obj:  obj,
+					Type: v1alpha1.DELETE,
+				}
+			}
+		default:
+			stopCh <- struct{}{}
+			return errors.Errorf("unknown event type: %s", string(eventType))
+		}
+	}
+
+	sharedInformer := informer.Informer()
+	sharedInformer.AddEventHandler(handlerFuncs)
+
+	doneCh := make(chan struct{})
+
+	log.Infoln("running informer...")
+	sharedInformer.Run(doneCh)
+
+	<-ctx.Done()
+	doneCh <- struct{}{}
+	stopCh <- struct{}{}
+
+	log.Infoln("event source is stopped")
+	close(informerEventCh)
+
+	return nil
+}
+
+// LabelReq returns label requirements
+func LabelReq(sel v1alpha1.Selector) (*labels.Requirement, error) {
+	op := selection.Equals
+	if sel.Operation != "" {
+		op = selection.Operator(sel.Operation)
+	}
+	req, err := labels.NewRequirement(sel.Key, op, []string{sel.Value})
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// LabelSelector returns label selector for resource filtering
+func LabelSelector(selectors []v1alpha1.Selector) (labels.Selector, error) {
+	var labelRequirements []labels.Requirement
+	for _, sel := range selectors {
+		req, err := LabelReq(sel)
+		if err != nil {
+			return nil, err
+		}
+		labelRequirements = append(labelRequirements, *req)
+	}
+	return labels.NewSelector().Add(labelRequirements...), nil
+}
+
+// FieldSelector returns field selector for resource filtering
+func FieldSelector(selectors []v1alpha1.Selector) (fields.Selector, error) {
+	var result []fields.Selector
+	for _, sel := range selectors {
+		op := selection.Equals
+		if sel.Operation != "" {
+			op = selection.Operator(sel.Operation)
+		}
+		selector, err := fields.ParseSelector(fmt.Sprintf("%s%s%s", sel.Key, op, sel.Value))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, selector)
+	}
+	return fields.AndSelectors(result...), nil
+}
+
+// helper method to check if the object passed the user defined filters
+func passFilters(event *InformerEvent, filter *v1alpha1.ResourceFilter, startTime time.Time, log *logrus.Entry) bool {
+	// no filters are applied.
+	if filter == nil {
+		return true
+	}
+	uObj := event.Obj.(*unstructured.Unstructured)
+	if len(filter.Prefix) > 0 && !strings.HasPrefix(uObj.GetName(), filter.Prefix) {
+		log.Infof("resource name does not match prefix. resource-name: %s, prefix: %s\n", uObj.GetName(), filter.Prefix)
+		return false
+	}
+	created := uObj.GetCreationTimestamp()
+	if !filter.CreatedBy.IsZero() && created.UTC().After(filter.CreatedBy.UTC()) {
+		log.Infof("resource is created after filter time. creation-timestamp: %s, filter-creation-timestamp: %s\n", created.UTC().String(), filter.CreatedBy.UTC().String())
+		return false
+	}
+	if filter.AfterStart && created.UTC().Before(startTime.UTC()) {
+		log.Infof("resource is created before service start time. creation-timestamp: %s, start-timestamp: %s\n", created.UTC().String(), startTime.UTC().String())
+		return false
+	}
+	return true
+}

--- a/eventsources/sources/resource/start_test.go
+++ b/eventsources/sources/resource/start_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 BlackRock, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/smartystreets/goconvey/convey"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/argoproj/argo-events/common/logging"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+)
+
+func TestFilter(t *testing.T) {
+	convey.Convey("Given a resource object, apply filter on it", t, func() {
+		resourceEventSource := &v1alpha1.ResourceEventSource{
+			Namespace: "fake",
+			GroupVersionResource: metav1.GroupVersionResource{
+				Group:    "",
+				Resource: "pods",
+				Version:  "v1",
+			},
+			Filter: &v1alpha1.ResourceFilter{
+				Labels: []v1alpha1.Selector{
+					{
+						Key:       "workflows.argoproj.io/phase",
+						Operation: "==",
+						Value:     "Succeeded",
+					},
+					{
+						Key:       "name",
+						Operation: "==",
+						Value:     "my-workflow",
+					},
+				},
+			},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake",
+				Namespace: "fake",
+				Labels: map[string]string{
+					"workflows.argoproj.io/phase": "Succeeded",
+					"name":                        "my-workflow",
+				},
+			},
+		}
+		pod, err := fake.NewSimpleClientset().CoreV1().Pods("fake").Create(pod)
+		convey.So(err, convey.ShouldBeNil)
+
+		outmap := make(map[string]interface{})
+		err = mapstructure.Decode(pod, &outmap)
+		convey.So(err, convey.ShouldBeNil)
+
+		pass := passFilters(&InformerEvent{
+			Obj:  &unstructured.Unstructured{Object: outmap},
+			Type: "ADD",
+		}, resourceEventSource.Filter, time.Now(), logging.NewArgoEventsLogger().WithField("a", "b"))
+		convey.So(pass, convey.ShouldBeTrue)
+	})
+}

--- a/eventsources/sources/resource/validate.go
+++ b/eventsources/sources/resource/validate.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 BlackRock, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/selection"
+
+	"github.com/argoproj/argo-events/common"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+)
+
+// ValidateEventSource validates a resource event source
+func (listener *EventListener) ValidateEventSource(ctx context.Context) error {
+	return validate(&listener.ResourceEventSource)
+}
+
+func validate(eventSource *v1alpha1.ResourceEventSource) error {
+	if eventSource == nil {
+		return common.ErrNilEventSource
+	}
+	if eventSource.Version == "" {
+		return fmt.Errorf("version must be specified")
+	}
+	if eventSource.Resource == "" {
+		return fmt.Errorf("resource must be specified")
+	}
+	if eventSource.EventTypes == nil {
+		return fmt.Errorf("event types must be specified")
+	}
+	if eventSource.Filter != nil {
+		if eventSource.Filter.Labels != nil {
+			if err := validateSelectors(eventSource.Filter.Labels); err != nil {
+				return err
+			}
+		}
+		if eventSource.Filter.Fields != nil {
+			if err := validateSelectors(eventSource.Filter.Fields); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateSelectors(selectors []v1alpha1.Selector) error {
+	for _, sel := range selectors {
+		if sel.Key == "" {
+			return fmt.Errorf("key can't be empty for selector")
+		}
+		if sel.Operation == "" {
+			continue
+		}
+		if selection.Operator(sel.Operation) == "" {
+			return fmt.Errorf("unknown selection operation %s", sel.Operation)
+		}
+	}
+	return nil
+}

--- a/eventsources/sources/resource/validate_test.go
+++ b/eventsources/sources/resource/validate_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 BlackRock, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-events/eventsources/sources"
+	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+)
+
+func TestValidateEventSource(t *testing.T) {
+	listener := &EventListener{}
+
+	err := listener.ValidateEventSource(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, "version must be specified", err.Error())
+
+	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "resource.yaml"))
+	assert.Nil(t, err)
+
+	var eventSource *v1alpha1.EventSource
+	err = yaml.Unmarshal(content, &eventSource)
+	assert.Nil(t, err)
+	assert.NotNil(t, eventSource.Spec.Resource)
+
+	for name, value := range eventSource.Spec.Resource {
+		fmt.Println(name)
+		l := &EventListener{
+			ResourceEventSource: value,
+		}
+		err := l.ValidateEventSource(context.Background())
+		assert.NoError(t, err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/minio/minio-go v1.0.1-0.20190523192347-c6c2912aa552
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.3.0 // indirect
+	github.com/mitchellh/mapstructure v1.3.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/nats-io/gnatsd v1.4.1 // indirect
 	github.com/nats-io/go-nats v1.7.2

--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -57,6 +57,7 @@ var (
 		MQTTEvent,
 		EmitterEvent,
 		NSQEvent,
+		ResourceEvent,
 	}
 )
 

--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -55,6 +55,8 @@ var (
 		AzureEventsHub,
 		NATSEvent,
 		MQTTEvent,
+		EmitterEvent,
+		NSQEvent,
 	}
 )
 

--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -46,6 +46,17 @@ var (
 	GenericEvent     EventSourceType = "generic"
 )
 
+var (
+	// RecreateStrategyEventSources refers to the list of event source types
+	// that need to use Recreate strategy for its Deployment
+	RecreateStrategyEventSources = []EventSourceType{
+		KafkaEvent,
+		PubSubEvent,
+		AzureEventsHub,
+		NATSEvent,
+	}
+)
+
 // EventBusType is the type of event bus
 type EventBusType string
 

--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -54,6 +54,7 @@ var (
 		PubSubEvent,
 		AzureEventsHub,
 		NATSEvent,
+		MQTTEvent,
 	}
 )
 


### PR DESCRIPTION
1.  Use `recreate` strategy for some of the eventsources deployment update.
2. Now EventSource allows multiple types of sources defined in one spec, following the rules:
    a.) **Event source with `rollingUpdate` and `recreate` are not allowed in one EventSource object** - Otherwise when the EventSource is updated, there will be downtime for those `rollingUpdate` type event sources such as `webhook`.
    b.) **Event name (the map key) needs to be unique in one EventSource object, even different type of event source can not use same name** - Because we use EventSourceName and EventName in Sensor as dependency.
    c.) `rollingUpdate` types use replicas defined in the spec, defaults to 1;
    d.) `recreate` ignores replica field in the spec, it always uses `1`
3. **Added missing `Resource` type EventSource.**
4. Fixed a bug for `HDFS` event source - a bug of `configMapSelector` to `envFrom` conversion.
5. Added eventsource-controller test cases.

Closes #752 