### PR TITLE
docs: Update 06-trigger-conditions.md

### DIFF
--- a/docs/tutorials/06-trigger-conditions.md
+++ b/docs/tutorials/06-trigger-conditions.md
@@ -90,7 +90,7 @@ Make sure there are no errors in any of the event-sources.
          kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/06-trigger-conditions/sensor-02.yaml
 
     Send a HTTP request and perform a file drop on Minio bucket as done above.
-    You should following output,
+    You should get the following output.
 
 
          _______________________________


### PR DESCRIPTION
docs: Update 06-trigger-conditions.md
The last line seems unfinished, and missed a verb between "should following".  Proposed to change it from "You should following output, " to "You should get the following output." .

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
