### PR TITLE
chore: remove source of duplicate properties in JSON log

### DIFF
--- a/eventsources/common/webhook/webhook.go
+++ b/eventsources/common/webhook/webhook.go
@@ -45,7 +45,7 @@ func NewController() *Controller {
 func NewRoute(hookContext *v1alpha1.WebhookContext, logger *zap.SugaredLogger, eventSourceName, eventName string, metrics *metrics.Metrics) *Route {
 	return &Route{
 		Context:         hookContext,
-		Logger:          logger.With(logging.LabelEventSourceName, eventSourceName, logging.LabelEventName, eventName),
+		Logger:          logger,
 		EventSourceName: eventSourceName,
 		EventName:       eventName,
 		Active:          false,


### PR DESCRIPTION
## Description
The `EventSource` logs contain noise in the form of duplicate properties
- `eventName`
- `eventSourceName`

E.g.
```json
{
   "eventSourceName": "jp-webhook",
   "eventSourceName": "jp-webhook",
   "eventSourceType": "webhook",
   "eventName": "example",
   "eventName": "example"
}
```

The following are the original contiguous logs:

### No Duplicates
```json
{"level":"info","ts":1621930364.5526974,"logger":"argo-events.eventsource","caller":"driver/nats.go:96","msg":"NATS auth strategy: None","eventSourceName":"jp-webhook","clientID":"client-jp-webhook-eventsource-6zw95-6c7794fcf8-6wsqb-507"},
{"level":"info","ts":1621930364.556608,"logger":"argo-events.eventsource","caller":"driver/nats.go:105","msg":"Connected to NATS server.","eventSourceName":"jp-webhook","clientID":"client-jp-webhook-eventsource-6zw95-6c7794fcf8-6wsqb-507"},
{"level":"info","ts":1621930364.5600975,"logger":"argo-events.eventsource","caller":"driver/nats.go:118","msg":"Connected to NATS streaming server.","eventSourceName":"jp-webhook","clientID":"client-jp-webhook-eventsource-6zw95-6c7794fcf8-6wsqb-507"},
{"level":"info","ts":1621930364.5601459,"logger":"argo-events.eventsource","caller":"eventsources/eventing.go:423","msg":"Eventing server started.","eventSourceName":"jp-webhook"},
{"level":"info","ts":1621930364.5601807,"logger":"argo-events.eventsource","caller":"eventsources/eventing.go:332","msg":"starting eventbus connection daemon...","eventSourceName":"jp-webhook"},
{"level":"info","ts":1621930364.560263,"logger":"argo-events.eventsource","caller":"webhook/start.go:149","msg":"started processing the webhook event source...","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example"},
```
### Duplicates
```json
{"level":"info","ts":1621930364.5602934,"logger":"argo-events.eventsource","caller":"webhook/webhook.go:216","msg":"validating the route...","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example","eventSourceName":"jp-webhook","eventName":"example"},
{"level":"info","ts":1621930364.5603027,"logger":"argo-events.eventsource","caller":"webhook/webhook.go:222","msg":"listening to payloads for the route...","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example","eventSourceName":"jp-webhook","eventName":"example"},
{"level":"info","ts":1621930364.5603175,"logger":"argo-events.eventsource","caller":"webhook/webhook.go:229","msg":"activating the route...","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example","eventSourceName":"jp-webhook","eventName":"example"},
{"level":"info","ts":1621930364.560419,"logger":"argo-events.eventsource","caller":"webhook/webhook.go:179","msg":"route is activated","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example","eventSourceName":"jp-webhook","eventName":"example","port":"12000","endpoint":"/example"},
{"level":"info","ts":1621930364.5604398,"logger":"argo-events.eventsource","caller":"webhook/webhook.go:232","msg":"running operations post route activation...","eventSourceName":"jp-webhook","eventSourceType":"webhook","eventName":"example","eventSourceName":"jp-webhook","eventName":"example"}
```

## The Problem

Each type of `EventSource` decorates the logs with `eventName` and `eventSourceName` before logging the specific type of webhook being set up:

https://github.com/argoproj/argo-events/blob/0e577da295e32e5dd483b223b181347c77356913/eventsources/sources/webhook/start.go#L147-L149

https://github.com/argoproj/argo-events/blob/b0ab8bbf7f34c7e4bb3028d3822584bd16a930b8/eventsources/sources/github/start.go#L291-L293

https://github.com/argoproj/argo-events/blob/b0ab8bbf7f34c7e4bb3028d3822584bd16a930b8/eventsources/sources/slack/start.go#L315-L318

However, each one of these calls `webhook.NewRoute`, which again decorates the logs with the `eventName` and `eventSourceName`:

https://github.com/argoproj/argo-events/blob/0e577da295e32e5dd483b223b181347c77356913/eventsources/common/webhook/webhook.go#L48

## The Fix

Ideally this decoration would happen in one common place (i.e. `webhook.NewRoute`) so developers aren't relied upon to remember to add this decoration with each new `EventSource`.

However:
- Each `EventSource` already adds these properties, so the easy fix is to pass the logger in unchanged to `webhook.NewRoute()` - i.e. no `.With()` modifications (done in this PR).
- Certain `EventSource`s (e.g. [Kafka](https://github.com/argoproj/argo-events/blob/b0ab8bbf7f34c7e4bb3028d3822584bd16a930b8/eventsources/sources/kafka/start.go#L73-L86)) don't use this common `webhook.NewRoute` function, so the decoration would need to happen at the specific `EventSource` regardless.

## Links

Related Zap issue: https://github.com/uber-go/zap/issues/622

## Checklist

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).
We are trialing it before adopting, happy to update this once/if we officially use argo-events.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

