### PR TITLE
feat: Generate CHANGELOG.md automatically

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,27 @@
+name: Changelog
+
+on:
+  push:
+    tags:
+      - v*
+      - "!v.0.9"
+jobs:
+  generate_changelog:
+    if: github.repository == 'argoproj/argo-events'
+    runs-on: ubuntu-latest
+    name: Generate changelog
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+      - run: git fetch --prune --prune-tags
+      - run: git tag -l 'v*'
+      # avoid invoking `make` to reduce the risk of a Makefile bug failing this workflow
+      - run: ./hack/changelog.sh > CHANGELOG.md
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          title: 'docs: updated CHANGELOG.md'
+          commit-message: 'docs: updated CHANGELOG.md'
+          signoff: true
+

--- a/hack/changelog.sh
+++ b/hack/changelog.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eu
+
+echo '# Changelog'
+echo
+
+tag=
+# we skip v.0.9 tags, so these can be used on branches without updating release notes
+git tag -l 'v*' | grep -v v.0.9 | sed 's/-rc/~/' | sort -rV | sed 's/~/-rc/' | while read last; do
+  if [ "$tag" != "" ]; then
+    echo "## $(git for-each-ref --format='%(refname:strip=2) (%(creatordate:short))' refs/tags/${tag})"
+    echo
+    git_log='git --no-pager log --no-merges --invert-grep --grep=^\(build\|chore\|ci\|docs\|test\):'
+	  $git_log --format=' * [%h](https://github.com/argoproj/argo-events/commit/%H) %s' $last..$tag
+	  echo
+	  echo "### Contributors"
+	  echo
+	  $git_log --format=' * %an'  $last..$tag | sort -u
+	  echo
+  fi
+  tag=$last
+done
+


### PR DESCRIPTION
Signed-off-by: makocchi-git <makocchi@gmail.com>

`CHANGELOG.md` in this repository is still old.  
I think that it needs the same flow as argo-workflows one.
- Add `hack/changelog.sh`
- Add `.github/workflows/changelog.yaml`

Tag `v.0.9` (may be typo) should be ignored because of sorting problem.