### PR TITLE
fix: documentation - Adding `channels:read` permission to Slack Trigger Documentation

### DIFF
--- a/docs/triggers/slack-trigger.md
+++ b/docs/triggers/slack-trigger.md
@@ -23,7 +23,7 @@ We need to create a Slack App which will send messages to your Slack Workspace. 
 
 2. Navigate to your app, then to `Features > OAuth & Permissions`
 
-3. Scroll down to `Scopes` and add the scopes `channels:join`, and `chat:write`
+3. Scroll down to `Scopes` and add the scopes `channels:join`, `channels:read` and `chat:write`
 
 4. Scroll to the top of the `OAuth & Permissions` page and click `Install App to Workspace` and follow the install Wizard
 

--- a/docs/triggers/slack-trigger.md
+++ b/docs/triggers/slack-trigger.md
@@ -23,7 +23,7 @@ We need to create a Slack App which will send messages to your Slack Workspace. 
 
 2. Navigate to your app, then to `Features > OAuth & Permissions`
 
-3. Scroll down to `Scopes` and add the scopes `channels:join`, `channels:read` and `chat:write`
+3. Scroll down to `Scopes` and add the scopes `channels:join`, `channels:read` and `chat:write` to the _Bot Token Scopes_
 
 4. Scroll to the top of the `OAuth & Permissions` page and click `Install App to Workspace` and follow the install Wizard
 

--- a/examples/event-sources/mqtt.yaml
+++ b/examples/event-sources/mqtt.yaml
@@ -13,7 +13,7 @@ spec:
       # source will be JSON
       jsonBody: true
       # client id
-      clientId: 2345
+      clientId: "2345"
       # optional backoff time for connection retries.
       # if not provided, default connection backoff time will be used.
       connectionBackoff:
@@ -30,7 +30,7 @@ spec:
 #      url: "tcp://mqtt.argo-events:1883"
 #      topic: "bar"
 #      jsonBody: true
-#      clientId: 2345
+#      clientId: "2345"
 #      tls:
 #        caCertSecret:
 #          name: my-secret


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md). - Not Applicable for now.

Resolves: https://github.com/argoproj/argo-events/issues/942

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
