### PR TITLE
bug #1626 - make aws-sns sensor work

### DIFF
--- a/examples/sensors/aws-sns.yaml
+++ b/examples/sensors/aws-sns.yaml
@@ -21,20 +21,20 @@ spec:
               metadata:
                 generateName: aws-sns-worfklow-
               spec:
-                entrypoint: whalesay
+                entrypoint: echo
                 arguments:
                   parameters:
                   - name: message
                     # value will be overridden by the event payload
                     value: hello world
                 templates:
-                - name: whalesay
+                - name: echo
                   inputs:
                     parameters:
                     - name: message
                   container:
-                    image: docker/whalesay:latest
-                    command: [cowsay]
+                    image: jreinhart/echo
+                    command: [echo]
                     args: ["{{inputs.parameters.message}}"]
           parameters:
             - src:


### PR DESCRIPTION
instead of failing on 
`This shouldn't happen at /usr/share/perl/5.18/Text/Wrap.pm line 84.`
bug #1626

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
