### PR TITLE
fix(eventsource/resource): return entire event object instead of just event.obj

### DIFF
--- a/eventsources/sources/resource/start.go
+++ b/eventsources/sources/resource/start.go
@@ -129,7 +129,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 		for {
 			select {
 			case event := <-informerEventCh:
-				objBody, err := json.Marshal(event.Obj)
+				objBody, err := json.Marshal(event)
 				if err != nil {
 					log.Desugar().Error("failed to marshal the resource, rejecting the event...", zap.Error(err))
 					continue


### PR DESCRIPTION
return entire event object instead of just event.obj

Signed-off-by: Scott Weitzner <scottweitzner@gmail.com>

Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
