### PR TITLE
don't wait for context when listening fails

### DIFF
--- a/eventsources/sources/minio/start.go
+++ b/eventsources/sources/minio/start.go
@@ -101,8 +101,6 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 		}
 	}
 
-	<-ctx.Done()
-
 	log.Info("event source is stopped")
 	return nil
 }


### PR DESCRIPTION
Fixes #1396 

I'm not entirely sure why this line was there in the first place. But it blocks the goroutine when the `ListenBucketNotification` call returns (e.g. when minio is down).