### PR TITLE
fix(trigger): correct field name in error message

### DIFF
--- a/sensors/triggers/argo-workflow/argo-workflow.go
+++ b/sensors/triggers/argo-workflow/argo-workflow.go
@@ -111,7 +111,7 @@ func (t *ArgoWorkflowTrigger) Execute(ctx context.Context, events map[string]*v1
 			return nil, errors.Errorf("failed to execute the workflow %v operation, no name is given", op)
 		}
 		if obj.GetGenerateName() == "" {
-			return nil, errors.New("failed to trigger the workflow, neither name nor generatedName is given")
+			return nil, errors.New("failed to trigger the workflow, neither name nor generateName is given")
 		}
 	}
 


### PR DESCRIPTION
The field name `generatedName` in the error of argo_workflow trigger is wrong. The correct name is `generateName`.
ref: https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/apis/meta/v1/unstructured/unstructured.go#L258

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
