### PR TITLE
chore: Allow dependabot to open two prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: k8s.io/*
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

@alexec is okay with allowing two prs now.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
