### PR TITLE
fix(resource-eventsource): Use event time instead of obj create time to filter UPDATE/DELETE events

### DIFF
--- a/eventsources/sources/resource/start.go
+++ b/eventsources/sources/resource/start.go
@@ -275,12 +275,13 @@ func passFilters(event *InformerEvent, filter *v1alpha1.ResourceFilter, startTim
 		return false
 	}
 	eventTime := getEventTime(uObj, event.Type)
-	if !filter.CreatedBy.IsZero() && eventTime.UTC().After(filter.CreatedBy.UTC()) {
-		log.Infof("Event happened after filter time. event-timestamp: %s, filter-creation-timestamp: %s\n", eventTime.UTC().String(), filter.CreatedBy.UTC().String())
-		return false
-	}
 	if filter.AfterStart && eventTime.UTC().Before(startTime.UTC()) {
 		log.Infof("Event happened before service start time. event-timestamp: %s, start-timestamp: %s\n", eventTime.UTC().String(), startTime.UTC().String())
+		return false
+	}
+	created := uObj.GetCreationTimestamp()
+	if !filter.CreatedBy.IsZero() && created.UTC().After(filter.CreatedBy.UTC()) {
+		log.Infof("resource is created after filter time. creation-timestamp: %s, filter-creation-timestamp: %s\n", created.UTC().String(), filter.CreatedBy.UTC().String())
 		return false
 	}
 	if len(filter.Fields) > 0 {

--- a/test/e2e/fixtures/e2e_suite.go
+++ b/test/e2e/fixtures/e2e_suite.go
@@ -119,6 +119,7 @@ func (s *E2ESuite) DeleteResources() {
 	resources := []schema.GroupVersionResource{
 		{Group: eventsource.Group, Version: "v1alpha1", Resource: eventsource.Plural},
 		{Group: sensor.Group, Version: "v1alpha1", Resource: sensor.Plural},
+		{Group: "", Version: "v1", Resource: "pods"},
 	}
 	s.deleteResources(resources)
 }

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -126,5 +127,14 @@ func (g *Given) When() *When {
 		sensor:            g.sensor,
 		restConfig:        g.restConfig,
 		kubeClient:        g.kubeClient,
+	}
+}
+
+var OutputRegexp = func(rx string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		t.Helper()
+		if assert.NoError(t, err, output) {
+			assert.Regexp(t, rx, output)
+		}
 	}
 }

--- a/test/e2e/testdata/es-resource.yaml
+++ b/test/e2e/testdata/es-resource.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: test-resource
+spec:
+  template:
+    serviceAccountName: argo-events-sa
+  resource:
+    example:
+      namespace: argo-events
+      group: ""
+      version: v1
+      resource: pods
+      eventTypes:
+        - DELETE
+      filter:
+        afterStart: true
+        fields:
+          - key: metadata.name
+            operation: ==
+            value: test-pod

--- a/test/e2e/testdata/sensor-resource.yaml
+++ b/test/e2e/testdata/sensor-resource.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: e2e-resource-log
+spec:
+  dependencies:
+    - name: test-dep
+      eventSourceName: test-resource
+      eventName: example
+  triggers:
+    - template:
+        name: log-trigger
+        log: {}


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

When using Resource event source to watch UPDATE/DELETE events, the time used to filter the events (`afterStart`) should be event happen time instead of obj create time.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
