### PR TITLE
fix: Always mount tmp emptyDir. Fixes #1194

### DIFF
--- a/controllers/eventsource/resource.go
+++ b/controllers/eventsource/resource.go
@@ -211,7 +211,7 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 		natsConf := eventBus.Status.Config.NATS
 		if natsConf.Auth != nil && natsConf.AccessSecret != nil {
 			// Mount the secret as volume instead of using evnFrom to gain the ability
-			// for the sensor deployment to auto reload when the secret changes
+			// for the event source deployment to auto reload when the secret changes
 			volumes = append(volumes, corev1.Volume{
 				Name: "auth-volume",
 				VolumeSource: corev1.VolumeSource{

--- a/controllers/eventsource/resource.go
+++ b/controllers/eventsource/resource.go
@@ -200,11 +200,18 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	encodedBusConfig := base64.StdEncoding.EncodeToString(busConfigBytes)
 	envVars = append(envVars, corev1.EnvVar{Name: common.EnvVarEventBusConfig, Value: encodedBusConfig})
 	if eventBus.Status.Config.NATS != nil {
+		volumes := deploymentSpec.Template.Spec.Volumes
+		volumeMounts := deploymentSpec.Template.Spec.Containers[0].VolumeMounts
+		emptyDirVolName := "tmp"
+		volumes = append(volumes, corev1.Volume{
+			Name: emptyDirVolName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: emptyDirVolName, MountPath: "/tmp"})
+
 		natsConf := eventBus.Status.Config.NATS
 		if natsConf.Auth != nil && natsConf.AccessSecret != nil {
 			// Mount the secret as volume instead of using evnFrom to gain the ability
 			// for the sensor deployment to auto reload when the secret changes
-			volumes := deploymentSpec.Template.Spec.Volumes
 			volumes = append(volumes, corev1.Volume{
 				Name: "auth-volume",
 				VolumeSource: corev1.VolumeSource{
@@ -219,16 +226,10 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 					},
 				},
 			})
-			emptyDirVolName := "tmp"
-			volumes = append(volumes, corev1.Volume{
-				Name: emptyDirVolName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-			})
-			deploymentSpec.Template.Spec.Volumes = volumes
-			volumeMounts := deploymentSpec.Template.Spec.Containers[0].VolumeMounts
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: "auth-volume", MountPath: common.EventBusAuthFileMountPath})
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: emptyDirVolName, MountPath: "/tmp"})
-			deploymentSpec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 		}
+		deploymentSpec.Template.Spec.Volumes = volumes
+		deploymentSpec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 	} else {
 		return nil, errors.New("unsupported event bus")
 	}

--- a/controllers/eventsource/resource_test.go
+++ b/controllers/eventsource/resource_test.go
@@ -46,10 +46,14 @@ func Test_BuildDeployment(t *testing.T) {
 		volumes := deployment.Spec.Template.Spec.Volumes
 		assert.True(t, len(volumes) > 0)
 		hasAuthVolume := false
+		hasTmpVolume := false
 		cmRefs, secretRefs := 0, 0
 		for _, vol := range volumes {
 			if vol.Name == "auth-volume" {
 				hasAuthVolume = true
+			}
+			if vol.Name == "tmp" {
+				hasTmpVolume = true
 			}
 			if strings.Contains(vol.Name, testEventSource.Spec.HDFS["test"].KrbCCacheSecret.Name) {
 				secretRefs++
@@ -59,6 +63,7 @@ func Test_BuildDeployment(t *testing.T) {
 			}
 		}
 		assert.True(t, hasAuthVolume)
+		assert.True(t, hasTmpVolume)
 		assert.True(t, len(deployment.Spec.Template.Spec.ImagePullSecrets) > 0)
 		assert.True(t, cmRefs > 0)
 		assert.True(t, secretRefs > 0)

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -166,11 +166,18 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 	encodedBusConfig := base64.StdEncoding.EncodeToString(busConfigBytes)
 	envVars = append(envVars, corev1.EnvVar{Name: common.EnvVarEventBusConfig, Value: encodedBusConfig})
 	if eventBus.Status.Config.NATS != nil {
+		volumes := deploymentSpec.Template.Spec.Volumes
+		volumeMounts := deploymentSpec.Template.Spec.Containers[0].VolumeMounts
+		emptyDirVolName := "tmp"
+		volumes = append(volumes, corev1.Volume{
+			Name: emptyDirVolName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: emptyDirVolName, MountPath: "/tmp"})
+
 		natsConf := eventBus.Status.Config.NATS
 		if natsConf.Auth != nil && natsConf.AccessSecret != nil {
 			// Mount the secret as volume instead of using evnFrom to gain the ability
 			// for the sensor deployment to auto reload when the secret changes
-			volumes := deploymentSpec.Template.Spec.Volumes
 			volumes = append(volumes, corev1.Volume{
 				Name: "auth-volume",
 				VolumeSource: corev1.VolumeSource{
@@ -185,16 +192,10 @@ func buildDeployment(args *AdaptorArgs, eventBus *eventbusv1alpha1.EventBus) (*a
 					},
 				},
 			})
-			emptyDirVolName := "tmp"
-			volumes = append(volumes, corev1.Volume{
-				Name: emptyDirVolName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-			})
-			deploymentSpec.Template.Spec.Volumes = volumes
-			volumeMounts := deploymentSpec.Template.Spec.Containers[0].VolumeMounts
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: "auth-volume", MountPath: common.EventBusAuthFileMountPath})
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: emptyDirVolName, MountPath: "/tmp"})
-			deploymentSpec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 		}
+		deploymentSpec.Template.Spec.Volumes = volumes
+		deploymentSpec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 	} else {
 		return nil, errors.New("unsupported event bus")
 	}

--- a/controllers/sensor/resource_test.go
+++ b/controllers/sensor/resource_test.go
@@ -143,13 +143,17 @@ func Test_BuildDeployment(t *testing.T) {
 		volumes := deployment.Spec.Template.Spec.Volumes
 		assert.True(t, len(volumes) > 0)
 		hasAuthVolume := false
+		hasTmpVolume := false
 		for _, vol := range volumes {
 			if vol.Name == "auth-volume" {
 				hasAuthVolume = true
-				break
+			}
+			if vol.Name == "tmp" {
+				hasTmpVolume = true
 			}
 		}
 		assert.True(t, hasAuthVolume)
+		assert.True(t, hasTmpVolume)
 		assert.True(t, len(deployment.Spec.Template.Spec.ImagePullSecrets) > 0)
 		assert.Equal(t, deployment.Spec.Template.Spec.PriorityClassName, "test-class")
 	})


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Fix the issue that volume `emptyDir` is not mounted when EventBus auth is `None`.

Fixes #1194

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
