### PR TITLE
build: Switch to use kustomize subcommand in kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,9 @@ crds:
 
 .PHONY: manifests
 manifests: crds
-	kustomize build manifests/cluster-install > manifests/install.yaml
-	kustomize build manifests/namespace-install > manifests/namespace-install.yaml
-	kustomize build manifests/extensions/validating-webhook > manifests/install-validating-webhook.yaml
+	kubectl kustomize manifests/cluster-install > manifests/install.yaml
+	kubectl kustomize manifests/namespace-install > manifests/namespace-install.yaml
+	kubectl kustomize manifests/extensions/validating-webhook > manifests/install-validating-webhook.yaml
 
 .PHONY: swagger
 swagger:
@@ -126,7 +126,7 @@ docs/assets/diagram.png: go-diagrams/diagram.dot
 .PHONY: start
 start: image
 	kubectl apply -f test/manifests/argo-events-ns.yaml
-	kustomize build test/manifests | sed 's@quay.io/argoproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:$(BASE_VERSION)/:$(VERSION)/' | kubectl -n argo-events apply -l app.kubernetes.io/part-of=argo-events --prune --force -f -
+	kubectl kustomize test/manifests | sed 's@quay.io/argoproj/@$(IMAGE_NAMESPACE)/@' | sed 's/:$(BASE_VERSION)/:$(VERSION)/' | kubectl -n argo-events apply -l app.kubernetes.io/part-of=argo-events --prune --force -f -
 	kubectl -n argo-events wait --for=condition=Ready --timeout 60s pod --all
 
 $(GOPATH)/bin/golangci-lint:


### PR DESCRIPTION
Since Kubernetes v1.14, kustomize became a subcommand in kubectl so we can just use kubectl instead.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
