### PR TITLE
fix(GithubEventSource): Compare events ignoring order and duplicate

### DIFF
--- a/eventsources/sources/github/hook_util.go
+++ b/eventsources/sources/github/hook_util.go
@@ -1,30 +1,62 @@
 package github
 
 import (
+	"sort"
+
 	gh "github.com/google/go-github/v31/github"
 )
 
 // sliceEqual returns true if the two provided string slices are equal.
 func sliceEqual(first []string, second []string) bool {
-	if len(first) != len(second) {
+	if len(first) == 0 && len(second) == 0 {
+		return true
+	}
+	if len(first) == 0 || len(second) == 0 {
 		return false
 	}
 
-	if first == nil && second == nil {
+	uniqFirst := unique(first)
+	uniqSecond := unique(second)
+
+	sort.Strings(uniqFirst)
+	sort.Strings(uniqSecond)
+
+	// all_request
+	if contains(uniqFirst, "*") && contains(uniqSecond, "*") {
 		return true
 	}
 
-	if first == nil || second == nil {
+	if len(uniqFirst) != len(uniqSecond) {
 		return false
 	}
 
-	for index := range first {
-		if first[index] != second[index] {
+	for index := range uniqFirst {
+		if uniqFirst[index] != uniqSecond[index] {
 			return false
 		}
 	}
 
 	return true
+}
+
+func contains(sortedList []string, str string) bool {
+	i := sort.SearchStrings(sortedList, str)
+	return i < len(sortedList) && sortedList[i] == str
+}
+
+func unique(stringSlice []string) []string {
+	if len(stringSlice) == 0 {
+		return stringSlice
+	}
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }
 
 // compareHook returns true if the hook matches the url and event.

--- a/eventsources/sources/github/hook_util.go
+++ b/eventsources/sources/github/hook_util.go
@@ -1,8 +1,6 @@
 package github
 
 import (
-	"sort"
-
 	gh "github.com/google/go-github/v31/github"
 )
 
@@ -15,48 +13,34 @@ func sliceEqual(first []string, second []string) bool {
 		return false
 	}
 
-	uniqFirst := unique(first)
-	uniqSecond := unique(second)
-
-	sort.Strings(uniqFirst)
-	sort.Strings(uniqSecond)
-
-	// all_request
-	if contains(uniqFirst, "*") && contains(uniqSecond, "*") {
-		return true
+	tmp := make(map[string]int)
+	for _, i := range first {
+		tmp[i] = 1
 	}
 
-	if len(uniqFirst) != len(uniqSecond) {
-		return false
+	for _, i := range second {
+		v, ok := tmp[i]
+		if !ok || v == -1 {
+			tmp[i] = -1
+		} else {
+			tmp[i] = 2
+		}
 	}
 
-	for index := range uniqFirst {
-		if uniqFirst[index] != uniqSecond[index] {
+	if v, ok := tmp["*"]; ok {
+		// If both slices contain "*", return true directly
+		return v == 2
+	}
+
+	for _, v := range tmp {
+		// -1: only exists in secod
+		// 1: only exists in first
+		// 2: eists in both
+		if v < 2 {
 			return false
 		}
 	}
-
 	return true
-}
-
-func contains(sortedList []string, str string) bool {
-	i := sort.SearchStrings(sortedList, str)
-	return i < len(sortedList) && sortedList[i] == str
-}
-
-func unique(stringSlice []string) []string {
-	if len(stringSlice) == 0 {
-		return stringSlice
-	}
-	keys := make(map[string]bool)
-	list := []string{}
-	for _, entry := range stringSlice {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
-		}
-	}
-	return list
 }
 
 // compareHook returns true if the hook matches the url and event.

--- a/eventsources/sources/github/hook_util.go
+++ b/eventsources/sources/github/hook_util.go
@@ -33,7 +33,7 @@ func sliceEqual(first []string, second []string) bool {
 	}
 
 	for _, v := range tmp {
-		// -1: only exists in secod
+		// -1: only exists in second
 		// 1: only exists in first
 		// 2: eists in both
 		if v < 2 {

--- a/eventsources/sources/github/hook_util.go
+++ b/eventsources/sources/github/hook_util.go
@@ -35,7 +35,7 @@ func sliceEqual(first []string, second []string) bool {
 	for _, v := range tmp {
 		// -1: only exists in second
 		// 1: only exists in first
-		// 2: eists in both
+		// 2: exists in both
 		if v < 2 {
 			return false
 		}

--- a/eventsources/sources/github/hook_util_test.go
+++ b/eventsources/sources/github/hook_util_test.go
@@ -23,8 +23,13 @@ func TestSliceEqual(t *testing.T) {
 	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*"}))
 	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*", "world"}))
 	assert.True(t, sliceEqual([]string{"hello", "world", "hello"}, []string{"hello", "hello", "world", "world"}))
+	assert.True(t, sliceEqual([]string{"world", "hello"}, []string{"hello", "hello", "world", "world"}))
+	assert.True(t, sliceEqual([]string{"hello", "hello", "world", "world"}, []string{"world", "hello"}))
 	assert.False(t, sliceEqual([]string{"hello"}, []string{"*", "hello"}))
 	assert.False(t, sliceEqual([]string{"hello", "*"}, []string{"hello"}))
+	assert.False(t, sliceEqual([]string{"*", "hello", "*"}, []string{"hello"}))
+	assert.False(t, sliceEqual([]string{"hello"}, []string{"world", "world"}))
+	assert.False(t, sliceEqual([]string{"hello", "hello"}, []string{"world", "world"}))
 	assert.True(t, sliceEqual([]string{"*", "hello", "*"}, []string{"*", "world", "hello", "world"}))
 }
 

--- a/eventsources/sources/github/hook_util_test.go
+++ b/eventsources/sources/github/hook_util_test.go
@@ -22,6 +22,10 @@ func TestSliceEqual(t *testing.T) {
 	assert.True(t, sliceEqual([]string{"hello", "world"}, []string{"world", "hello"}))
 	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*"}))
 	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*", "world"}))
+	assert.True(t, sliceEqual([]string{"hello", "world", "hello"}, []string{"hello", "hello", "world", "world"}))
+	assert.False(t, sliceEqual([]string{"hello"}, []string{"*", "hello"}))
+	assert.False(t, sliceEqual([]string{"hello", "*"}, []string{"hello"}))
+	assert.True(t, sliceEqual([]string{"*", "hello", "*"}, []string{"*", "world", "hello", "world"}))
 }
 
 func TestCompareHook(t *testing.T) {

--- a/eventsources/sources/github/hook_util_test.go
+++ b/eventsources/sources/github/hook_util_test.go
@@ -19,6 +19,9 @@ func TestSliceEqual(t *testing.T) {
 	assert.False(t, sliceEqual([]string{"hello"}, []string{"hello", "world"}))
 	assert.False(t, sliceEqual([]string{"hello", "world"}, []string{"hello"}))
 	assert.False(t, sliceEqual([]string{"hello", "world"}, []string{"hello", "moon"}))
+	assert.True(t, sliceEqual([]string{"hello", "world"}, []string{"world", "hello"}))
+	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*"}))
+	assert.True(t, sliceEqual([]string{"hello", "*"}, []string{"*", "world"}))
 }
 
 func TestCompareHook(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Fix the bugs mentioned in https://github.com/argoproj/argo-events/issues/1112.

Function `sliceEqual` is used to compare the Github events listed in the spec and the ones from Github API response.

It should:

1. If "*" (`all_events`) is in both slices, that should be considered as equal.
2. It should compare ignoring the duplicate and order, which means `{"a", "c", "a", "b"}` = `{"b", "c", "c", "a"}` = `{"a", "b", "c"}`

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
