### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -61,7 +61,7 @@ Sensor.
 When the Sensor is used to trigger a Workflow, you might need to configure the
 Service Account used in the Workflow spec (**NOT**
 `spec.template.serviceAccountName`) following Argo Workflow
-[instructions](https://github.com/argoproj/argo/blob/master/docs/service-accounts.md).
+[instructions](https://github.com/argoproj/argo-workflows/blob/master/docs/service-accounts.md).
 
 If it is used to trigger other K8s resources (i.e. a Deployment), make sure to
 follow least privilege principle.


### PR DESCRIPTION
the instructions link in "Service Account for Trigged Workflows" section is broken. Find the correct one ,and replaced it.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
