### PR TITLE
fix: resource eventsource duplicate update events. Fixes #760 (#1025)

### DIFF
--- a/eventsources/sources/resource/start.go
+++ b/eventsources/sources/resource/start.go
@@ -199,6 +199,12 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 		case v1alpha1.UPDATE:
 			handlerFuncs.UpdateFunc = func(oldObj, newObj interface{}) {
 				log.Info("detected update event")
+				uNewObj := newObj.(*unstructured.Unstructured)
+				uOldObj := oldObj.(*unstructured.Unstructured)
+				if uNewObj.GetResourceVersion() == uOldObj.GetResourceVersion() {
+					log.Infof("rejecting update event with identical resource versions: %s", uNewObj.GetResourceVersion())
+					return
+				}
 				informerEventCh <- &InformerEvent{
 					Obj:    newObj,
 					OldObj: oldObj,


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

This fixes spurious update events for k8s resources that have not changed at all. At the moment, those unwanted and unnecessary update events are generated by the apiserver dropping the watch at some point every 30 to 60 minutes. Obviously, having a downstream service relying on this behavior would be "weird" at best.
