### PR TITLE
feat: support for PubSub emulator

### DIFF
--- a/docs/eventsources/gcp-pubsub.md
+++ b/docs/eventsources/gcp-pubsub.md
@@ -27,3 +27,13 @@ Full spec is available [here](https://github.com/argoproj/argo-events/tree/stabl
 
 See a PubSub EventSource
 [example](https://github.com/argoproj/argo-events/tree/stable/examples/event-sources/gcp-pubsub.yaml).
+
+## Running With PubSub Emulator
+
+You can point this event source at the
+[PubSub Emulator](https://cloud.google.com/pubsub/docs/emulator) by
+configuring the `PUBSUB_EMULATOR_HOST` environment variable for the event
+source pod. This can be configured on the `EventSource` resource under the
+`spec.template.container.env` key. This option is also documented in the
+PubSub EventSource
+[example](https://github.com/argoproj/argo-events/tree/stable/examples/event-sources/gcp-pubsub.yaml).

--- a/eventsources/sources/gcppubsub/start.go
+++ b/eventsources/sources/gcppubsub/start.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -233,23 +234,28 @@ func (el *EventListener) prepareSubscription(ctx context.Context, logger *zap.Su
 	// no            | yes         | yes          | create subsc.         | pubsub.subscriptions.create (proj.) + pubsub.topics.attachSubscription (topic)
 	// no            | yes         | no           | create topic & subsc. | above + pubsub.topics.create (proj. for topic)
 
-	// trick: you don't need to have get permission to check only whether it exists
-	perms, err := subscription.IAM().TestPermissions(ctx, []string{"pubsub.subscriptions.consume"})
-	subscExists := len(perms) == 1
-	if !subscExists {
-		switch status.Code(err) {
-		case codes.OK:
-			client.Close()
-			return nil, nil, errors.Errorf("you lack permission to pull from %s", subscription)
-		case codes.NotFound:
-			// OK, maybe the subscription doesn't exist yet, so create it later
-			// (it possibly means project itself doesn't exist, but it's ok because we'll see an error later in such case)
-		default:
-			client.Close()
-			return nil, nil, errors.Wrapf(err, "failed to test permission for subscription %s", subscription)
+	subscExists := false
+	if addr := os.Getenv("PUBSUB_EMULATOR_HOST"); addr != "" {
+		logger.Debug("using pubsub emulator - skipping permissions check")
+	} else {
+		// trick: you don't need to have get permission to check only whether it exists
+		perms, err := subscription.IAM().TestPermissions(ctx, []string{"pubsub.subscriptions.consume"})
+		subscExists = len(perms) == 1
+		if !subscExists {
+			switch status.Code(err) {
+			case codes.OK:
+				client.Close()
+				return nil, nil, errors.Errorf("you lack permission to pull from %s", subscription)
+			case codes.NotFound:
+				// OK, maybe the subscription doesn't exist yet, so create it later
+				// (it possibly means project itself doesn't exist, but it's ok because we'll see an error later in such case)
+			default:
+				client.Close()
+				return nil, nil, errors.Wrapf(err, "failed to test permission for subscription %s", subscription)
+			}
 		}
+		logger.Debug("checked if subscription exists and you have right permission")
 	}
-	logger.Debug("checked if subscription exists and you have right permission")
 
 	// subsc. exists | topic given | topic exists | action                | required permissions
 	// :------------ | :---------- | :----------- | :-------------------- | :-----------------------------------------------------------------------------

--- a/eventsources/sources/gcppubsub/start.go
+++ b/eventsources/sources/gcppubsub/start.go
@@ -237,6 +237,11 @@ func (el *EventListener) prepareSubscription(ctx context.Context, logger *zap.Su
 	subscExists := false
 	if addr := os.Getenv("PUBSUB_EMULATOR_HOST"); addr != "" {
 		logger.Debug("using pubsub emulator - skipping permissions check")
+		subscExists, err = subscription.Exists(ctx)
+		if err != nil {
+			client.Close()
+			return nil, nil, errors.Errorf("failed to check if subscription %s exists", subscription)
+		}
 	} else {
 		// trick: you don't need to have get permission to check only whether it exists
 		perms, err := subscription.IAM().TestPermissions(ctx, []string{"pubsub.subscriptions.consume"})

--- a/examples/event-sources/gcp-pubsub.yaml
+++ b/examples/event-sources/gcp-pubsub.yaml
@@ -44,6 +44,12 @@ spec:
 
 #   template:
 #     serviceAccountName: my-sa
+#     # (optional) you can add a PUBSUB_EMULATOR_HOST environment variable to the EventSource pod to connect
+#     # to a PubSub emulator (no credentials needed)
+#     container:
+#       env:
+#         - name: PUBSUB_EMULATOR_HOST
+#           value: pubsub-emulator:9030
 #   pubSub:
 #     example-workload-identity:
 #       # (optional) jsonBody specifies that all event body payload coming from this


### PR DESCRIPTION
The rest of my application runs locally and uses the PubSub emulator, and I'd like to be able to run Argo Events locally as well.

My application triggers Argo Workflows via the GCP PubSub event source. However, when pointing the PubSub source at the emulator (by setting the `PUBSUB_EMULATOR_HOST` environment variable), the source errors out on the permissions test, since the PubSub emulator doesn't support that gRPC call.

This PR makes the GCP PubSub event source skip the permissions check when the `PUBSUB_EMULATOR_HOST` environment variable is set.

I've tested this locally on my machine, and events are being pulled from the PubSub emulator with these changes.