### PR TITLE
Fix problem with triggering workflows

### DIFF
--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -152,6 +152,7 @@ rules:
 - apiGroups:
   - argoproj.io
   resources:
+  - workflows
   - sensors
   - sensors/finalizers
   - sensors/status


### PR DESCRIPTION
Hi all,

I found a problem in the Role when I wanted to trigger workflow on an event. The log is here:

```
{"level":"info","ts":1650698032.4655874,"logger":"argo-events.sensor","caller":"standard-k8s/standard-k8s.go:159","msg":"creating the object...","sensorName":"ognjen-sensor-workflow","triggerName":"webhook-workflow-trigger","triggerType":"Kubernetes"}
{"level":"error","ts":1650698032.4675329,"logger":"argo-events.sensor","caller":"sensors/listener.go:355","msg":"failed to execute a trigger","sensorName":"ognjen-sensor-workflow","error":"failed to execute trigger: timed out waiting for the condition: workflows.argoproj.io is forbidden: User \"system:serviceaccount:argo-project-ns:argo-events-sa\" cannot create resource \"workflows\" in API group \"argoproj.io\" in the namespace \"argo-project-ns\"","errorVerbose":"timed out waiting for the condition: workflows.argoproj.io is forbidden: User \"system:serviceaccount:argo-project-ns:argo-events-sa\" cannot create resource \"workflows\" in API group \"argoproj.io\" in the namespace \"argo-project-ns\"\nfailed to execute trigger\ngithub.com/argoproj/argo-events/sensors.(*SensorContext).triggerOne\n\t/home/runner/work/argo-events/argo-events/sensors/listener.go:408\ngithub.com/argoproj/argo-events/sensors.(*SensorContext).triggerWithRateLimit\n\t/home/runner/work/argo-events/argo-events/sensors/listener.go:353\nruntime.goexit\n\t/opt/hostedtoolcache/go/1.17.1/x64/src/runtime/asm_amd64.s:1581","triggerName":"webhook-workflow-trigger","triggeredBy":["catching-s3-filename-ognjen-sensor-workflow"],"triggeredByEvents":["65663666373039362d636564662d343634642d393338352d346332663365303265613132"],"stacktrace":"github.com/argoproj/argo-events/sensors.(*SensorContext).triggerWithRateLimit\n\t/home/runner/work/argo-events/argo-events/sensors/listener.go:355"}

```

When I added **workflows** in the role, everything started to work properly.