### PR TITLE
chore: Update golangci-lint to 1.44.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
     - rowserrcheck

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ start: image
 	kubectl -n argo-events wait --for=condition=Ready --timeout 60s pod --all
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.42.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.44.0
 
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/eventsources/sources/amqp/start.go
+++ b/eventsources/sources/amqp/start.go
@@ -19,8 +19,9 @@ package amqp
 import (
 	"context"
 	"encoding/json"
-	"sigs.k8s.io/yaml"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/pkg/errors"
 	amqplib "github.com/streadway/amqp"

--- a/eventsources/sources/amqp/start_test.go
+++ b/eventsources/sources/amqp/start_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package amqp
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseYamlTable(t *testing.T) {

--- a/eventsources/sources/kafka/start.go
+++ b/eventsources/sources/kafka/start.go
@@ -261,7 +261,7 @@ func (el *EventListener) partitionConsumer(ctx context.Context, log *zap.Sugared
 	}
 }
 
-func getSaramaConfig(kafkaEventSource *v1alpha1.KafkaEventSource, log *zap.SugaredLogger) (*sarama.Config, error) { //nolint:interfacer
+func getSaramaConfig(kafkaEventSource *v1alpha1.KafkaEventSource, log *zap.SugaredLogger) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 
 	if kafkaEventSource.Version == "" {

--- a/sensors/dependencies/filter_test.go
+++ b/sensors/dependencies/filter_test.go
@@ -922,5 +922,4 @@ func TestFilter(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, pass)
 	})
-
 }

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -277,23 +277,10 @@ func (o *options) runTesting(ctx context.Context, eventSourceName, sensorName st
 		return fmt.Errorf("no pod found for sensor %s", sensorName)
 	}
 
-	successActionReg, err := regexp.Compile(logTriggerActionSuccessful)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex for sensor success pattern: %v", err)
-	}
-	failureActionReg, err := regexp.Compile(logTriggerActionFailed)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex for sensor failure pattern: %v", err)
-	}
-
-	successEventReg, err := regexp.Compile(logEventSuccessful)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex for event source success pattern: %v", err)
-	}
-	failureEventReg, err := regexp.Compile(logEventFailed)
-	if err != nil {
-		return fmt.Errorf("failed to compile regex for event source failure pattern: %v", err)
-	}
+	successActionReg := regexp.MustCompile(logTriggerActionSuccessful)
+	failureActionReg := regexp.MustCompile(logTriggerActionFailed)
+	successEventReg := regexp.MustCompile(logEventSuccessful)
+	failureEventReg := regexp.MustCompile(logEventFailed)
 
 	fmt.Printf(`
 *********************************************************


### PR DESCRIPTION
This commit updates golangci-lint and removes the interfacer check because it
was marked as deprecated and will be removed. See
https://github.com/golangci/golangci-lint/issues/541 for more information.

Signed-off-by: William Van Hevelingen <william.vanhevelingen@acquia.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
