### PR TITLE
feat: Connect to git with InsecureIgnoreHostKey. Closes #841

### DIFF
--- a/examples/sensors/trigger-source-git.yaml
+++ b/examples/sensors/trigger-source-git.yaml
@@ -10,19 +10,11 @@ spec:
           name: argoproj
         - mountPath: /git/argoproj1
           name: argoproj1
-        - mountPath: /etc/ssh
-          name: known-hosts
     volumes:
       - name: argoproj
         emptyDir: {}
       - name: argoproj1
         emptyDir: {}
-      # The name of the key in the secret must be "ssh_known_hosts"
-      # Make sure you have your git provider added in the known hosts
-      # e.g. create the secret by running, kubectl -n argo-events create secret generic git-known-hosts --from-file=ssh_known_hosts=.ssh/known_hosts
-      - name: known-hosts
-        secret:
-          secretName: git-known-hosts
     serviceAccountName: argo-events-sa
   dependencies:
     - name: test-dep
@@ -63,6 +55,5 @@ spec:
               sshKeySecret:
                 name: git-ssh
                 key: key
-              namespace: argo-events
               filePath: "examples/hello-world.yaml"
               branch: "master"

--- a/store/git.go
+++ b/store/git.go
@@ -64,7 +64,6 @@ func (g *GitArtifactReader) getRemote() string {
 }
 
 func getSSHKeyAuth(sshKeyFile string) (transport.AuthMethod, error) {
-	var auth transport.AuthMethod
 	sshKey, err := ioutil.ReadFile(sshKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ssh key file. err: %+v", err)
@@ -73,7 +72,8 @@ func getSSHKeyAuth(sshKeyFile string) (transport.AuthMethod, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ssh key. err: %+v", err)
 	}
-	auth = &go_git_ssh.PublicKeys{User: "git", Signer: signer}
+	auth := &go_git_ssh.PublicKeys{User: "git", Signer: signer}
+	auth.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 	return auth, nil
 }
 

--- a/store/url.go
+++ b/store/url.go
@@ -2,9 +2,10 @@ package store
 
 import (
 	"crypto/tls"
-	"errors"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
@@ -41,7 +42,7 @@ func (reader *URLReader) Read() ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Warnf("failed to read %s. status code: %d", reader.urlArtifact.Path, resp.StatusCode)
-		return nil, errors.New("status code " + string(resp.StatusCode))
+		return nil, errors.Errorf("status code %v", resp.StatusCode)
 	}
 
 	content, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Don't need to mount `~/.ssh/known_hosts` to the POD any more to pull resources from git with `git://xxxxx`.

Closes #841