### PR TITLE
fix(docs): Update link in 02-parameterization.md

### DIFF
--- a/docs/tutorials/02-parameterization.md
+++ b/docs/tutorials/02-parameterization.md
@@ -17,7 +17,7 @@ with the event payload.
 
 ### Prerequisites
 
-Make sure to have the basic webhook event-source and sensor set up. Follow the [introduction](https://argoproj.github.io/argo-events/tutorials/01_introduction) tutorial if haven't done already.
+Make sure to have the basic webhook event-source and sensor set up. Follow the [introduction](https://argoproj.github.io/argo-events/tutorials/01-introduction) tutorial if haven't done already.
 
 ### Webhook Event Payload
 


### PR DESCRIPTION
The link to the first page of the tutorial was wrong. An underscore instead of a dash after 01. 
This change repairs that error.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
