### PR TITLE
fix: address timeout issue on CI server for 'make lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ $(GOPATH)/bin/golangci-lint:
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint
 	go mod tidy
-	golangci-lint run --fix --verbose
+	golangci-lint run --fix --verbose --concurrency 4 --timeout 10m
 
 # release - targets only available on release branch
 ifneq ($(findstring release,$(GIT_BRANCH)),)


### PR DESCRIPTION
Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
