### PR TITLE
feat: add support of submit from existing resource (#1908)

### DIFF
--- a/controllers/sensor/validate.go
+++ b/controllers/sensor/validate.go
@@ -179,7 +179,7 @@ func validateArgoWorkflowTrigger(trigger *v1alpha1.ArgoWorkflowTrigger) error {
 	}
 
 	switch trigger.Operation {
-	case v1alpha1.Submit, v1alpha1.Suspend, v1alpha1.Retry, v1alpha1.Resume, v1alpha1.Resubmit, v1alpha1.Terminate, v1alpha1.Stop:
+	case v1alpha1.Submit, v1alpha1.SubmitFrom, v1alpha1.Suspend, v1alpha1.Retry, v1alpha1.Resume, v1alpha1.Resubmit, v1alpha1.Terminate, v1alpha1.Stop:
 	default:
 		return errors.Errorf("unknown operation type %s", string(trigger.Operation))
 	}

--- a/docs/sensors/triggers/argo-workflow.md
+++ b/docs/sensors/triggers/argo-workflow.md
@@ -60,14 +60,17 @@ Although the sensor defined above lets you trigger an Argo workflow, it doesn't 
 provided by the Argo CLI such as,
 
 1. Submit
-2. Resubmit
-3. Resume
-4. Retry
-5. Suspend
+2. Submit --from
+3. Resubmit
+4. Resume
+5. Retry
+6. Suspend
+7. Terminate
+8. Stop
 
 To make use of Argo CLI operations, The sensor provides the `argoWorkflow` trigger template,
 
         argoWorkflow:
-          operation: submit  # submit, resubmit, resume, retry, suspend, terminate or stop
+          operation: submit  # submit, submit-from, resubmit, resume, retry, suspend, terminate or stop
 
 Complete example is available [here](https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/special-workflow-trigger.yaml).

--- a/examples/sensors/specia-workflow-trigger-submit-existing.yml
+++ b/examples/sensors/specia-workflow-trigger-submit-existing.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: webhook
+spec:
+  template:
+    serviceAccountName: operate-workflow-sa
+  dependencies:
+    - name: test-dep
+      eventSourceName: webhook
+      eventName: example
+  triggers:
+    - template:
+        name: argo-workflow-trigger
+        argoWorkflow:
+          operation: submit-from
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: CronWorkflow
+              metadata:
+                name: special-trigger

--- a/pkg/apis/sensor/v1alpha1/types.go
+++ b/pkg/apis/sensor/v1alpha1/types.go
@@ -45,13 +45,14 @@ type ArgoWorkflowOperation string
 
 // possible values for ArgoWorkflowOperation
 const (
-	Submit    ArgoWorkflowOperation = "submit"    // submit a workflow
-	Suspend   ArgoWorkflowOperation = "suspend"   // suspends a workflow
-	Resubmit  ArgoWorkflowOperation = "resubmit"  // resubmit a workflow
-	Retry     ArgoWorkflowOperation = "retry"     // retry a workflow
-	Resume    ArgoWorkflowOperation = "resume"    // resume a workflow
-	Terminate ArgoWorkflowOperation = "terminate" // terminate a workflow
-	Stop      ArgoWorkflowOperation = "stop"      // stop a workflow
+	Submit     ArgoWorkflowOperation = "submit"      // submit a workflow
+	SubmitFrom ArgoWorkflowOperation = "submit-from" // submit from existing resource
+	Suspend    ArgoWorkflowOperation = "suspend"     // suspends a workflow
+	Resubmit   ArgoWorkflowOperation = "resubmit"    // resubmit a workflow
+	Retry      ArgoWorkflowOperation = "retry"       // retry a workflow
+	Resume     ArgoWorkflowOperation = "resume"      // resume a workflow
+	Terminate  ArgoWorkflowOperation = "terminate"   // terminate a workflow
+	Stop       ArgoWorkflowOperation = "stop"        // stop a workflow
 )
 
 // Comparator refers to the comparator operator for a data filter


### PR DESCRIPTION
This PR fixes #1908 

This PR adds the feature about to submit from existing resources to the argo workflow trigger.

Specify the resource by adding "from" in "metadata" as shown below. In this example, `argo submit --from cronwf/special-trigger` is executed.

```
resource:
  apiVersion: argoproj.io/v1alpha1
  # does not need kind
  metadata:
    name: special-trigger
    from: cronwf
````

I propose this format as a first step. Please give me your comments.

(I tried to add tests, but the existing tests seemed to be hard-coded and adding test makes massive changes. So I don't added any test)

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
