### PR TITLE
docs: Add GitHub and GitLab example event-source yaml.

### DIFF
--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -24,7 +24,8 @@ The structure of an event dispatched by the event-source over the eventbus looks
 
 ## Specification
 
-GitHub event-source specification is available [here](https://github.com/argoproj/argo-events/blob/master/api/event-source.md#githubeventsource).
+GitHub event-source specification is available [here](https://github.com/argoproj/argo-events/blob/master/api/event-source.md#githubeventsource). <br />
+Example event-source yaml file is [here](https://github.com/argoproj/argo-events/blob/master/examples/event-sources/github.yaml).
 
 ## Setup
 

--- a/docs/setup/gitlab.md
+++ b/docs/setup/gitlab.md
@@ -24,7 +24,8 @@ The structure of an event dispatched by the event-source over the eventbus looks
 
 ## Specification
 
-GitLab event-source specification is available [here](https://github.com/argoproj/argo-events/blob/master/api/event-source.md#gitlabeventsource).
+GitLab event-source specification is available [here](https://github.com/argoproj/argo-events/blob/master/api/event-source.md#gitlabeventsource). <br />
+Example event-source yaml file is [here](https://github.com/argoproj/argo-events/blob/master/examples/event-sources/gitlab.yaml).
 
 ## Setup
 


### PR DESCRIPTION
Checklist:

* [x] (c) this is a chore.
* [x] The title of the PR is (b) states what changed
* [x] I've signed the CLA.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

I take more time when my first setup GitLab event-source without the YAML example. But I found an event-sources tutorial. I think others have the same problem.