### PR TITLE
feat: use status resources for controller reconciliation. Closes #1029

### DIFF
--- a/controllers/eventbus/controller.go
+++ b/controllers/eventbus/controller.go
@@ -7,9 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/argoproj/argo-events/controllers/eventbus/installer"
@@ -44,19 +44,22 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			r.logger.Warnw("WARNING: eventbus not found", "request", req)
 			return reconcile.Result{}, nil
 		}
-		r.logger.Errorw("unable to get eventbus ctl", "request", req, "error", err)
+		r.logger.Errorw("unable to get eventbus ctl", zap.Any("request", req), zap.Error(err))
 		return ctrl.Result{}, err
 	}
 	log := r.logger.With("namespace", eventBus.Namespace).With("eventbus", eventBus.Name)
 	busCopy := eventBus.DeepCopy()
 	reconcileErr := r.reconcile(ctx, busCopy)
 	if reconcileErr != nil {
-		log.Desugar().Error("reconcile error", zap.Error(reconcileErr))
+		log.Errorw("reconcile error", zap.Error(reconcileErr))
 	}
 	if r.needsUpdate(eventBus, busCopy) {
 		if err := r.client.Update(ctx, busCopy); err != nil {
 			return reconcile.Result{}, err
 		}
+	}
+	if err := r.client.Status().Update(ctx, busCopy); err != nil {
+		return reconcile.Result{}, err
 	}
 	return ctrl.Result{}, reconcileErr
 }
@@ -66,38 +69,24 @@ func (r *reconciler) reconcile(ctx context.Context, eventBus *v1alpha1.EventBus)
 	log := r.logger.With("namespace", eventBus.Namespace).With("eventbus", eventBus.Name)
 	if !eventBus.DeletionTimestamp.IsZero() {
 		log.Info("deleting eventbus")
-		// Finalizer logic should be added here.
-		err := installer.Uninstall(eventBus, r.client, r.natsStreamingImage, r.natsMetricsImage, log)
-		if err != nil {
-			log.Errorw("failed to uninstall", "error", err)
-			return nil
+		if controllerutil.ContainsFinalizer(eventBus, finalizerName) {
+			// Finalizer logic should be added here.
+			if err := installer.Uninstall(eventBus, r.client, r.natsStreamingImage, r.natsMetricsImage, log); err != nil {
+				log.Errorw("failed to uninstall", zap.Error(err))
+				return nil
+			}
+			controllerutil.RemoveFinalizer(eventBus, finalizerName)
 		}
-		r.removeFinalizer(eventBus)
 		return nil
 	}
-	r.addFinalizer(eventBus)
+	controllerutil.AddFinalizer(eventBus, finalizerName)
 
 	eventBus.Status.InitConditions()
 	return installer.Install(eventBus, r.client, r.natsStreamingImage, r.natsMetricsImage, log)
 }
 
-func (r *reconciler) addFinalizer(s *v1alpha1.EventBus) {
-	finalizers := sets.NewString(s.Finalizers...)
-	finalizers.Insert(finalizerName)
-	s.Finalizers = finalizers.List()
-}
-
-func (r *reconciler) removeFinalizer(s *v1alpha1.EventBus) {
-	finalizers := sets.NewString(s.Finalizers...)
-	finalizers.Delete(finalizerName)
-	s.Finalizers = finalizers.List()
-}
-
 func (r *reconciler) needsUpdate(old, new *v1alpha1.EventBus) bool {
 	if old == nil {
-		return true
-	}
-	if !equality.Semantic.DeepEqual(old.Status, new.Status) {
 		return true
 	}
 	if !equality.Semantic.DeepEqual(old.Finalizers, new.Finalizers) {

--- a/controllers/eventbus/controller_test.go
+++ b/controllers/eventbus/controller_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
@@ -122,10 +123,10 @@ func TestNeedsUpdate(t *testing.T) {
 			logger:             logging.NewArgoEventsLogger(),
 		}
 		assert.False(t, r.needsUpdate(nativeBus, testBus))
-		r.addFinalizer(testBus)
+		controllerutil.AddFinalizer(testBus, finalizerName)
 		assert.True(t, contains(testBus.Finalizers, finalizerName))
 		assert.True(t, r.needsUpdate(nativeBus, testBus))
-		r.removeFinalizer(testBus)
+		controllerutil.RemoveFinalizer(testBus, finalizerName)
 		assert.False(t, contains(testBus.Finalizers, finalizerName))
 		assert.False(t, r.needsUpdate(nativeBus, testBus))
 		testBus.Status.MarkConfigured()

--- a/controllers/eventbus/controller_test.go
+++ b/controllers/eventbus/controller_test.go
@@ -130,7 +130,7 @@ func TestNeedsUpdate(t *testing.T) {
 		assert.False(t, contains(testBus.Finalizers, finalizerName))
 		assert.False(t, r.needsUpdate(nativeBus, testBus))
 		testBus.Status.MarkConfigured()
-		assert.True(t, r.needsUpdate(nativeBus, testBus))
+		assert.False(t, r.needsUpdate(nativeBus, testBus))
 	})
 }
 

--- a/controllers/eventsource/cmd/main.go
+++ b/controllers/eventsource/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -10,9 +11,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	argoevents "github.com/argoproj/argo-events"
@@ -59,54 +62,68 @@ func main() {
 	}
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), opts)
 	if err != nil {
-		logger.Desugar().Fatal("unable to get a controller-runtime manager", zap.Error(err))
+		logger.Fatalw("unable to get a controller-runtime manager", zap.Error(err))
 	}
 	err = v1alpha1.AddToScheme(mgr.GetScheme())
 	if err != nil {
-		logger.Desugar().Fatal("unable to add EventSource scheme", zap.Error(err))
+		logger.Fatalw("unable to add EventSource scheme", zap.Error(err))
 	}
 
 	// Readyness probe
 	err = mgr.AddReadyzCheck("readiness", healthz.Ping)
 	if err != nil {
-		logger.Desugar().Fatal("unable add a readiness check", zap.Error(err))
+		logger.Fatalw("unable add a readiness check", zap.Error(err))
 	}
 
 	// Liveness probe
 	err = mgr.AddHealthzCheck("liveness", healthz.Ping)
 	if err != nil {
-		logger.Desugar().Fatal("unable add a health check", zap.Error(err))
+		logger.Fatalw("unable add a health check", zap.Error(err))
 	}
 
 	err = eventbusv1alpha1.AddToScheme(mgr.GetScheme())
 	if err != nil {
-		logger.Desugar().Fatal("unable to add EventBus scheme", zap.Error(err))
+		logger.Fatalw("unable to add EventBus scheme", zap.Error(err))
 	}
 	// A controller with DefaultControllerRateLimiter
 	c, err := controller.New(eventsource.ControllerName, mgr, controller.Options{
 		Reconciler: eventsource.NewReconciler(mgr.GetClient(), mgr.GetScheme(), eventSourceImage, logger),
 	})
 	if err != nil {
-		logger.Desugar().Fatal("unable to set up individual controller", zap.Error(err))
+		logger.Fatalw("unable to set up individual controller", zap.Error(err))
 	}
 
 	// Watch EventSource and enqueue EventSource object key
-	if err := c.Watch(&source.Kind{Type: &v1alpha1.EventSource{}}, &handler.EnqueueRequestForObject{}); err != nil {
-		logger.Desugar().Fatal("unable to watch EventSources", zap.Error(err))
+	if err := c.Watch(&source.Kind{Type: &v1alpha1.EventSource{}}, &handler.EnqueueRequestForObject{},
+		predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			// TODO: change to use LabelChangedPredicate with controller-runtime v0.8
+			predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if e.ObjectOld == nil {
+						return false
+					}
+					if e.ObjectNew == nil {
+						return false
+					}
+					return !reflect.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels())
+				}},
+		)); err != nil {
+		logger.Fatalw("unable to watch EventSources", zap.Error(err))
 	}
 
 	// Watch Deployments and enqueue owning EventSource key
-	if err := c.Watch(&source.Kind{Type: &appv1.Deployment{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.EventSource{}, IsController: true}); err != nil {
-		logger.Desugar().Fatal("unable to watch Deployments", zap.Error(err))
+	if err := c.Watch(&source.Kind{Type: &appv1.Deployment{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.EventSource{}, IsController: true}, predicate.GenerationChangedPredicate{}); err != nil {
+		logger.Fatalw("unable to watch Deployments", zap.Error(err))
 	}
 
 	// Watch Services and enqueue owning EventSource key
-	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.EventSource{}, IsController: true}); err != nil {
-		logger.Desugar().Fatal("unable to watch Services", zap.Error(err))
+	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.EventSource{}, IsController: true}, predicate.GenerationChangedPredicate{}); err != nil {
+		logger.Fatalw("unable to watch Services", zap.Error(err))
 	}
 
 	logger.Infow("starting eventsource controller", "version", argoevents.GetVersion())
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		logger.Desugar().Fatal("unable to run eventsource controller", zap.Error(err))
+		logger.Fatalw("unable to run eventsource controller", zap.Error(err))
 	}
 }

--- a/controllers/sensor/cmd/main.go
+++ b/controllers/sensor/cmd/main.go
@@ -19,15 +19,18 @@ package main
 import (
 	"flag"
 	"os"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	appv1 "k8s.io/api/apps/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	argoevents "github.com/argoproj/argo-events"
@@ -74,49 +77,63 @@ func main() {
 	}
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), opts)
 	if err != nil {
-		logger.Desugar().Fatal("unable to get a controller-runtime manager", zap.Error(err))
+		logger.Fatalw("unable to get a controller-runtime manager", zap.Error(err))
 	}
 
 	// Readyness probe
 	err = mgr.AddReadyzCheck("readiness", healthz.Ping)
 	if err != nil {
-		logger.Desugar().Fatal("unable add a readiness check", zap.Error(err))
+		logger.Fatalw("unable add a readiness check", zap.Error(err))
 	}
 
 	// Liveness probe
 	err = mgr.AddHealthzCheck("liveness", healthz.Ping)
 	if err != nil {
-		logger.Desugar().Fatal("unable add a health check", zap.Error(err))
+		logger.Fatalw("unable add a health check", zap.Error(err))
 	}
 
 	err = v1alpha1.AddToScheme(mgr.GetScheme())
 	if err != nil {
-		logger.Desugar().Fatal("unable to add Sensor scheme", zap.Error(err))
+		logger.Fatalw("unable to add Sensor scheme", zap.Error(err))
 	}
 	err = eventbusv1alpha1.AddToScheme(mgr.GetScheme())
 	if err != nil {
-		logger.Desugar().Fatal("uunable to add EventBus scheme", zap.Error(err))
+		logger.Fatalw("uunable to add EventBus scheme", zap.Error(err))
 	}
 	// A controller with DefaultControllerRateLimiter
 	c, err := controller.New(sensor.ControllerName, mgr, controller.Options{
 		Reconciler: sensor.NewReconciler(mgr.GetClient(), mgr.GetScheme(), sensorImage, logger),
 	})
 	if err != nil {
-		logger.Desugar().Fatal("unable to set up individual controller", zap.Error(err))
+		logger.Fatalw("unable to set up individual controller", zap.Error(err))
 	}
 
 	// Watch Sensor and enqueue Sensor object key
-	if err := c.Watch(&source.Kind{Type: &v1alpha1.Sensor{}}, &handler.EnqueueRequestForObject{}); err != nil {
-		logger.Desugar().Fatal("unable to watch Sensors", zap.Error(err))
+	if err := c.Watch(&source.Kind{Type: &v1alpha1.Sensor{}}, &handler.EnqueueRequestForObject{},
+		predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			// TODO: change to use LabelChangedPredicate with controller-runtime v0.8
+			predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if e.ObjectOld == nil {
+						return false
+					}
+					if e.ObjectNew == nil {
+						return false
+					}
+					return !reflect.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels())
+				}},
+		)); err != nil {
+		logger.Fatalw("unable to watch Sensors", zap.Error(err))
 	}
 
 	// Watch Deployments and enqueue owning Sensor key
-	if err := c.Watch(&source.Kind{Type: &appv1.Deployment{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.Sensor{}, IsController: true}); err != nil {
-		logger.Desugar().Fatal("unable to watch Deployments", zap.Error(err))
+	if err := c.Watch(&source.Kind{Type: &appv1.Deployment{}}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.Sensor{}, IsController: true}, predicate.GenerationChangedPredicate{}); err != nil {
+		logger.Fatalw("unable to watch Deployments", zap.Error(err))
 	}
 
 	logger.Infow("starting sensor controller", "version", argoevents.GetVersion())
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		logger.Desugar().Fatal("unable to run sensor controller", zap.Error(err))
+		logger.Fatalw("unable to run sensor controller", zap.Error(err))
 	}
 }

--- a/manifests/base/crds/argoproj.io_eventbus.yaml
+++ b/manifests/base/crds/argoproj.io_eventbus.yaml
@@ -13,6 +13,8 @@ spec:
     - eb
     singular: eventbus
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/manifests/base/crds/argoproj.io_eventsources.yaml
+++ b/manifests/base/crds/argoproj.io_eventsources.yaml
@@ -13,6 +13,8 @@ spec:
     - es
     singular: eventsource
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/manifests/base/crds/argoproj.io_sensors.yaml
+++ b/manifests/base/crds/argoproj.io_sensors.yaml
@@ -13,6 +13,8 @@ spec:
     - sn
     singular: sensor
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/manifests/cluster-install/rbac/argo-events-aggregate-to-admin.yaml
+++ b/manifests/cluster-install/rbac/argo-events-aggregate-to-admin.yaml
@@ -10,10 +10,13 @@ rules:
     resources:
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
     verbs:
       - create
       - delete

--- a/manifests/cluster-install/rbac/argo-events-aggregate-to-edit.yaml
+++ b/manifests/cluster-install/rbac/argo-events-aggregate-to-edit.yaml
@@ -10,10 +10,13 @@ rules:
     resources:
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
     verbs:
       - create
       - delete

--- a/manifests/cluster-install/rbac/argo-events-aggregate-to-view.yaml
+++ b/manifests/cluster-install/rbac/argo-events-aggregate-to-view.yaml
@@ -10,10 +10,13 @@ rules:
     resources:
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
     verbs:
       - get
       - list

--- a/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
+++ b/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
@@ -39,10 +39,13 @@ rules:
       - clusterworkflowtemplates/finalizers
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
   - apiGroups:
       - ""
     resources:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -12,6 +12,8 @@ spec:
     - eb
     singular: eventbus
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -32,6 +34,8 @@ spec:
     - es
     singular: eventsource
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -52,6 +56,8 @@ spec:
     - sn
     singular: sensor
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -76,10 +82,13 @@ rules:
   resources:
   - sensors
   - sensors/finalizers
+  - sensors/status
   - eventsources
   - eventsources/finalizers
+  - eventsources/status
   - eventbus
   - eventbus/finalizers
+  - eventbus/status
   verbs:
   - create
   - delete
@@ -102,10 +111,13 @@ rules:
   resources:
   - sensors
   - sensors/finalizers
+  - sensors/status
   - eventsources
   - eventsources/finalizers
+  - eventsources/status
   - eventbus
   - eventbus/finalizers
+  - eventbus/status
   verbs:
   - create
   - delete
@@ -128,10 +140,13 @@ rules:
   resources:
   - sensors
   - sensors/finalizers
+  - sensors/status
   - eventsources
   - eventsources/finalizers
+  - eventsources/status
   - eventbus
   - eventbus/finalizers
+  - eventbus/status
   verbs:
   - get
   - list
@@ -169,10 +184,13 @@ rules:
   - clusterworkflowtemplates/finalizers
   - sensors
   - sensors/finalizers
+  - sensors/status
   - eventsources
   - eventsources/finalizers
+  - eventsources/status
   - eventbus
   - eventbus/finalizers
+  - eventbus/status
   verbs:
   - create
   - delete

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -12,6 +12,8 @@ spec:
     - eb
     singular: eventbus
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -32,6 +34,8 @@ spec:
     - es
     singular: eventsource
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -52,6 +56,8 @@ spec:
     - sn
     singular: sensor
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -83,10 +89,13 @@ rules:
   - clusterworkflowtemplates/finalizers
   - sensors
   - sensors/finalizers
+  - sensors/status
   - eventsources
   - eventsources/finalizers
+  - eventsources/status
   - eventbus
   - eventbus/finalizers
+  - eventbus/status
   verbs:
   - create
   - delete

--- a/manifests/namespace-install/rbac/argo-events-role.yaml
+++ b/manifests/namespace-install/rbac/argo-events-role.yaml
@@ -25,10 +25,13 @@ rules:
       - clusterworkflowtemplates/finalizers
       - sensors
       - sensors/finalizers
+      - sensors/status
       - eventsources
       - eventsources/finalizers
+      - eventsources/status
       - eventbus
       - eventbus/finalizers
+      - eventbus/status
   - apiGroups:
       - ""
     resources:

--- a/pkg/apis/eventbus/v1alpha1/generated.proto
+++ b/pkg/apis/eventbus/v1alpha1/generated.proto
@@ -43,6 +43,7 @@ message ContainerTemplate {
 // EventBus is the definition of a eventbus resource
 // +genclient
 // +kubebuilder:resource:singular=eventbus,shortName=eb
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 message EventBus {

--- a/pkg/apis/eventbus/v1alpha1/types.go
+++ b/pkg/apis/eventbus/v1alpha1/types.go
@@ -11,6 +11,7 @@ import (
 // EventBus is the definition of a eventbus resource
 // +genclient
 // +kubebuilder:resource:singular=eventbus,shortName=eb
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 type EventBus struct {

--- a/pkg/apis/eventsource/v1alpha1/generated.proto
+++ b/pkg/apis/eventsource/v1alpha1/generated.proto
@@ -280,6 +280,7 @@ message EventPersistence {
 // EventSource is the definition of a eventsource resource
 // +genclient
 // +kubebuilder:resource:shortName=es
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 message EventSource {

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -28,6 +28,7 @@ import (
 // EventSource is the definition of a eventsource resource
 // +genclient
 // +kubebuilder:resource:shortName=es
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 type EventSource struct {

--- a/pkg/apis/sensor/v1alpha1/generated.proto
+++ b/pkg/apis/sensor/v1alpha1/generated.proto
@@ -432,6 +432,7 @@ message OpenWhiskTrigger {
 // +genclient
 // +genclient:noStatus
 // +kubebuilder:resource:shortName=sn
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 message Sensor {

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -69,6 +69,7 @@ const (
 // +genclient
 // +genclient:noStatus
 // +kubebuilder:resource:shortName=sn
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 type Sensor struct {


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

Closes #1029

This PR:
1. Enabled `status` subresource for CRDs, and controllers use `status` update API to update object status;
2. Controllers do not watch `status` change any more;
3. Fixed a bug that it kept emitting UPDATE notifications and updating status field infinitely.
4. Some code refactory and enhancement.