### PR TITLE
fix: read kafka error channel. Fixes #1656

### DIFF
--- a/sensors/triggers/kafka/kafka.go
+++ b/sensors/triggers/kafka/kafka.go
@@ -123,14 +123,12 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 		kafkaProducers[trigger.Template.Name] = producer
 	}
 
-	kafkaTrigger := &KafkaTrigger{
+	return &KafkaTrigger{
 		Sensor:   sensor,
 		Trigger:  trigger,
 		Producer: producer,
 		Logger:   triggerLogger,
-	}
-
-	return kafkaTrigger, nil
+	}, nil
 }
 
 // GetTriggerType returns the type of the trigger

--- a/sensors/triggers/kafka/kafka.go
+++ b/sensors/triggers/kafka/kafka.go
@@ -47,6 +47,7 @@ type KafkaTrigger struct {
 // NewKafkaTrigger returns a new kafka trigger context.
 func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaProducers map[string]sarama.AsyncProducer, logger *zap.SugaredLogger) (*KafkaTrigger, error) {
 	kafkatrigger := trigger.Template.Kafka
+	triggerLogger := logger.With(logging.LabelTriggerType, apicommon.KafkaTrigger)
 
 	producer, ok := kafkaProducers[trigger.Template.Name]
 	if !ok {
@@ -112,6 +113,13 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 			return nil, err
 		}
 
+		//must read from the Errors() channel or the async producer will deadlock.
+		go func() {
+			for err := range producer.Errors() {
+				triggerLogger.Errorf("Error happened in kafka producer", err)
+			}
+		}()
+
 		kafkaProducers[trigger.Template.Name] = producer
 	}
 
@@ -119,15 +127,8 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 		Sensor:   sensor,
 		Trigger:  trigger,
 		Producer: producer,
-		Logger:   logger.With(logging.LabelTriggerType, apicommon.KafkaTrigger),
+		Logger:   triggerLogger,
 	}
-
-	//must read from the Errors() channel or the async producer will deadlock.
-	go func() {
-		for err := range producer.Errors() {
-			kafkaTrigger.Logger.Errorf("Error happened in kafka producer", err)
-		}
-	}()
 
 	return kafkaTrigger, nil
 }

--- a/sensors/triggers/kafka/kafka.go
+++ b/sensors/triggers/kafka/kafka.go
@@ -122,7 +122,7 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 		Logger:   logger.With(logging.LabelTriggerType, apicommon.KafkaTrigger),
 	}
 
-	//must read from the Errors() channel or the producer will deadlock.
+	//must read from the Errors() channel or the async producer will deadlock.
 	go func() {
 		for err := range producer.Errors() {
 			kafkaTrigger.Logger.Errorf("Error happened in kafka producer", err)


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

This tiny PR is to fix this [issue](https://github.com/argoproj/argo-events/issues/1656). The kafka async producer's error channel must be read otherwise the producer will be blocked. This case happened, e.g., when the brokers restarted.