### PR TITLE
fix(eventbus): set nats routes with pod DNS names. Fixes #1026

### DIFF
--- a/controllers/eventbus/installer/nats.go
+++ b/controllers/eventbus/installer/nats.go
@@ -509,16 +509,16 @@ func (i *natsInstaller) buildConfigMap() (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 	peers := []string{}
+	routes := []string{}
 	for j := 0; j < replicas; j++ {
 		peers = append(peers, fmt.Sprintf("\"%s-%s\"", ssName, strconv.Itoa(j)))
+		routes = append(routes, fmt.Sprintf("nats://%s-%s.%s.%s.svc:%s", ssName, strconv.Itoa(j), svcName, i.eventBus.Namespace, strconv.Itoa(int(clusterPort))))
 	}
 	conf := fmt.Sprintf(`http: %s
 include ./auth.conf
 cluster {
   port: %s
-  routes [
-   nats://%s:%s
-  ]
+  routes: [%s]
   cluster_advertise: $CLUSTER_ADVERTISE
   connect_retries: 10
 }
@@ -534,7 +534,7 @@ streaming {
   store_limits {
     max_age: %s
   }
-}`, strconv.Itoa(int(monitorPort)), strconv.Itoa(int(clusterPort)), svcName, strconv.Itoa(int(clusterPort)), clusterID, strings.Join(peers, ","), maxAge)
+}`, strconv.Itoa(int(monitorPort)), strconv.Itoa(int(clusterPort)), strings.Join(routes, ","), clusterID, strings.Join(peers, ","), maxAge)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: i.eventBus.Namespace,


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

Fixes #1026

Old config:

```
http: 8222
include ./auth.conf
cluster {
  port: 6222
  routes [
   nats://eventbus-default-stan-svc:6222
  ]
  cluster_advertise: $CLUSTER_ADVERTISE
  connect_retries: 10
}
streaming {
  xxxxxx
}
```

New config:

```
http: 8222
include ./auth.conf
cluster {
  port: 6222
  routes: [
   nats://eventbus-default-stan-0.eventbus-default-stan-svc.argo-events.svc:6222,nats://eventbus-default-stan-1.eventbus-default-stan-svc.argo-events.svc:6222,nats://eventbus-default-stan-2.eventbus-default-stan-svc.argo-events.svc:6222
  ]
  cluster_advertise: $CLUSTER_ADVERTISE
  connect_retries: 10
}
streaming {
  xxxxx
}
```


Tested in a real environment, `routes` change in the configmap will be gradually picked up when the NATS pods restart, and there's no impact even when mixed old and new config are used by different replicas.
