### PR TITLE
fix: Marked optional fields in github and calendar eventsources

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -706,6 +706,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Schedule is a cron-like expression. For reference, see: <a href="https://en.wikipedia.org/wiki/Cron">https://en.wikipedia.org/wiki/Cron</a></p>
 </td>
 </tr>
@@ -717,6 +718,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Interval is a string that describes an interval duration, e.g. 1s, 30m, 2h&hellip;</p>
 </td>
 </tr>
@@ -728,6 +730,7 @@ string
 </em>
 </td>
 <td>
+<p>ExclusionDates defines the list of DATE-TIME exceptions for recurring events.</p>
 </td>
 </tr>
 <tr>
@@ -2061,6 +2064,7 @@ int64
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Id is the webhook&rsquo;s id
 Deprecated: This is not used at all, will be removed in v1.6</p>
 </td>
@@ -2086,6 +2090,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DeprecatedOwner refers to GitHub owner name i.e. argoproj
 Deprecated: use Repositories instead. Will be unsupported in v 1.6</p>
 </td>
@@ -2098,6 +2103,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DeprecatedRepository refers to GitHub repo name i.e. argo-events
 Deprecated: use Repositories instead. Will be unsupported in v 1.6</p>
 </td>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -751,6 +751,7 @@ Description
 <code>schedule</code></br> <em> string </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 Schedule is a cron-like expression. For reference, see:
 <a href="https://en.wikipedia.org/wiki/Cron">https://en.wikipedia.org/wiki/Cron</a>
@@ -762,6 +763,7 @@ Schedule is a cron-like expression. For reference, see:
 <code>interval</code></br> <em> string </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 Interval is a string that describes an interval duration, e.g. 1s, 30m,
 2h…
@@ -773,6 +775,10 @@ Interval is a string that describes an interval duration, e.g. 1s, 30m,
 <code>exclusionDates</code></br> <em> \[\]string </em>
 </td>
 <td>
+<p>
+ExclusionDates defines the list of DATE-TIME exceptions for recurring
+events.
+</p>
 </td>
 </tr>
 <tr>
@@ -2130,6 +2136,7 @@ Description
 <code>id</code></br> <em> int64 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 Id is the webhook’s id Deprecated: This is not used at all, will be
 removed in v1.6
@@ -2153,6 +2160,7 @@ Webhook refers to the configuration required to run a http server
 <code>owner</code></br> <em> string </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 DeprecatedOwner refers to GitHub owner name i.e. argoproj Deprecated:
 use Repositories instead. Will be unsupported in v 1.6
@@ -2164,6 +2172,7 @@ use Repositories instead. Will be unsupported in v 1.6
 <code>repository</code></br> <em> string </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 DeprecatedRepository refers to GitHub repo name i.e. argo-events
 Deprecated: use Repositories instead. Will be unsupported in v 1.6

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -774,6 +774,7 @@
       "description": "CalendarEventSource describes a time based dependency. One of the fields (schedule, interval, or recurrence) must be passed. Schedule takes precedence over interval; interval takes precedence over recurrence",
       "properties": {
         "exclusionDates": {
+          "description": "ExclusionDates defines the list of DATE-TIME exceptions for recurring events.",
           "items": {
             "type": "string"
           },
@@ -803,10 +804,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "schedule",
-        "interval"
-      ],
       "type": "object"
     },
     "io.argoproj.eventsource.v1alpha1.CatchupConfiguration": {
@@ -1322,9 +1319,6 @@
         }
       },
       "required": [
-        "id",
-        "owner",
-        "repository",
         "events"
       ],
       "type": "object"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -768,12 +768,9 @@
     "io.argoproj.eventsource.v1alpha1.CalendarEventSource": {
       "description": "CalendarEventSource describes a time based dependency. One of the fields (schedule, interval, or recurrence) must be passed. Schedule takes precedence over interval; interval takes precedence over recurrence",
       "type": "object",
-      "required": [
-        "schedule",
-        "interval"
-      ],
       "properties": {
         "exclusionDates": {
+          "description": "ExclusionDates defines the list of DATE-TIME exceptions for recurring events.",
           "type": "array",
           "items": {
             "type": "string"
@@ -1230,9 +1227,6 @@
       "description": "GithubEventSource refers to event-source for github related events",
       "type": "object",
       "required": [
-        "id",
-        "owner",
-        "repository",
         "events"
       ],
       "properties": {

--- a/pkg/apis/eventsource/v1alpha1/generated.proto
+++ b/pkg/apis/eventsource/v1alpha1/generated.proto
@@ -231,11 +231,14 @@ message BitbucketServerEventSource {
 // Schedule takes precedence over interval; interval takes precedence over recurrence
 message CalendarEventSource {
   // Schedule is a cron-like expression. For reference, see: https://en.wikipedia.org/wiki/Cron
+  // +optional
   optional string schedule = 1;
 
   // Interval is a string that describes an interval duration, e.g. 1s, 30m, 2h...
+  // +optional
   optional string interval = 2;
 
+  // ExclusionDates defines the list of DATE-TIME exceptions for recurring events.
   repeated string exclusionDates = 3;
 
   // Timezone in which to run the schedule
@@ -478,6 +481,7 @@ message GenericEventSource {
 message GithubEventSource {
   // Id is the webhook's id
   // Deprecated: This is not used at all, will be removed in v1.6
+  // +optional
   optional int64 id = 1;
 
   // Webhook refers to the configuration required to run a http server
@@ -485,10 +489,12 @@ message GithubEventSource {
 
   // DeprecatedOwner refers to GitHub owner name i.e. argoproj
   // Deprecated: use Repositories instead. Will be unsupported in v 1.6
+  // +optional
   optional string owner = 3;
 
   // DeprecatedRepository refers to GitHub repo name i.e. argo-events
   // Deprecated: use Repositories instead. Will be unsupported in v 1.6
+  // +optional
   optional string repository = 4;
 
   // Events refer to Github events to which the event source will subscribe

--- a/pkg/apis/eventsource/v1alpha1/openapi_generated.go
+++ b/pkg/apis/eventsource/v1alpha1/openapi_generated.go
@@ -533,7 +533,8 @@ func schema_pkg_apis_eventsource_v1alpha1_CalendarEventSource(ref common.Referen
 					},
 					"exclusionDates": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "ExclusionDates defines the list of DATE-TIME exceptions for recurring events.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -575,7 +576,6 @@ func schema_pkg_apis_eventsource_v1alpha1_CalendarEventSource(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"schedule", "interval"},
 			},
 		},
 		Dependencies: []string{
@@ -1570,7 +1570,7 @@ func schema_pkg_apis_eventsource_v1alpha1_GithubEventSource(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"id", "owner", "repository", "events"},
+				Required: []string{"events"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -206,11 +206,12 @@ type Service struct {
 // Schedule takes precedence over interval; interval takes precedence over recurrence
 type CalendarEventSource struct {
 	// Schedule is a cron-like expression. For reference, see: https://en.wikipedia.org/wiki/Cron
+	// +optional
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 	// Interval is a string that describes an interval duration, e.g. 1s, 30m, 2h...
+	// +optional
 	Interval string `json:"interval" protobuf:"bytes,2,opt,name=interval"`
 	// ExclusionDates defines the list of DATE-TIME exceptions for recurring events.
-
 	ExclusionDates []string `json:"exclusionDates,omitempty" protobuf:"bytes,3,rep,name=exclusionDates"`
 	// Timezone in which to run the schedule
 	// +optional
@@ -662,14 +663,17 @@ type OwnedRepositories struct {
 type GithubEventSource struct {
 	// Id is the webhook's id
 	// Deprecated: This is not used at all, will be removed in v1.6
+	// +optional
 	ID int64 `json:"id" protobuf:"varint,1,opt,name=id"`
 	// Webhook refers to the configuration required to run a http server
 	Webhook *WebhookContext `json:"webhook,omitempty" protobuf:"bytes,2,opt,name=webhook"`
 	// DeprecatedOwner refers to GitHub owner name i.e. argoproj
 	// Deprecated: use Repositories instead. Will be unsupported in v 1.6
+	// +optional
 	DeprecatedOwner string `json:"owner" protobuf:"bytes,3,opt,name=owner"`
 	// DeprecatedRepository refers to GitHub repo name i.e. argo-events
 	// Deprecated: use Repositories instead. Will be unsupported in v 1.6
+	// +optional
 	DeprecatedRepository string `json:"repository" protobuf:"bytes,4,opt,name=repository"`
 	// Events refer to Github events to which the event source will subscribe
 	Events []string `json:"events" protobuf:"bytes,5,rep,name=events"`


### PR DESCRIPTION
Signed-off-by: Daniel Soifer <daniel.soifer@codefresh.io>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
