### PR TITLE
docs: Revert "docs: Update link to the new CNCF Slack channel (#1179)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Argo Events - The Event-driven Workflow Automation Framework
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/argoproj/argo-events)](https://goreportcard.com/report/github.com/argoproj/argo-events)
-[![slack](https://img.shields.io/badge/slack-argo_events-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01TNKD6KL6)
+[![slack](https://img.shields.io/badge/slack-argoproj-brightgreen.svg?logo=slack)](https://argoproj.github.io/community/join-slack)
 [![Build Status](https://travis-ci.org/argoproj/argo-events.svg?branch=master)](https://travis-ci.org/argoproj/argo-events)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3832/badge)](https://bestpractices.coreinfrastructure.org/projects/3832)
 [![GoDoc](https://godoc.org/github.com/argoproj/argo-events?status.svg)](https://godoc.org/github.com/argoproj/argo-events/pkg/apis)


### PR DESCRIPTION
I discussed with @alexmt and he's going to reuse the existing link with instructions to join the CNCF workspace and channels. See https://github.com/argoproj/argo-cd/pull/6044#discussion_r614325390 for more context. Reverting previous change.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>
This reverts commit bb1f7407f5bcdd8362a73391eb7edec5129eb857.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
