### PR TITLE
feat: Retry starting event server and quick fail. Closes #926

### DIFF
--- a/common/retry.go
+++ b/common/retry.go
@@ -30,7 +30,7 @@ var DefaultRetry = wait.Backoff{
 	Steps:    5,
 	Duration: 1 * time.Second,
 	Factor:   1.0,
-	Jitter:   5,
+	Jitter:   1,
 }
 
 // IsRetryableKubeAPIError returns if the error is a retryable kubernetes error

--- a/common/retry.go
+++ b/common/retry.go
@@ -28,9 +28,9 @@ import (
 // DefaultRetry is a default retry backoff settings when retrying API calls
 var DefaultRetry = wait.Backoff{
 	Steps:    5,
-	Duration: 10 * time.Millisecond,
+	Duration: 1 * time.Second,
 	Factor:   1.0,
-	Jitter:   0.1,
+	Jitter:   5,
 }
 
 // IsRetryableKubeAPIError returns if the error is a retryable kubernetes error


### PR DESCRIPTION
1. Retry initial EventBus connection;
2. Retry starting eventing servers;
3. Panic EventSource POD if there's no active eventing servers(failed after retry)


Checklist:

* [x] Either (a) I've created an [feature request](https://github.com/argoproj/argo-events/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed the CLA.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Closes #926 