### PR TITLE
feat: User should not be able to change Jetstream StreamConfig

### DIFF
--- a/controllers/eventbus/validate.go
+++ b/controllers/eventbus/validate.go
@@ -9,7 +9,7 @@ import (
 // ValidateEventBus accepts an EventBus and performs validation against it
 func ValidateEventBus(eb *v1alpha1.EventBus) error {
 	if eb.Spec.NATS == nil && eb.Spec.JetStream == nil {
-		return fmt.Errorf("invalid spec: either \"nats\" or \"jststream\" needs to be specified")
+		return fmt.Errorf("invalid spec: either \"nats\" or \"jetstream\" needs to be specified")
 	}
 	if x := eb.Spec.NATS; x != nil {
 		if x.Native != nil && x.Exotic != nil {

--- a/webhook/validator/eventbus.go
+++ b/webhook/validator/eventbus.go
@@ -33,6 +33,7 @@ func (eb *eventbus) ValidateCreate(ctx context.Context) *admissionv1.AdmissionRe
 	if err := eventbuscontroller.ValidateEventBus(eb.neweb); err != nil {
 		return DeniedResponse(err.Error())
 	}
+
 	return AllowedResponse()
 }
 

--- a/webhook/validator/eventbus.go
+++ b/webhook/validator/eventbus.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"context"
-	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/client-go/kubernetes"
@@ -67,7 +66,6 @@ func (eb *eventbus) ValidateUpdate(ctx context.Context) *admissionv1.AdmissionRe
 			}
 		}
 	case eb.neweb.Spec.JetStream != nil:
-		fmt.Println("checking update of Jetstream spec")
 		if eb.oldeb.Spec.JetStream == nil {
 			return DeniedResponse("Can not change event bus implmementation")
 		}

--- a/webhook/validator/eventbus.go
+++ b/webhook/validator/eventbus.go
@@ -47,20 +47,20 @@ func (eb *eventbus) ValidateUpdate(ctx context.Context) *admissionv1.AdmissionRe
 	switch {
 	case eb.neweb.Spec.NATS != nil:
 		if eb.oldeb.Spec.NATS == nil {
-			return DeniedResponse("Can not change event bus implmementation")
+			return DeniedResponse("Can not change event bus implementation")
 		}
 		oldNats := eb.oldeb.Spec.NATS
 		newNats := eb.neweb.Spec.NATS
 		if newNats.Native != nil {
 			if oldNats.Native == nil {
-				return DeniedResponse("Can not change NATS event bus implmementation from exotic to native")
+				return DeniedResponse("Can not change NATS event bus implementation from exotic to native")
 			}
 			if authChanged(oldNats.Native.Auth, newNats.Native.Auth) {
 				return DeniedResponse("\"spec.nats.native.auth\" is immutable, can not be updated")
 			}
 		} else if newNats.Exotic != nil {
 			if oldNats.Exotic == nil {
-				return DeniedResponse("Can not change NATS event bus implmementation from native to exotic")
+				return DeniedResponse("Can not change NATS event bus implementation from native to exotic")
 			}
 			if authChanged(oldNats.Exotic.Auth, newNats.Exotic.Auth) {
 				return DeniedResponse("\"spec.nats.exotic.auth\" is immutable, can not be updated")
@@ -68,7 +68,7 @@ func (eb *eventbus) ValidateUpdate(ctx context.Context) *admissionv1.AdmissionRe
 		}
 	case eb.neweb.Spec.JetStream != nil:
 		if eb.oldeb.Spec.JetStream == nil {
-			return DeniedResponse("Can not change event bus implmementation")
+			return DeniedResponse("Can not change event bus implementation")
 		}
 		oldJs := eb.oldeb.Spec.JetStream
 		newJs := eb.neweb.Spec.JetStream

--- a/webhook/validator/eventbus.go
+++ b/webhook/validator/eventbus.go
@@ -74,10 +74,10 @@ func (eb *eventbus) ValidateUpdate(ctx context.Context) *admissionv1.AdmissionRe
 		newJs := eb.neweb.Spec.JetStream
 		if (oldJs.StreamConfig == nil && newJs.StreamConfig != nil) ||
 			(oldJs.StreamConfig != nil && newJs.StreamConfig == nil) {
-			return DeniedResponse("\"spec.jetstream.config\" is immutable, can not be updated")
+			return DeniedResponse("\"spec.jetstream.streamConfig\" is immutable, can not be updated")
 		}
 		if oldJs.StreamConfig != nil && newJs.StreamConfig != nil && *oldJs.StreamConfig != *newJs.StreamConfig {
-			return DeniedResponse("\"spec.jetstream.config\" is immutable, can not be updated, old value='%s', new value='%s'", *oldJs.StreamConfig, *newJs.StreamConfig)
+			return DeniedResponse("\"spec.jetstream.streamConfig\" is immutable, can not be updated, old value='%s', new value='%s'", *oldJs.StreamConfig, *newJs.StreamConfig)
 		}
 	}
 


### PR DESCRIPTION
Fixes #1793 

User should not be able to change Jetstream StreamConfig, since once it's been used the stream settings have been passed to Jetstream

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
