### PR TITLE
docs: fix minor typos for http trigger

### DIFF
--- a/docs/triggers/http-trigger.md
+++ b/docs/triggers/http-trigger.md
@@ -82,8 +82,8 @@ We will set up a basic go http server and connect it with the minio events.
 
 ### Request Payload
 
-In order to construct a request payload based on the event data, sensor offers 
-`payload` field as a part of the HTP trigger.
+In order to construct a request payload based on the event data, the sensor offers 
+`payload` field as a part of the HTTP trigger.
 
 Let's examine a HTTP trigger,
 


### PR DESCRIPTION
Fixes a couple minor typos I noticed while looking through the http trigger docs.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
