### PR TITLE
fix: remove string replacement on expressions for event filtering

### DIFF
--- a/common/expr/eval_test.go
+++ b/common/expr/eval_test.go
@@ -41,6 +41,7 @@ func TestEvalBool(t *testing.T) {
 		"email":      "johndoe@intuit.com",
 		"gender":     "Male",
 		"dept":       "devp",
+		"uuid":       "test-case-hyphen",
 	}
 
 	pass, err := EvalBool("(id == 1) && (last_name == 'Doe')", env)
@@ -54,4 +55,9 @@ func TestEvalBool(t *testing.T) {
 	pass, err = EvalBool("invalidexpression", env)
 	assert.Error(t, err)
 	assert.False(t, pass)
+
+	// expr with '-' evaluate the same as others
+	pass, err = EvalBool("(uuid == 'test-case-hyphen')", env)
+	assert.NoError(t, err)
+	assert.True(t, pass)
 }

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -565,5 +565,5 @@ func filterEvent(data []byte, filter *v1alpha1.EventSourceFilter) (bool, error) 
 		params[strings.ReplaceAll(key, "-", "_")] = value
 	}
 	env := expr.GetFuncMap(params)
-	return expr.EvalBool(strings.ReplaceAll(filter.Expression, "-", "_"), env)
+	return expr.EvalBool(filter.Expression, env)
 }


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dpadhiar99@gmail.com>

Fixes #1667 

Previously, expressions were filtered to replace `-` with `_` similar to how params for their keys of their pairs. However this causes unintended behavior and makes filters fail on messages which it shouldn't. 

Example yaml from issue:

```
apiVersion: argoproj.io/v1alpha1
kind: EventSource
metadata:
  name: kafka-eventsource-test
spec:
  kafka:  
    my-test-event:
[...]
       expression: "(body.someUUIDfield == '7e577e57-7e57-7e57-7e57-7e577e577e57')"
```

Sample JSON message:

```
{"someUUIDfield": "7e577e57-7e57-7e57-7e57-7e577e577e57",
  "id": 1}
```

We expect this message to be published since it will evaluate true with our expression.

Logs for this message being sent:
```
2022-02-24T18:14:12.584Z        INFO    argo-events.eventsource kafka/start.go:217      dispatching event on the data channel...        {"eventSourceName": "kafka", "eventSourceType": "kafka", "eventName": "example", "partition-id": "0"}
2022-02-24T18:14:12.607Z        INFO    argo-events.eventsource eventsources/eventing.go:512    succeeded to publish an event   {"eventSourceName": "kafka", "eventName": "example", "eventSourceType": "kafka", "eventID": "kafka:example:kafka-broker:9092:topic-2:0:12"}
```

We also test a JSON message with all `_` instead to show that we have removed string replacement from the expression as previously this would evaluate to `true`.

```
{"someUUIDfield": "7e577e57_7e57_7e57_7e57_7e577e577e57",
  "id": 1}
```

Logs for this message being sent:
```
2022-02-24T18:06:16.493Z        INFO    argo-events.eventsource kafka/start.go:217      dispatching event on the data channel...        {"eventSourceName": "kafka", "eventSourceType": "kafka", "eventName": "example", "partition-id": "0"}
2022-02-24T18:06:16.550Z        DEBUG   argo-events.eventsource eventsources/eventing.go:477    Do not publish event, filter condition not met  {"eventSourceName": "kafka"}
```