### PR TITLE
feat: Implemented Exact Once triggering for NATS event bus

### DIFF
--- a/docs/eventsources/naming.md
+++ b/docs/eventsources/naming.md
@@ -9,7 +9,7 @@ dependencies:
     eventName: example
 ```
 
-The `eventSourceName` ad `eventName` might be confusing. Take the following
+The `eventSourceName` and `eventName` might be confusing. Take the following
 EventSource example, the `eventSourceName` and `eventName` are described as
 below.
 

--- a/docs/webhook-authentication.md
+++ b/docs/webhook-authentication.md
@@ -25,16 +25,16 @@ Then add `authSecret` to your `webhook` EventSource.
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:
-name: webhook
+  name: webhook
 spec:
-webhook:
-  example:
-  port: "12000"
-  endpoint: /example
-  method: POST
-  authSecret:
-    name: my-webhook-token
-    key: my-token
+  webhook:
+    example:
+      port: "12000"
+      endpoint: /example
+      method: POST
+      authSecret:
+        name: my-webhook-token
+        key: my-token
 ```
 
 Now you can authenticate your webhook endpoint with the configured token.

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -327,7 +327,7 @@ type eventSourceMessageHolder struct {
 	sourceDepMap map[string]string
 	parameters   map[string]interface{}
 	msgs         map[string]*eventSourceMessage
-	// A sync map used to stop the message ID and ack time, it is used to guarantee Exact Once triggering
+	// A sync map used to cache the message IDs, it is used to guarantee Exact Once triggering
 	smap *sync.Map
 }
 

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -149,7 +149,7 @@ func (n *natsStreaming) SubscribeEventSources(ctx context.Context, conn Connecti
 		n.processEventSourceMsg(m, msgHolder, filter, action, log)
 	}, stan.DurableName(durableName),
 		stan.SetManualAckMode(),
-		stan.StartAt(pb.StartPosition_LastReceived),
+		stan.StartAt(pb.StartPosition_NewOnly),
 		stan.AckWait(3*time.Second),
 		stan.MaxInflight(len(msgHolder.depNames)+2))
 	if err != nil {

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -180,7 +180,7 @@ func (n *natsStreaming) SubscribeEventSources(ctx context.Context, conn Connecti
 					if now-v > 5*60*1000*1000*1000 {
 						msgHolder.smap.Delete(key)
 						num++
-						log.Debugw("cached ID evicted", "ID", key)
+						log.Debugw("cached ID evicted", "id", key)
 					}
 					return true
 				})

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -150,7 +150,7 @@ func (n *natsStreaming) SubscribeEventSources(ctx context.Context, conn Connecti
 	}, stan.DurableName(durableName),
 		stan.SetManualAckMode(),
 		stan.StartAt(pb.StartPosition_NewOnly),
-		stan.AckWait(3*time.Second),
+		stan.AckWait(1*time.Second),
 		stan.MaxInflight(len(msgHolder.depNames)+2))
 	if err != nil {
 		log.Errorf("failed to subscribe to subject %s", n.subject)

--- a/eventbus/driver/nats.go
+++ b/eventbus/driver/nats.go
@@ -379,7 +379,7 @@ func (mh *eventSourceMessageHolder) getDependencyName(eventSourceName, eventName
 	return "", nil
 }
 
-// Ack the stan message and cache the ID  to make sure Exact Once triggering
+// Ack the stan message and cache the ID to make sure Exact Once triggering
 func (mh *eventSourceMessageHolder) ackAndCache(m *stan.Msg, id string) {
 	_ = m.Ack()
 	mh.smap.Store(id, time.Now().UnixNano())

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -36,6 +36,7 @@ import (
 	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
 	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -284,7 +285,7 @@ func (e *EventSourceAdaptor) Start(ctx context.Context, stopCh <-chan struct{}) 
 						logger.Error("failed to reconnect to eventbus", zap.Error(err))
 						continue
 					}
-					logger.Info("reconnected the NATS streaming server...")
+					logger.Info("reconnected to eventbus successfully")
 				}
 			}
 		}


### PR DESCRIPTION
The change implemented an in-memory cache for acked message IDs, it is used to make sure acked IDs will not make any impact on the triggering.

Closes #850 
Closes #853 