### PR TITLE
chore: Change environment section in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,10 +21,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. macOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
+ - Kubernetes: [e.g. v1.18.6]
+ - Argo: [e.g. v2.9.4]
+ - Argo Events: [e.g. v0.17.0]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Currently, the bug report template requests information about OS and browser. I am not sure that information is useful. I think providing Kubernetes, argo, and argo-events versions would be more appropriate for bug reports.