### PR TITLE
fix: Ignore mv event buses error on make codegen. Fixes #1638

### DIFF
--- a/hack/crdgen.sh
+++ b/hack/crdgen.sh
@@ -16,7 +16,7 @@ fi
 header "Generating CRDs"
 controller-gen crd:crdVersions=v1,maxDescLen=262143,maxDescLen=0 paths=./pkg/apis/... output:dir=manifests/base/crds
 
-mv manifests/base/crds/argoproj.io_eventbuses.yaml manifests/base/crds/argoproj.io_eventbus.yaml
+mv manifests/base/crds/argoproj.io_eventbuses.yaml manifests/base/crds/argoproj.io_eventbus.yaml || true
 
 find manifests/base/crds -name 'argoproj.io*.yaml' | while read -r file; do
   echo "Patching ${file}"


### PR DESCRIPTION
This PR:
- Ignores the error from the event buses crd not existing if it doesn't already exist
- Closes #1638
Signed-off-by: J.P. Zivalich <jp@pipekit.io>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
