### PR TITLE
fix(slack trigger): properly iterate api response

### DIFF
--- a/sensors/triggers/slack/slack.go
+++ b/sensors/triggers/slack/slack.go
@@ -124,7 +124,7 @@ func (t *SlackTrigger) Execute(ctx context.Context, events map[string]*v1alpha1.
 				break
 			}
 		}
-		if len(channels) < params.Limit || nextCursor == "" {
+		if nextCursor == "" {
 			break
 		}
 		params.Cursor = nextCursor


### PR DESCRIPTION
Fixes #1057  The iteration should not assume every page has size of limit set (200)

Checklist:
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).
