### PR TITLE
Adds argo stop as a supported operation for argoWorkflow triggers.

### DIFF
--- a/controllers/sensor/validate.go
+++ b/controllers/sensor/validate.go
@@ -178,7 +178,7 @@ func validateArgoWorkflowTrigger(trigger *v1alpha1.ArgoWorkflowTrigger) error {
 	}
 
 	switch trigger.Operation {
-	case v1alpha1.Submit, v1alpha1.Suspend, v1alpha1.Retry, v1alpha1.Resume, v1alpha1.Resubmit, v1alpha1.Terminate:
+	case v1alpha1.Submit, v1alpha1.Suspend, v1alpha1.Retry, v1alpha1.Resume, v1alpha1.Resubmit, v1alpha1.Terminate, v1alpha1.Stop:
 	default:
 		return errors.Errorf("unknown operation type %s", string(trigger.Operation))
 	}

--- a/docs/sensors/triggers/argo-workflow.md
+++ b/docs/sensors/triggers/argo-workflow.md
@@ -68,6 +68,6 @@ provided by the Argo CLI such as,
 To make use of Argo CLI operations, The sensor provides the `argoWorkflow` trigger template,
 
         argoWorkflow:
-          operation: submit  # submit, resubmit, resume, retry, suspend or terminate
+          operation: submit  # submit, resubmit, resume, retry, suspend, terminate or stop
 
 Complete example is available [here](https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/special-workflow-trigger.yaml).

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -51,6 +51,7 @@ const (
 	Retry     ArgoWorkflowOperation = "retry"     // retry a workflow
 	Resume    ArgoWorkflowOperation = "resume"    // resume a workflow
 	Terminate ArgoWorkflowOperation = "terminate" // terminate a workflow
+	Stop      ArgoWorkflowOperation = "stop"      // stop a workflow
 )
 
 // Comparator refers to the comparator operator for a data filter

--- a/sensors/triggers/argo-workflow/argo-workflow.go
+++ b/sensors/triggers/argo-workflow/argo-workflow.go
@@ -166,6 +166,8 @@ func (t *ArgoWorkflowTrigger) Execute(ctx context.Context, events map[string]*v1
 		cmd = exec.Command("argo", "-n", namespace, "suspend", name)
 	case v1alpha1.Terminate:
 		cmd = exec.Command("argo", "-n", namespace, "terminate", name)
+	case v1alpha1.Stop:
+		cmd = exec.Command("argo", "-n", namespace, "stop", name)
 	default:
 		return nil, errors.Errorf("unknown operation type %s", string(op))
 	}


### PR DESCRIPTION
Closes #1647 

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

I haven't added any tests as was done in https://github.com/argoproj/argo-events/pull/1268. Looks like some refactoring would be required in order to unit test this (injecting command runner or something).