### PR TITLE
fix: disable bool simplifier due to performance issue. Fixes #1339

### DIFF
--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -416,15 +416,8 @@ func (sensorCtx *SensorContext) getDependencyExpression(ctx context.Context, tri
 		}
 		depExpression = strings.Join(deps, "&&")
 	}
-	logger.Infof("Dependency expression for trigger %s before simplification: %s", trigger.Template.Name, depExpression)
-	boolSimplifier, err := common.NewBoolExpression(depExpression)
-	if err != nil {
-		logger.Errorw("Invalid dependency expression", zap.Error(err))
-		return "", err
-	}
-	result := boolSimplifier.GetExpression()
-	logger.Infof("Dependency expression for trigger %s after simplification: %s", trigger.Template.Name, result)
-	return result, nil
+	logger.Infof("Dependency expression for trigger %s: %s", trigger.Template.Name, depExpression)
+	return depExpression, nil
 }
 
 func convertEvent(event cloudevents.Event) *v1alpha1.Event {

--- a/sensors/listener_test.go
+++ b/sensors/listener_test.go
@@ -82,9 +82,8 @@ func TestGetDependencyExpression(t *testing.T) {
 		sensorCtx := &SensorContext{
 			sensor: obj,
 		}
-		expr, err := sensorCtx.getDependencyExpression(context.Background(), *fakeTrigger)
+		_, err := sensorCtx.getDependencyExpression(context.Background(), *fakeTrigger)
 		assert.NoError(t, err)
-		assert.Equal(t, "dep1 && dep2", expr)
 	})
 
 	t.Run("get complex expression", func(t *testing.T) {
@@ -110,9 +109,8 @@ func TestGetDependencyExpression(t *testing.T) {
 			sensor: obj,
 		}
 		trig := fakeTrigger.DeepCopy()
-		expr, err := sensorCtx.getDependencyExpression(context.Background(), *trig)
+		_, err := sensorCtx.getDependencyExpression(context.Background(), *trig)
 		assert.NoError(t, err)
-		assert.Equal(t, "dep1 && dep1a && dep2", expr)
 	})
 
 	t.Run("get conditions expression", func(t *testing.T) {
@@ -144,8 +142,7 @@ func TestGetDependencyExpression(t *testing.T) {
 		}
 		trig := fakeTrigger.DeepCopy()
 		trig.Template.Conditions = "dep-1 || dep-1a || dep-3"
-		expr, err := sensorCtx.getDependencyExpression(context.Background(), *trig)
+		_, err := sensorCtx.getDependencyExpression(context.Background(), *trig)
 		assert.NoError(t, err)
-		assert.Equal(t, "dep_1a || dep-3 || dep-1", expr)
 	})
 }


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Fixes: #1339

The `bool expression simplifier` is used by the Sensor to simplify and group different trigger conditions, fox example, `a || (a && b) || c` will be simplified as `a || c`, so that different triggers using same condition will only start one subscription to NATS Streaming. It's implemented by using [Quine–McCluskey](https://en.wikipedia.org/wiki/Quine%E2%80%93McCluskey_algorithm) algorithm. However, this implementation consumes huge memory when the number of the items involved in the bool expression is greater than certain number (around 20).

It's not easy to enhance the algorithm, so I'd like to disable it.

Possible impact:

1. There's no feature changes for the user;
2. It might start more subscriptions to STAN than before in some cases. For example, there are 2 triggers in a sensor object, condition for the 1st one is `a && b`, 2nd one is `b && a`, it used to start 1 subscription to STAN because they are essentially same, but now it will do two. This will not bring any feature changes from the users' point of view, but will just increase a little bit of resources consumption for the Sensor, but this could be ignored comparing with the huge memory consumption mentioned in the issue.
3. Since in some cases there will be more subscriptions to STAN, potentially it could reach the max subscription limit of NATS Streaming, which defaults to 1000. So if there are around 1000 triggers defined in all the sensors in one namespace, the user should increase max subscription limit settings, see https://github.com/argoproj/argo-events/blob/master/docs/eventbus.md#more-about-native-nats-eventbus.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
