### PR TITLE
Add SNSEvent to RecreateStrategyEventSources

### DIFF
--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -73,6 +73,7 @@ var (
 		HDFSEvent,
 		FileEvent,
 		GenericEvent,
+		SNSEvent
 	}
 )
 

--- a/pkg/apis/common/common.go
+++ b/pkg/apis/common/common.go
@@ -73,7 +73,7 @@ var (
 		HDFSEvent,
 		FileEvent,
 		GenericEvent,
-		SNSEvent
+		SNSEvent,
 	}
 )
 


### PR DESCRIPTION
The SNS EventSource creates (and removes) a subscription to the SNS Topic in AWS. With the default RollingUpdate strategy, the subscription is removed by the terminating Pod after the new EventSource starts, preventing the EventSource from working.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
