### PR TITLE
docs: Add example service that selects event source pods with selector

### DIFF
--- a/docs/eventsources/services.md
+++ b/docs/eventsources/services.md
@@ -36,7 +36,7 @@ to select pods created for the "webhook" event source, like the following:
 apiVersion: v1
 kind: Service
 metadata:
-  name: github-eventsource-svc
+  name: webhook-eventsource
 spec:
   ports:
   - port: 12000

--- a/docs/eventsources/services.md
+++ b/docs/eventsources/services.md
@@ -29,5 +29,25 @@ expose the endpoint for external access, please manage it by using native K8s
 objects (i.e. a Load Balancer type Service, or an Ingress), and remove `service`
 field from the EventSource object.
 
+For example, you can create a K8s service with the selector `eventsource-name: webhook`
+to select pods created for the "webhook" event source, like the following:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-eventsource-svc
+spec:
+  ports:
+  - port: 12000
+    protocol: TCP
+    targetPort: 12000
+  selector:
+    eventsource-name: webhook
+  type: NodePort
+```
+
+Then you can expose the service for external access using native K8s objects as mentioned above.
+
 You can refer to [webhook heath check](webhook-health-check.md) if you need a
 health check endpoint for LB Service or Ingress configuration.


### PR DESCRIPTION
Currently, there's only documentation on the use of `service` in event source spec. Adding this example so that users don't have to search for the selector key for event source pods.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
