### PR TITLE
feat: Jetstream allows multiple dependencies to refer to the same Event

### DIFF
--- a/controllers/sensor/controller.go
+++ b/controllers/sensor/controller.go
@@ -98,9 +98,9 @@ func (r *reconciler) reconcile(ctx context.Context, sensor *v1alpha1.Sensor) err
 	sensor.Status.InitConditions()
 
 	eventBus := &eventbusv1alpha1.EventBus{}
-	eventBusName := sensor.Spec.EventBusName
-	if eventBusName == "" {
-		eventBusName = common.DefaultEventBusName
+	eventBusName := common.DefaultEventBusName
+	if len(sensor.Spec.EventBusName) > 0 {
+		eventBusName = sensor.Spec.EventBusName
 	}
 	err := r.client.Get(ctx, types.NamespacedName{Namespace: sensor.Namespace, Name: eventBusName}, eventBus)
 	if err != nil {

--- a/controllers/sensor/controller.go
+++ b/controllers/sensor/controller.go
@@ -98,7 +98,10 @@ func (r *reconciler) reconcile(ctx context.Context, sensor *v1alpha1.Sensor) err
 	sensor.Status.InitConditions()
 
 	eventBus := &eventbusv1alpha1.EventBus{}
-	eventBusName := common.DefaultEventBusName
+	eventBusName := sensor.Spec.EventBusName
+	if eventBusName == "" {
+		eventBusName = common.DefaultEventBusName
+	}
 	err := r.client.Get(ctx, types.NamespacedName{Namespace: sensor.Namespace, Name: eventBusName}, eventBus)
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/controllers/sensor/controller.go
+++ b/controllers/sensor/controller.go
@@ -23,13 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/argoproj/argo-events/common"
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -93,7 +96,22 @@ func (r *reconciler) reconcile(ctx context.Context, sensor *v1alpha1.Sensor) err
 	controllerutil.AddFinalizer(sensor, finalizerName)
 
 	sensor.Status.InitConditions()
-	if err := ValidateSensor(sensor); err != nil {
+
+	eventBus := &eventbusv1alpha1.EventBus{}
+	eventBusName := common.DefaultEventBusName
+	err := r.client.Get(ctx, types.NamespacedName{Namespace: sensor.Namespace, Name: eventBusName}, eventBus)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			sensor.Status.MarkDeployFailed("EventBusNotFound", "EventBus not found.")
+			log.Errorw("EventBus not found", "eventBusName", eventBusName, "error", err)
+			return errors.Errorf("eventbus %s not found", eventBusName)
+		}
+		sensor.Status.MarkDeployFailed("GetEventBusFailed", "Failed to get EventBus.")
+		log.Errorw("failed to get EventBus", "eventBusName", eventBusName, "error", err)
+		return err
+	}
+
+	if err := ValidateSensor(sensor, eventBus); err != nil {
 		log.Errorw("validation error", "error", err)
 		return err
 	}
@@ -106,7 +124,7 @@ func (r *reconciler) reconcile(ctx context.Context, sensor *v1alpha1.Sensor) err
 			common.LabelOwnerName:  sensor.Name,
 		},
 	}
-	return Reconcile(r.client, args, log)
+	return Reconcile(r.client, eventBus, args, log)
 }
 
 func (r *reconciler) needsUpdate(old, new *v1alpha1.Sensor) bool {

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-events/common"
@@ -48,28 +47,13 @@ type AdaptorArgs struct {
 }
 
 // Reconcile does the real logic
-func Reconcile(client client.Client, args *AdaptorArgs, logger *zap.SugaredLogger) error {
+func Reconcile(client client.Client, eventBus *eventbusv1alpha1.EventBus, args *AdaptorArgs, logger *zap.SugaredLogger) error {
 	ctx := context.Background()
 	sensor := args.Sensor
-	eventBus := &eventbusv1alpha1.EventBus{}
 	eventBusName := common.DefaultEventBusName
-	if len(sensor.Spec.EventBusName) > 0 {
-		eventBusName = sensor.Spec.EventBusName
-	}
-	err := client.Get(ctx, types.NamespacedName{Namespace: sensor.Namespace, Name: eventBusName}, eventBus)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			sensor.Status.MarkDeployFailed("EventBusNotFound", "EventBus not found.")
-			logger.Errorw("EventBus not found", "eventBusName", eventBusName, "error", err)
-			return errors.Errorf("eventbus %s not found", eventBusName)
-		}
-		sensor.Status.MarkDeployFailed("GetEventBusFailed", "Failed to get EventBus.")
-		logger.Errorw("failed to get EventBus", "eventBusName", eventBusName, "error", err)
-		return err
-	}
 	if !eventBus.Status.IsReady() {
 		sensor.Status.MarkDeployFailed("EventBusNotReady", "EventBus not ready.")
-		logger.Errorw("event bus is not in ready status", "eventBusName", eventBusName, "error", err)
+		logger.Errorw("event bus is not in ready status", "eventBusName", eventBusName)
 		return errors.New("eventbus not ready")
 	}
 

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -50,6 +50,13 @@ type AdaptorArgs struct {
 func Reconcile(client client.Client, eventBus *eventbusv1alpha1.EventBus, args *AdaptorArgs, logger *zap.SugaredLogger) error {
 	ctx := context.Background()
 	sensor := args.Sensor
+
+	if eventBus == nil {
+		sensor.Status.MarkDeployFailed("GetEventBusFailed", "Failed to get EventBus.")
+		logger.Error("failed to get EventBus")
+		return errors.New("failed to get EventBus")
+	}
+
 	eventBusName := common.DefaultEventBusName
 	if !eventBus.Status.IsReady() {
 		sensor.Status.MarkDeployFailed("EventBusNotReady", "EventBus not ready.")

--- a/controllers/sensor/resource.go
+++ b/controllers/sensor/resource.go
@@ -58,6 +58,9 @@ func Reconcile(client client.Client, eventBus *eventbusv1alpha1.EventBus, args *
 	}
 
 	eventBusName := common.DefaultEventBusName
+	if len(sensor.Spec.EventBusName) > 0 {
+		eventBusName = sensor.Spec.EventBusName
+	}
 	if !eventBus.Status.IsReady() {
 		sensor.Status.MarkDeployFailed("EventBusNotReady", "EventBus not ready.")
 		logger.Errorw("event bus is not in ready status", "eventBusName", eventBusName)

--- a/controllers/sensor/resource_test.go
+++ b/controllers/sensor/resource_test.go
@@ -162,7 +162,7 @@ func TestResourceReconcile(t *testing.T) {
 			Sensor: sensorObj,
 			Labels: testLabels,
 		}
-		err := Reconcile(cl, args, logging.NewArgoEventsLogger())
+		err := Reconcile(cl, nil, args, logging.NewArgoEventsLogger())
 		assert.Error(t, err)
 		assert.False(t, sensorObj.Status.IsReady())
 	})
@@ -180,7 +180,7 @@ func TestResourceReconcile(t *testing.T) {
 			Sensor: sensorObj,
 			Labels: testLabels,
 		}
-		err = Reconcile(cl, args, logging.NewArgoEventsLogger())
+		err = Reconcile(cl, testBus, args, logging.NewArgoEventsLogger())
 		assert.Nil(t, err)
 		assert.True(t, sensorObj.Status.IsReady())
 

--- a/controllers/sensor/validate.go
+++ b/controllers/sensor/validate.go
@@ -442,7 +442,7 @@ func validateDependencies(eventDependencies []v1alpha1.EventDependency, b *event
 			// For STAN, EventSourceName + EventName can not be referenced more than once in one Sensor object.
 			comboKey := fmt.Sprintf("%s-$$$-%s", dep.EventSourceName, dep.EventName)
 			if _, existing := comboKeys[comboKey]; existing {
-				return errors.Errorf("%s and %s are referenced more than once in this Sensor object", dep.EventSourceName, dep.EventName)
+				return errors.Errorf("Event '%s' from EventSource '%s' is referenced for more than one dependency in this Sensor object", dep.EventName, dep.EventSourceName)
 			}
 			comboKeys[comboKey] = true
 		}

--- a/controllers/sensor/validate_test.go
+++ b/controllers/sensor/validate_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -41,27 +42,43 @@ func TestValidateSensor(t *testing.T) {
 				assert.NoError(t, err)
 
 				var sensor *v1alpha1.Sensor
+				eventBus := &eventbusv1alpha1.EventBus{Spec: eventbusv1alpha1.EventBusSpec{JetStream: &eventbusv1alpha1.JetStreamBus{}}}
 				err = yaml.Unmarshal(content, &sensor)
 				assert.NoError(t, err)
 
-				err = ValidateSensor(sensor)
+				err = ValidateSensor(sensor, eventBus)
 				assert.NoError(t, err)
 			})
 	}
 }
 
 func TestValidDependencies(t *testing.T) {
-	/*t.Run("test duplicate deps", func(t *testing.T) {
+
+	jetstreamBus := &eventbusv1alpha1.EventBus{Spec: eventbusv1alpha1.EventBusSpec{JetStream: &eventbusv1alpha1.JetStreamBus{}}}
+	stanBus := &eventbusv1alpha1.EventBus{Spec: eventbusv1alpha1.EventBusSpec{NATS: &eventbusv1alpha1.NATSBus{}}}
+
+	t.Run("test duplicate deps fail for STAN", func(t *testing.T) {
 		sObj := sensorObj.DeepCopy()
 		sObj.Spec.Dependencies = append(sObj.Spec.Dependencies, v1alpha1.EventDependency{
 			Name:            "fake-dep2",
 			EventSourceName: "fake-source",
 			EventName:       "fake-one",
 		})
-		err := ValidateSensor(sObj)
+		err := ValidateSensor(sObj, stanBus)
 		assert.NotNil(t, err)
-		assert.Equal(t, true, strings.Contains(err.Error(), "more than once"))
-	})*/
+		assert.Equal(t, true, strings.Contains(err.Error(), "is referenced for more than one dependency"))
+	})
+
+	t.Run("test duplicate deps are fine for Jetstream", func(t *testing.T) {
+		sObj := sensorObj.DeepCopy()
+		sObj.Spec.Dependencies = append(sObj.Spec.Dependencies, v1alpha1.EventDependency{
+			Name:            "fake-dep2",
+			EventSourceName: "fake-source",
+			EventName:       "fake-one",
+		})
+		err := ValidateSensor(sObj, jetstreamBus)
+		assert.Nil(t, err)
+	})
 
 	t.Run("test empty event source name", func(t *testing.T) {
 		sObj := sensorObj.DeepCopy()
@@ -69,7 +86,7 @@ func TestValidDependencies(t *testing.T) {
 			Name:      "fake-dep2",
 			EventName: "fake-one",
 		})
-		err := ValidateSensor(sObj)
+		err := ValidateSensor(sObj, jetstreamBus)
 		assert.NotNil(t, err)
 		assert.Equal(t, true, strings.Contains(err.Error(), "must define the EventSourceName"))
 	})
@@ -80,7 +97,7 @@ func TestValidDependencies(t *testing.T) {
 			Name:            "fake-dep2",
 			EventSourceName: "fake-source",
 		})
-		err := ValidateSensor(sObj)
+		err := ValidateSensor(sObj, jetstreamBus)
 		assert.NotNil(t, err)
 		assert.Equal(t, true, strings.Contains(err.Error(), "must define the EventName"))
 	})
@@ -91,7 +108,7 @@ func TestValidDependencies(t *testing.T) {
 			EventSourceName: "fake-source2",
 			EventName:       "fake-one2",
 		})
-		err := ValidateSensor(sObj)
+		err := ValidateSensor(sObj, jetstreamBus)
 		assert.NotNil(t, err)
 		assert.Equal(t, true, strings.Contains(err.Error(), "must define a name"))
 	})

--- a/controllers/sensor/validate_test.go
+++ b/controllers/sensor/validate_test.go
@@ -53,7 +53,6 @@ func TestValidateSensor(t *testing.T) {
 }
 
 func TestValidDependencies(t *testing.T) {
-
 	jetstreamBus := &eventbusv1alpha1.EventBus{Spec: eventbusv1alpha1.EventBusSpec{JetStream: &eventbusv1alpha1.JetStreamBus{}}}
 	stanBus := &eventbusv1alpha1.EventBus{Spec: eventbusv1alpha1.EventBusSpec{NATS: &eventbusv1alpha1.NATSBus{}}}
 

--- a/webhook/validator/sensor.go
+++ b/webhook/validator/sensor.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	sensorcontroller "github.com/argoproj/argo-events/controllers/sensor"
-	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	sensorv1alpha1 "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	eventbusclient "github.com/argoproj/argo-events/pkg/client/eventbus/clientset/versioned"
 	eventsourceclient "github.com/argoproj/argo-events/pkg/client/eventsource/clientset/versioned"
@@ -34,8 +33,6 @@ func NewSensorValidator(client kubernetes.Interface, ebClient eventbusclient.Int
 }
 
 func (s *sensor) ValidateCreate(ctx context.Context) *admissionv1.AdmissionResponse {
-
-	eventBus := &eventbusv1alpha1.EventBus{}
 	eventBusName := common.DefaultEventBusName
 	if len(s.newSensor.Spec.EventBusName) > 0 {
 		eventBusName = s.newSensor.Spec.EventBusName

--- a/webhook/validator/sensor.go
+++ b/webhook/validator/sensor.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/argoproj/argo-events/common"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/argoproj/argo-events/common"
 	sensorcontroller "github.com/argoproj/argo-events/controllers/sensor"
 	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	sensorv1alpha1 "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
@@ -37,7 +37,10 @@ func (s *sensor) ValidateCreate(ctx context.Context) *admissionv1.AdmissionRespo
 
 	eventBus := &eventbusv1alpha1.EventBus{}
 	eventBusName := common.DefaultEventBusName
-	eventBus, err := s.eventBusClient.ArgoprojV1alpha1().EventBus(s.newSensor.Namespace).Get(ctx, s.newSensor.Spec.EventBusName, metav1.GetOptions{})
+	if len(s.newSensor.Spec.EventBusName) > 0 {
+		eventBusName = s.newSensor.Spec.EventBusName
+	}
+	eventBus, err := s.eventBusClient.ArgoprojV1alpha1().EventBus(s.newSensor.Namespace).Get(ctx, eventBusName, metav1.GetOptions{})
 	if err != nil {
 		return DeniedResponse(fmt.Sprintf("failed to get EventBus eventBusName=%s; err=%v", eventBusName, err))
 	}

--- a/webhook/validator/sensor_test.go
+++ b/webhook/validator/sensor_test.go
@@ -1,20 +1,66 @@
 package validator
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"testing"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-events/common"
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+)
+
+var (
+	fakeBus = &eventbusv1alpha1.EventBus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: eventbusv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "EventBus",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      common.DefaultEventBusName,
+		},
+		Spec: eventbusv1alpha1.EventBusSpec{
+			NATS: &eventbusv1alpha1.NATSBus{
+				Native: &eventbusv1alpha1.NativeStrategy{
+					Auth: &eventbusv1alpha1.AuthStrategyToken,
+				},
+			},
+		},
+		Status: eventbusv1alpha1.EventBusStatus{
+			Config: eventbusv1alpha1.BusConfig{
+				NATS: &eventbusv1alpha1.NATSConfig{
+					URL:  "nats://xxxx",
+					Auth: &eventbusv1alpha1.AuthStrategyToken,
+					AccessSecret: &corev1.SecretKeySelector{
+						Key: "test-key",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-name",
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestValidateSensor(t *testing.T) {
 	dir := "../../examples/sensors"
 	files, err := ioutil.ReadDir(dir)
 	assert.Nil(t, err)
+
+	testBus := fakeBus.DeepCopy()
+	testBus.Status.MarkDeployed("test", "test")
+	testBus.Status.MarkConfigured()
+	_, err = fakeEventBusClient.ArgoprojV1alpha1().EventBus(testNamespace).Create(context.TODO(), testBus, metav1.CreateOptions{})
+	assert.Nil(t, err)
+
 	for _, file := range files {
 		content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", dir, file.Name()))
 		assert.Nil(t, err)


### PR DESCRIPTION
Jetstream and STAN have diverged in terms of what they allow for dependencies being allowed to refer to the same Event. Therefore, the Admission webhook and Sensor Controller both need to grab the currently running EventBus spec to find out which one is. 


Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
