### PR TITLE
feat:  kafka multiple-broker support. Closes #892

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -1895,7 +1895,7 @@ string
 </em>
 </td>
 <td>
-<p>URL to kafka cluster</p>
+<p>URL to kafka cluster, multiple URLs separated by comma</p>
 </td>
 </tr>
 <tr>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -3607,7 +3607,7 @@ Description
 
 <p>
 
-URL to kafka cluster
+URL to kafka cluster, multiple URLs separated by comma
 
 </p>
 

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1061,7 +1061,7 @@
           "type": "string"
         },
         "url": {
-          "description": "URL to kafka cluster",
+          "description": "URL to kafka cluster, multiple URLs separated by comma",
           "type": "string"
         },
         "version": {

--- a/eventsources/sources/kafka/start.go
+++ b/eventsources/sources/kafka/start.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -106,7 +107,8 @@ func (listener *EventListener) consumerGroupConsumer(ctx context.Context, log *z
 		kafkaEventSource: kafkaEventSource,
 	}
 
-	client, err := sarama.NewConsumerGroup([]string{kafkaEventSource.URL}, kafkaEventSource.ConsumerGroup.GroupName, config)
+	urls := strings.Split(kafkaEventSource.URL, ",")
+	client, err := sarama.NewConsumerGroup(urls, kafkaEventSource.ConsumerGroup.GroupName, config)
 	if err != nil {
 		log.Errorf("Error creating consumer group client: %v", err)
 		return err
@@ -163,7 +165,8 @@ func (el *EventListener) partitionConsumer(ctx context.Context, log *zap.Sugared
 			return err
 		}
 
-		consumer, err = sarama.NewConsumer([]string{kafkaEventSource.URL}, config)
+		urls := strings.Split(kafkaEventSource.URL, ",")
+		consumer, err = sarama.NewConsumer(urls, config)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/eventsource/v1alpha1/generated.proto
+++ b/pkg/apis/eventsource/v1alpha1/generated.proto
@@ -427,7 +427,7 @@ message KafkaConsumerGroup {
 
 // KafkaEventSource refers to event-source for Kafka related events
 message KafkaEventSource {
-  // URL to kafka cluster
+  // URL to kafka cluster, multiple URLs separated by comma
   optional string url = 1;
 
   // Partition name

--- a/pkg/apis/eventsource/v1alpha1/openapi_generated.go
+++ b/pkg/apis/eventsource/v1alpha1/openapi_generated.go
@@ -1308,7 +1308,7 @@ func schema_pkg_apis_eventsource_v1alpha1_KafkaEventSource(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL to kafka cluster",
+							Description: "URL to kafka cluster, multiple URLs separated by comma",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -294,7 +294,7 @@ type AMQPEventSource struct {
 
 // KafkaEventSource refers to event-source for Kafka related events
 type KafkaEventSource struct {
-	// URL to kafka cluster
+	// URL to kafka cluster, multiple URLs separated by comma
 	URL string `json:"url" protobuf:"bytes,1,opt,name=url"`
 	// Partition name
 	Partition string `json:"partition" protobuf:"bytes,2,opt,name=partition"`


### PR DESCRIPTION
Extend kafka URL to support multiple brokers, separated by comma.

```
pec:
  kafka:
    example:
      # kafka broker url
      url: kafka1.argo-events:9092,kafka2.argo-events:9092
```

Closes #892