### PR TITLE
docs(argo-events): Added helpful information to FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,7 +33,9 @@ Note: You can set the environment variable `DEBUG_LOG:true` in any of the contai
 
 1. Check the sensor resource is deployed and a pod is running for the resource.
 If the sensor pod is running, check for `Started to subscribe events for triggers` in the logs.
-If the sensor has subscribed to the event-bus but is unable to create the trigger resource, please raise an issue on GitHub. 
+If the sensor has subscribed to the event-bus but is unable to create the trigger resource, please raise an issue on GitHub.
+
+2. The sensor's dependencies have a specific eventSourceName and eventName that should match the values defined in the `EventSource` resource. See full details [here](https://github.com/argoproj/argo-events/blob/master/docs/eventsources/naming.md).
 
 **Q. Helm chart installation does not work.**
 


### PR DESCRIPTION
I think it would be helpful to add this to the FAQ guide. The eventSourceName and eventName can be confusing at first.