### PR TITLE
docs: updated git url to point to the correct argo-workflows repo containing the specified hello-world.yaml file

### DIFF
--- a/examples/tutorials/03-trigger-sources/sensor-git.yaml
+++ b/examples/tutorials/03-trigger-sources/sensor-git.yaml
@@ -36,7 +36,7 @@ spec:
           operation: create
           source:
             git:
-              url: "git@github.com:argoproj/argo.git"
+              url: "git@github.com:argoproj/argo-workflows.git"
               cloneDirectory: "/git/argoproj"
               sshKeyPath: "/secret/key"
               namespace: argo-events


### PR DESCRIPTION
The tutorial on [git triggers ](https://argoproj.github.io/argo-events/tutorials/03-trigger-sources/) references this yaml file which contains the following:

>        source:
>             git:
>               url: "git@github.com:argoproj/argo.git"
>               cloneDirectory: "/git/argoproj"
>               sshKeyPath: "/secret/key"
>               namespace: argo-events
>               filePath: "examples/hello-world.yaml"
>               branch: "master"

The url is incorrect and causes an error when Argo Events attempts to utilize this workflow. This small change corrects that url to the yaml file I believe is being specified in the argo-workflows repo.

--- 

- updated git repo to point to the correct argo-workflows repo containing the specified hello-world.yaml file

Signed-off-by: Anthony Scott <anthony@canthonyscott.com>**
