### PR TITLE
Update docs

### DIFF
--- a/docs/setup/resource.md
+++ b/docs/setup/resource.md
@@ -59,7 +59,7 @@ The structure of an event dispatched by the gateway to the sensor looks like fol
         metadata:
           name: my-workflow
           labels:
-            name: my-workflow
+            app: my-workflow
         spec:
           entrypoint: whalesay
           templates:


### PR DESCRIPTION
Stumbled upon this as I was running the example. The example workflow doesn't actually trigger the event source, because the label is wrong. This fixes it.