### PR TITLE
fix(git-sensor): force fetch from git repository

### DIFF
--- a/sensors/artifacts/git.go
+++ b/sensors/artifacts/git.go
@@ -125,6 +125,7 @@ func (g *GitArtifactReader) readFromRepository(r *git.Repository, dir string) ([
 		fetchOptions := &git.FetchOptions{
 			RemoteName: g.artifact.Remote.Name,
 			RefSpecs:   fetchRefSpec,
+			Force:      true,
 		}
 		if auth != nil {
 			fetchOptions.Auth = auth
@@ -143,6 +144,7 @@ func (g *GitArtifactReader) readFromRepository(r *git.Repository, dir string) ([
 	fetchOptions := &git.FetchOptions{
 		RemoteName: g.getRemote(),
 		RefSpecs:   fetchRefSpec,
+		Force:      true,
 	}
 	if auth != nil {
 		fetchOptions.Auth = auth


### PR DESCRIPTION
We've run into an issue with using the existing git sensor with our repository.  The sensor works for a while until it starts erroring on `failed to fetch. err: some refs were not updated`.  This seems to happen when we merge code to our repository, and our deploy process updates tags.  Updating tags on existing branches causes git to throw an error unless you force fetch.  The artifact already force fetches when given a particular ref, and I can't think of a downside of doing it everywhere given that you wouldn't be making local changes to branches in a sensor.

Fixes: #1120

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
