### PR TITLE
fix: adds SigningCertURL validation for SNS messages

### DIFF
--- a/eventsources/sources/awssns/start.go
+++ b/eventsources/sources/awssns/start.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"reflect"
 	"regexp"
 	"time"
@@ -285,10 +286,30 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 	}, controller, dispatch)
 }
 
+func (m *httpNotification) verifySigningCertUrl() error {
+	regexSigningCertHost := `^sns\.[a-zA-Z0-9\-]{3,}\.amazonaws\.com(\.cn)?$`
+	regex := regexp.MustCompile(regexSigningCertHost)
+	url, err := url.Parse(m.SigningCertURL)
+	if err != nil {
+		return errors.Wrap(err, "SigningCertURL is not a valid URL")
+	}
+	if !regex.MatchString(url.Hostname()) {
+		return errors.Errorf("SigningCertURL hostname `%s` does not match `%s`", url.Hostname(), regexSigningCertHost)
+	}
+	if url.Scheme != "https" {
+		return errors.New("SigningCertURL is not using https")
+	}
+	return nil
+}
+
 func (m *httpNotification) verify() error {
 	msgSig, err := base64.StdEncoding.DecodeString(m.Signature)
 	if err != nil {
 		return errors.Wrap(err, "failed to base64 decode signature")
+	}
+
+	if err := m.verifySigningCertUrl(); err != nil {
+		return errors.Wrap(err, "failed to verify SigningCertURL")
 	}
 
 	res, err := http.Get(m.SigningCertURL)

--- a/eventsources/sources/awssns/start_test.go
+++ b/eventsources/sources/awssns/start_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 BlackRock, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssns
+
+import (
+	"testing"
+)
+
+func Test_httpNotification_verifySigningCertUrl(t *testing.T) {
+	type fields struct {
+		SigningCertURL string
+	}
+	tests := map[string]struct {
+		fields  fields
+		wantErr bool
+	}{
+		"valid":             {fields{"https://sns.us-west-2.amazonaws.com/SimpleNotificationService-123.pem"}, false},
+		"without https":     {fields{"http://sns.us-west-2.amazonaws.com/SimpleNotificationService-123.pem"}, true},
+		"invalid hostname":  {fields{"https://sns.us-west-2.amazonaws-malicious.com/SimpleNotificationService-123.pem"}, true},
+		"invalid subdomain": {fields{"https://other.us-west-2.amazonaws.com/SimpleNotificationService-123.pem"}, true},
+	}
+	for name, tt := range tests {
+		name, tt := name, tt
+		t.Run(name, func(t *testing.T) {
+			m := &httpNotification{
+				SigningCertURL: tt.fields.SigningCertURL,
+			}
+			if err := m.verifySigningCertUrl(); (err != nil) != tt.wantErr {
+				t.Errorf("httpNotification.verifySigningCertUrl() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Given the SigningCertURL is part of the HTTP request body, I don't see where we're validating that the cert URL is indeed valid and from AWS before retrieving the cert [here](https://github.com/argoproj/argo-events/blob/master/eventsources/sources/awssns/start.go#L294). [Here's](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs#L244) an example of this being done in the .net SDK but I don't see that happening in the Golang SDK anywhere.

This PR adds that validation check explicitly.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
