### PR TITLE
chore: Add pandoc to executable check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 GIT_BRANCH=$(shell git rev-parse --symbolic-full-name --verify --quiet --abbrev-ref HEAD)
 GIT_TAG=$(shell if [ -z "`git status --porcelain`" ]; then git describe --exact-match --tags HEAD 2>/dev/null; fi)
 GIT_TREE_STATE=$(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
-EXECUTABLES = curl docker gzip go
+EXECUTABLES = curl docker gzip go pandoc
 
 #  docker image publishing options
 DOCKER_PUSH?=false


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->


With the patch applied. `make codegen` warns you to install pandoc.

Example output: 
```
make codegen
Makefile:41: *** "No pandoc in PATH".  Stop.
```

```
 brew install pandoc
```

```
make codegen
./hack/generate-proto.sh
[.....]
```