### PR TITLE
fix(codegen): EventBus codegen plural issue introduced by k8s upgrade

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -17,15 +17,6 @@ cd "${FAKE_REPOPATH}"
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${FAKE_REPOPATH}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-#### fix the plural issue of code-generator  ####
-for i in `grep '"Endpoints": "Endpoints"' -R vendor/k8s.io/code-generator/ | grep -v EventBus | awk -F\: '{print $1}'`; do
-  if [ "$(uname -s)" = "Darwin" ]; then
-    sed -i "" "s/\"Endpoints\": \"Endpoints\"/\"Endpoints\": \"Endpoints\", \"EventBus\": \"EventBus\"/g" $i
-  elif [ "$(uname -s)" = "Linux" ]; then
-    sed -i "s/\"Endpoints\": \"Endpoints\"/\"Endpoints\": \"Endpoints\", \"EventBus\": \"EventBus\"/g" $i
-  fi
-done
-
 subheader "running codegen for sensor"
 bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
   github.com/argoproj/argo-events/pkg/client/sensor github.com/argoproj/argo-events/pkg/apis \
@@ -39,9 +30,15 @@ bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
   --go-header-file hack/custom-boilerplate.go.txt
 
 subheader "running codegen for eventbus"
-bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy" \
   github.com/argoproj/argo-events/pkg/client/eventbus github.com/argoproj/argo-events/pkg/apis \
   "eventbus:v1alpha1" \
+  --go-header-file hack/custom-boilerplate.go.txt
+
+bash -x ${CODEGEN_PKG}/generate-groups.sh "client,informer,lister" \
+  github.com/argoproj/argo-events/pkg/client/eventbus github.com/argoproj/argo-events/pkg/apis \
+  "eventbus:v1alpha1" \
+  --plural-exceptions EventBus:EventBus \
   --go-header-file hack/custom-boilerplate.go.txt
 
 subheader "running codegen for common"

--- a/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/eventbus.go
+++ b/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/eventbus.go
@@ -30,10 +30,10 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// EventBusesGetter has a method to return a EventBusInterface.
+// EventBusGetter has a method to return a EventBusInterface.
 // A group's client should implement this interface.
-type EventBusesGetter interface {
-	EventBuses(namespace string) EventBusInterface
+type EventBusGetter interface {
+	EventBus(namespace string) EventBusInterface
 }
 
 // EventBusInterface has methods to work with EventBus resources.
@@ -50,26 +50,26 @@ type EventBusInterface interface {
 	EventBusExpansion
 }
 
-// eventBuses implements EventBusInterface
-type eventBuses struct {
+// eventBus implements EventBusInterface
+type eventBus struct {
 	client rest.Interface
 	ns     string
 }
 
-// newEventBuses returns a EventBuses
-func newEventBuses(c *ArgoprojV1alpha1Client, namespace string) *eventBuses {
-	return &eventBuses{
+// newEventBus returns a EventBus
+func newEventBus(c *ArgoprojV1alpha1Client, namespace string) *eventBus {
+	return &eventBus{
 		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }
 
 // Get takes name of the eventBus, and returns the corresponding eventBus object, and an error if there is any.
-func (c *eventBuses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.EventBus, err error) {
+func (c *eventBus) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.EventBus, err error) {
 	result = &v1alpha1.EventBus{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(ctx).
@@ -77,8 +77,8 @@ func (c *eventBuses) Get(ctx context.Context, name string, options v1.GetOptions
 	return
 }
 
-// List takes label and field selectors, and returns the list of EventBuses that match those selectors.
-func (c *eventBuses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.EventBusList, err error) {
+// List takes label and field selectors, and returns the list of EventBus that match those selectors.
+func (c *eventBus) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.EventBusList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -86,7 +86,7 @@ func (c *eventBuses) List(ctx context.Context, opts v1.ListOptions) (result *v1a
 	result = &v1alpha1.EventBusList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Do(ctx).
@@ -94,8 +94,8 @@ func (c *eventBuses) List(ctx context.Context, opts v1.ListOptions) (result *v1a
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested eventBuses.
-func (c *eventBuses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested eventBus.
+func (c *eventBus) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -103,18 +103,18 @@ func (c *eventBuses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch(ctx)
 }
 
 // Create takes the representation of a eventBus and creates it.  Returns the server's representation of the eventBus, and an error, if there is any.
-func (c *eventBuses) Create(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.CreateOptions) (result *v1alpha1.EventBus, err error) {
+func (c *eventBus) Create(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.CreateOptions) (result *v1alpha1.EventBus, err error) {
 	result = &v1alpha1.EventBus{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(eventBus).
 		Do(ctx).
@@ -123,11 +123,11 @@ func (c *eventBuses) Create(ctx context.Context, eventBus *v1alpha1.EventBus, op
 }
 
 // Update takes the representation of a eventBus and updates it. Returns the server's representation of the eventBus, and an error, if there is any.
-func (c *eventBuses) Update(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
+func (c *eventBus) Update(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
 	result = &v1alpha1.EventBus{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		Name(eventBus.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(eventBus).
@@ -138,11 +138,11 @@ func (c *eventBuses) Update(ctx context.Context, eventBus *v1alpha1.EventBus, op
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *eventBuses) UpdateStatus(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
+func (c *eventBus) UpdateStatus(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
 	result = &v1alpha1.EventBus{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		Name(eventBus.Name).
 		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -153,10 +153,10 @@ func (c *eventBuses) UpdateStatus(ctx context.Context, eventBus *v1alpha1.EventB
 }
 
 // Delete takes name of the eventBus and deletes it. Returns an error if one occurs.
-func (c *eventBuses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+func (c *eventBus) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		Name(name).
 		Body(&opts).
 		Do(ctx).
@@ -164,14 +164,14 @@ func (c *eventBuses) Delete(ctx context.Context, name string, opts v1.DeleteOpti
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *eventBuses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+func (c *eventBus) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
 	var timeout time.Duration
 	if listOpts.TimeoutSeconds != nil {
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(&opts).
@@ -180,11 +180,11 @@ func (c *eventBuses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 }
 
 // Patch applies the patch and returns the patched eventBus.
-func (c *eventBuses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.EventBus, err error) {
+func (c *eventBus) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.EventBus, err error) {
 	result = &v1alpha1.EventBus{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
-		Resource("eventbuses").
+		Resource("eventbus").
 		Name(name).
 		SubResource(subresources...).
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/eventbus_client.go
+++ b/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/eventbus_client.go
@@ -26,7 +26,7 @@ import (
 
 type ArgoprojV1alpha1Interface interface {
 	RESTClient() rest.Interface
-	EventBusesGetter
+	EventBusGetter
 }
 
 // ArgoprojV1alpha1Client is used to interact with features provided by the argoproj.io group.
@@ -34,8 +34,8 @@ type ArgoprojV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ArgoprojV1alpha1Client) EventBuses(namespace string) EventBusInterface {
-	return newEventBuses(c, namespace)
+func (c *ArgoprojV1alpha1Client) EventBus(namespace string) EventBusInterface {
+	return newEventBus(c, namespace)
 }
 
 // NewForConfig creates a new ArgoprojV1alpha1Client for the given config.

--- a/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/fake/fake_eventbus.go
+++ b/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/fake/fake_eventbus.go
@@ -30,20 +30,20 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-// FakeEventBuses implements EventBusInterface
-type FakeEventBuses struct {
+// FakeEventBus implements EventBusInterface
+type FakeEventBus struct {
 	Fake *FakeArgoprojV1alpha1
 	ns   string
 }
 
-var eventbusesResource = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "eventbuses"}
+var eventbusResource = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "eventbus"}
 
-var eventbusesKind = schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "EventBus"}
+var eventbusKind = schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "EventBus"}
 
 // Get takes name of the eventBus, and returns the corresponding eventBus object, and an error if there is any.
-func (c *FakeEventBuses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.EventBus, err error) {
+func (c *FakeEventBus) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.EventBus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(eventbusesResource, c.ns, name), &v1alpha1.EventBus{})
+		Invokes(testing.NewGetAction(eventbusResource, c.ns, name), &v1alpha1.EventBus{})
 
 	if obj == nil {
 		return nil, err
@@ -51,10 +51,10 @@ func (c *FakeEventBuses) Get(ctx context.Context, name string, options v1.GetOpt
 	return obj.(*v1alpha1.EventBus), err
 }
 
-// List takes label and field selectors, and returns the list of EventBuses that match those selectors.
-func (c *FakeEventBuses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.EventBusList, err error) {
+// List takes label and field selectors, and returns the list of EventBus that match those selectors.
+func (c *FakeEventBus) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.EventBusList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(eventbusesResource, eventbusesKind, c.ns, opts), &v1alpha1.EventBusList{})
+		Invokes(testing.NewListAction(eventbusResource, eventbusKind, c.ns, opts), &v1alpha1.EventBusList{})
 
 	if obj == nil {
 		return nil, err
@@ -73,17 +73,17 @@ func (c *FakeEventBuses) List(ctx context.Context, opts v1.ListOptions) (result 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested eventBuses.
-func (c *FakeEventBuses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested eventBus.
+func (c *FakeEventBus) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(eventbusesResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchAction(eventbusResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a eventBus and creates it.  Returns the server's representation of the eventBus, and an error, if there is any.
-func (c *FakeEventBuses) Create(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.CreateOptions) (result *v1alpha1.EventBus, err error) {
+func (c *FakeEventBus) Create(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.CreateOptions) (result *v1alpha1.EventBus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(eventbusesResource, c.ns, eventBus), &v1alpha1.EventBus{})
+		Invokes(testing.NewCreateAction(eventbusResource, c.ns, eventBus), &v1alpha1.EventBus{})
 
 	if obj == nil {
 		return nil, err
@@ -92,9 +92,9 @@ func (c *FakeEventBuses) Create(ctx context.Context, eventBus *v1alpha1.EventBus
 }
 
 // Update takes the representation of a eventBus and updates it. Returns the server's representation of the eventBus, and an error, if there is any.
-func (c *FakeEventBuses) Update(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
+func (c *FakeEventBus) Update(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (result *v1alpha1.EventBus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(eventbusesResource, c.ns, eventBus), &v1alpha1.EventBus{})
+		Invokes(testing.NewUpdateAction(eventbusResource, c.ns, eventBus), &v1alpha1.EventBus{})
 
 	if obj == nil {
 		return nil, err
@@ -104,9 +104,9 @@ func (c *FakeEventBuses) Update(ctx context.Context, eventBus *v1alpha1.EventBus
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeEventBuses) UpdateStatus(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (*v1alpha1.EventBus, error) {
+func (c *FakeEventBus) UpdateStatus(ctx context.Context, eventBus *v1alpha1.EventBus, opts v1.UpdateOptions) (*v1alpha1.EventBus, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(eventbusesResource, "status", c.ns, eventBus), &v1alpha1.EventBus{})
+		Invokes(testing.NewUpdateSubresourceAction(eventbusResource, "status", c.ns, eventBus), &v1alpha1.EventBus{})
 
 	if obj == nil {
 		return nil, err
@@ -115,25 +115,25 @@ func (c *FakeEventBuses) UpdateStatus(ctx context.Context, eventBus *v1alpha1.Ev
 }
 
 // Delete takes name of the eventBus and deletes it. Returns an error if one occurs.
-func (c *FakeEventBuses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+func (c *FakeEventBus) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(eventbusesResource, c.ns, name), &v1alpha1.EventBus{})
+		Invokes(testing.NewDeleteAction(eventbusResource, c.ns, name), &v1alpha1.EventBus{})
 
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeEventBuses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(eventbusesResource, c.ns, listOpts)
+func (c *FakeEventBus) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(eventbusResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.EventBusList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched eventBus.
-func (c *FakeEventBuses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.EventBus, err error) {
+func (c *FakeEventBus) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.EventBus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventbusesResource, c.ns, name, pt, data, subresources...), &v1alpha1.EventBus{})
+		Invokes(testing.NewPatchSubresourceAction(eventbusResource, c.ns, name, pt, data, subresources...), &v1alpha1.EventBus{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/fake/fake_eventbus_client.go
+++ b/pkg/client/eventbus/clientset/versioned/typed/eventbus/v1alpha1/fake/fake_eventbus_client.go
@@ -28,8 +28,8 @@ type FakeArgoprojV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeArgoprojV1alpha1) EventBuses(namespace string) v1alpha1.EventBusInterface {
-	return &FakeEventBuses{c, namespace}
+func (c *FakeArgoprojV1alpha1) EventBus(namespace string) v1alpha1.EventBusInterface {
+	return &FakeEventBus{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/eventbus/informers/externalversions/eventbus/v1alpha1/eventbus.go
+++ b/pkg/client/eventbus/informers/externalversions/eventbus/v1alpha1/eventbus.go
@@ -33,7 +33,7 @@ import (
 )
 
 // EventBusInformer provides access to a shared informer and lister for
-// EventBuses.
+// EventBus.
 type EventBusInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() v1alpha1.EventBusLister
@@ -62,13 +62,13 @@ func NewFilteredEventBusInformer(client versioned.Interface, namespace string, r
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ArgoprojV1alpha1().EventBuses(namespace).List(context.TODO(), options)
+				return client.ArgoprojV1alpha1().EventBus(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ArgoprojV1alpha1().EventBuses(namespace).Watch(context.TODO(), options)
+				return client.ArgoprojV1alpha1().EventBus(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&eventbusv1alpha1.EventBus{},

--- a/pkg/client/eventbus/informers/externalversions/eventbus/v1alpha1/interface.go
+++ b/pkg/client/eventbus/informers/externalversions/eventbus/v1alpha1/interface.go
@@ -24,8 +24,8 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// EventBuses returns a EventBusInformer.
-	EventBuses() EventBusInformer
+	// EventBus returns a EventBusInformer.
+	EventBus() EventBusInformer
 }
 
 type version struct {
@@ -39,7 +39,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// EventBuses returns a EventBusInformer.
-func (v *version) EventBuses() EventBusInformer {
+// EventBus returns a EventBusInformer.
+func (v *version) EventBus() EventBusInformer {
 	return &eventBusInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/client/eventbus/informers/externalversions/generic.go
+++ b/pkg/client/eventbus/informers/externalversions/generic.go
@@ -53,8 +53,8 @@ func (f *genericInformer) Lister() cache.GenericLister {
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
 	// Group=argoproj.io, Version=v1alpha1
-	case v1alpha1.SchemeGroupVersion.WithResource("eventbuses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Argoproj().V1alpha1().EventBuses().Informer()}, nil
+	case v1alpha1.SchemeGroupVersion.WithResource("eventbus"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Argoproj().V1alpha1().EventBus().Informer()}, nil
 
 	}
 

--- a/pkg/client/eventbus/listers/eventbus/v1alpha1/eventbus.go
+++ b/pkg/client/eventbus/listers/eventbus/v1alpha1/eventbus.go
@@ -25,14 +25,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// EventBusLister helps list EventBuses.
+// EventBusLister helps list EventBus.
 // All objects returned here must be treated as read-only.
 type EventBusLister interface {
-	// List lists all EventBuses in the indexer.
+	// List lists all EventBus in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.EventBus, err error)
-	// EventBuses returns an object that can list and get EventBuses.
-	EventBuses(namespace string) EventBusNamespaceLister
+	// EventBus returns an object that can list and get EventBus.
+	EventBus(namespace string) EventBusNamespaceLister
 	EventBusListerExpansion
 }
 
@@ -46,7 +46,7 @@ func NewEventBusLister(indexer cache.Indexer) EventBusLister {
 	return &eventBusLister{indexer: indexer}
 }
 
-// List lists all EventBuses in the indexer.
+// List lists all EventBus in the indexer.
 func (s *eventBusLister) List(selector labels.Selector) (ret []*v1alpha1.EventBus, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.EventBus))
@@ -54,15 +54,15 @@ func (s *eventBusLister) List(selector labels.Selector) (ret []*v1alpha1.EventBu
 	return ret, err
 }
 
-// EventBuses returns an object that can list and get EventBuses.
-func (s *eventBusLister) EventBuses(namespace string) EventBusNamespaceLister {
+// EventBus returns an object that can list and get EventBus.
+func (s *eventBusLister) EventBus(namespace string) EventBusNamespaceLister {
 	return eventBusNamespaceLister{indexer: s.indexer, namespace: namespace}
 }
 
-// EventBusNamespaceLister helps list and get EventBuses.
+// EventBusNamespaceLister helps list and get EventBus.
 // All objects returned here must be treated as read-only.
 type EventBusNamespaceLister interface {
-	// List lists all EventBuses in the indexer for a given namespace.
+	// List lists all EventBus in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.EventBus, err error)
 	// Get retrieves the EventBus from the indexer for a given namespace and name.
@@ -78,7 +78,7 @@ type eventBusNamespaceLister struct {
 	namespace string
 }
 
-// List lists all EventBuses in the indexer for a given namespace.
+// List lists all EventBus in the indexer for a given namespace.
 func (s eventBusNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.EventBus, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.EventBus))


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

With k8s version upgraded to v1.9.6, `code-generator` was also upgraded to new version, which broke the original codegen patch for `EventBus` plural (We want `EventBus` instead of `EventBuses`). This PR permanently fixes the issue.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
