### PR TITLE
feat: add a default location to look for .kube/config in home directory

### DIFF
--- a/test/e2e/fixtures/e2e_suite.go
+++ b/test/e2e/fixtures/e2e_suite.go
@@ -56,7 +56,15 @@ type E2ESuite struct {
 
 func (s *E2ESuite) SetupSuite() {
 	var err error
-	kubeConfig, _ := os.LookupEnv(common.EnvVarKubeConfig)
+
+	kubeConfig, found := os.LookupEnv(common.EnvVarKubeConfig)
+	if !found {
+		home, _ := os.UserHomeDir()
+		kubeConfig = home + "/.kube/config"
+		if _, err := os.Stat(kubeConfig); err != nil && os.IsNotExist(err) {
+			kubeConfig = ""
+		}
+	}
 	s.restConfig, err = common.GetClientConfig(kubeConfig)
 	s.CheckError(err)
 	s.kubeClient, err = kubernetes.NewForConfig(s.restConfig)


### PR DESCRIPTION
adding a default location to look for .kube/config in home directory if the environment variable isn't defined


