### PR TITLE
Modified deprecated projectID field of Gitlab Eventsource to be optional

### DIFF
--- a/api/event-source.html
+++ b/api/event-source.html
@@ -2594,6 +2594,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DeprecatedProjectID is the id of project for which integration needs to setup
 Deprecated: use Projects instead. Will be unsupported in v 1.7</p>
 </td>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -2676,6 +2676,7 @@ Webhook holds configuration to run a http server
 <code>projectID</code></br> <em> string </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>
 DeprecatedProjectID is the id of project for which integration needs to
 setup Deprecated: use Projects instead. Will be unsupported in v 1.7

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -1499,7 +1499,6 @@
         }
       },
       "required": [
-        "projectID",
         "events",
         "gitlabBaseURL"
       ],

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1432,7 +1432,6 @@
       "description": "GitlabEventSource refers to event-source related to Gitlab events",
       "type": "object",
       "required": [
-        "projectID",
         "events",
         "gitlabBaseURL"
       ],

--- a/pkg/apis/eventsource/v1alpha1/generated.proto
+++ b/pkg/apis/eventsource/v1alpha1/generated.proto
@@ -618,6 +618,7 @@ message GitlabEventSource {
 
   // DeprecatedProjectID is the id of project for which integration needs to setup
   // Deprecated: use Projects instead. Will be unsupported in v 1.7
+  // +optional
   optional string projectID = 2;
 
   // Events are gitlab event to listen to.

--- a/pkg/apis/eventsource/v1alpha1/openapi_generated.go
+++ b/pkg/apis/eventsource/v1alpha1/openapi_generated.go
@@ -1801,7 +1801,6 @@ func schema_pkg_apis_eventsource_v1alpha1_GitlabEventSource(ref common.Reference
 					"projectID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DeprecatedProjectID is the id of project for which integration needs to setup Deprecated: use Projects instead. Will be unsupported in v 1.7",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1887,7 +1886,7 @@ func schema_pkg_apis_eventsource_v1alpha1_GitlabEventSource(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"projectID", "events", "gitlabBaseURL"},
+				Required: []string{"events", "gitlabBaseURL"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -763,7 +763,8 @@ type GitlabEventSource struct {
 	Webhook *WebhookContext `json:"webhook,omitempty" protobuf:"bytes,1,opt,name=webhook"`
 	// DeprecatedProjectID is the id of project for which integration needs to setup
 	// Deprecated: use Projects instead. Will be unsupported in v 1.7
-	DeprecatedProjectID string `json:"projectID" protobuf:"bytes,2,opt,name=projectID"`
+	// +optional
+	DeprecatedProjectID string `json:"projectID,omitempty" protobuf:"bytes,2,opt,name=projectID"`
 	// Events are gitlab event to listen to.
 	// Refer https://github.com/xanzy/go-gitlab/blob/bf34eca5d13a9f4c3f501d8a97b8ac226d55e4d9/projects.go#L794.
 	Events []string `json:"events" protobuf:"bytes,3,opt,name=events"`


### PR DESCRIPTION
Signed-off-by: Daniel Soifer <daniel.soifer@codefresh.io>

Fixes the following JSON schema validation error when using `projects` field instead of the deprecated `projectID` field in a Gitlab Eventsource:


![Screen Shot 2022-01-05 at 14 41 55](https://user-images.githubusercontent.com/69415974/148219469-001e6fbd-cbe0-4bb3-bdf7-ed24d9dc8fbb.png)



<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
