### PR TITLE
fix(amqp): Return error when channel is closed. Fixes #920

### DIFF
--- a/eventsources/sources/amqp/start.go
+++ b/eventsources/sources/amqp/start.go
@@ -108,8 +108,8 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 		select {
 		case msg, ok := <-delivery:
 			if !ok {
-				log.Error("failed to read message from amqp channel, channel closed")
-				return errors.New("channel closed")
+				log.Error("failed to read a message, channel might have been closed")
+				return errors.New("channel might have been closed")
 			}
 			log.Info("received the message", zap.Any("message-id", msg.MessageId))
 			body := &events.AMQPEventData{

--- a/eventsources/sources/amqp/start.go
+++ b/eventsources/sources/amqp/start.go
@@ -106,7 +106,11 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 	log.Info("listening to messages on channel...")
 	for {
 		select {
-		case msg := <-delivery:
+		case msg, ok := <-delivery:
+			if !ok {
+				log.Error("failed to read message from amqp channel, channel closed")
+				return errors.New("channel closed")
+			}
 			log.Info("received the message", zap.Any("message-id", msg.MessageId))
 			body := &events.AMQPEventData{
 				ContentType:     msg.ContentType,


### PR DESCRIPTION
When connection/channel is closed, it keeps reading empty messages from the channel without checking if it's successful.

Checklist:

* [x] Either (a) I've created an [feature request](https://github.com/argoproj/argo-events/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Fixes #920