### PR TITLE
chore: discontinue using ioutil

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -151,7 +150,7 @@ func GetSecretFromVolume(selector *v1.SecretKeySelector) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get secret value of name: %s, key: %s", selector.Name, selector.Key)
 	}
@@ -175,7 +174,7 @@ func GetConfigMapFromVolume(selector *v1.ConfigMapKeySelector) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get configMap value of name: %s, key: %s", selector.Name, selector.Key)
 	}
@@ -259,7 +258,7 @@ func GetTLSConfig(config *apicommon.TLSConfig) (*tls.Config, error) {
 
 	c := &tls.Config{}
 	if len(caCertPath) > 0 {
-		caCert, err := ioutil.ReadFile(caCertPath)
+		caCert, err := os.ReadFile(caCertPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read ca cert file %s", caCertPath)
 		}

--- a/controllers/sensor/validate_test.go
+++ b/controllers/sensor/validate_test.go
@@ -18,7 +18,7 @@ package sensor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -31,14 +31,17 @@ import (
 
 func TestValidateSensor(t *testing.T) {
 	dir := "../../examples/sensors"
-	files, dirErr := ioutil.ReadDir(dir)
-	require.NoError(t, dirErr)
+	dirEntries, err := os.ReadDir(dir)
+	require.NoError(t, err)
 
-	for _, file := range files {
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			continue
+		}
 		t.Run(
-			fmt.Sprintf("test example load: %s/%s", dir, file.Name()),
+			fmt.Sprintf("test example load: %s/%s", dir, entry.Name()),
 			func(t *testing.T) {
-				content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", dir, file.Name()))
+				content, err := os.ReadFile(fmt.Sprintf("%s/%s", dir, entry.Name()))
 				assert.NoError(t, err)
 
 				var sensor *v1alpha1.Sensor

--- a/docs/sensors/triggers/http-trigger.md
+++ b/docs/sensors/triggers/http-trigger.md
@@ -13,6 +13,7 @@ Argo Events offers HTTP trigger which can easily invoke serverless functions lik
 <br/>
 
 ## Specification
+
 The HTTP trigger specification is available [here](https://github.com/argoproj/argo-events/blob/master/api/sensor.md#httptrigger).
 
 ## REST API Calls
@@ -21,21 +22,20 @@ Consider a scenario where your REST API server needs to consume events from even
 the integration yourself in the server code, although server logic has nothing to do any of the event-sources. This is where Argo Events HTTP trigger
 can help. The HTTP trigger takes the task of consuming events from event-sources away from API server and seamlessly integrates these events via REST API calls.
 
-
 We will set up a basic go http server and connect it with the Minio events.
 
-1. The HTTP server simply prints the request body as follows.
+1.  The HTTP server simply prints the request body as follows.
 
         package main
 
         import (
         	"fmt"
-        	"io/ioutil"
+        	"io"
         	"net/http"
         )
 
         func hello(w http.ResponseWriter, req *http.Request) {
-        	body, err := ioutil.ReadAll(req.Body)
+        	body, err := io.ReadAll(req.Body)
         	if err != nil {
         		fmt.Printf("%+v\n", err)
         		return
@@ -50,35 +50,34 @@ We will set up a basic go http server and connect it with the Minio events.
         	http.ListenAndServe(":8090", nil)
         }
 
-2. Deploy the HTTP server.
+2.  Deploy the HTTP server.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/09-http-trigger/http-server.yaml
 
-3. Create a service to expose the http server.
+3.  Create a service to expose the http server.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/09-http-trigger/http-server-svc.yaml
 
-4. Either use Ingress, OpenShift Route or port-forwarding to expose the http server.
+4.  Either use Ingress, OpenShift Route or port-forwarding to expose the http server.
 
         kubectl -n argo-events port-forward <http-server-pod-name> 8090:8090
 
-5. Our goals is to seamlessly integrate Minio S3 bucket notifications with REST API server created in previous step. So,
-   lets set up the Minio event-source available [here](https://argoproj.github.io/argo-events/setup/minio/).
-   Don't create the sensor as we will be deploying it in next step.
+5.  Our goals is to seamlessly integrate Minio S3 bucket notifications with REST API server created in previous step. So,
+    lets set up the Minio event-source available [here](https://argoproj.github.io/argo-events/setup/minio/).
+    Don't create the sensor as we will be deploying it in next step.
 
-6. Create a sensor as follows.
+6.  Create a sensor as follows.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/http-trigger.yaml
 
-7. Now, drop a file onto `input` bucket in Minio server.
+7.  Now, drop a file onto `input` bucket in Minio server.
 
-
-8. The sensor has triggered a http request to the http server. Take a look at the logs.
+8.  The sensor has triggered a http request to the http server. Take a look at the logs.
 
         server is listening on 8090
         {"type":"minio","bucket":"input"}
 
-9. Great!!!
+9.  Great!!!
 
 ### Request Payload
 
@@ -122,6 +121,7 @@ you want to define a generic trigger template in the sensor and populate values 
 You can learn more about trigger parameterization [here](https://argoproj.github.io/argo-events/tutorials/02-parameterization/).
 
 ### Policy
+
 Trigger policy helps you determine the status of the HTTP request and decide whether to stop or continue sensor.
 
 To determine whether the HTTP request was successful or not, the HTTP trigger provides a `Status` policy.
@@ -155,32 +155,30 @@ The above HTTP trigger will be treated successful only if the HTTP request retur
 OpenFaaS offers a simple way to spin up serverless functions. Lets see how we can leverage Argo Events HTTP trigger
 to invoke OpenFaaS function.
 
-1. If you don't have OpenFaaS installed, follow the [instructions](https://docs.openfaas.com/deployment/kubernetes/).
+1.  If you don't have OpenFaaS installed, follow the [instructions](https://docs.openfaas.com/deployment/kubernetes/).
 
-2. Let's create a basic function. You can follow the [steps](https://blog.alexellis.io/serverless-golang-with-openfaas/).
-   to set up the function.
+2.  Let's create a basic function. You can follow the [steps](https://blog.alexellis.io/serverless-golang-with-openfaas/).
+    to set up the function.
 
+         package function
 
-        package function
+         import (
+         	"fmt"
+         )
 
-        import (
-        	"fmt"
-        )
+         // Handle a serverless request
+         func Handle(req []byte) string {
+         	return fmt.Sprintf("Hello, Go. You said: %s", string(req))
+         }
 
-        // Handle a serverless request
-        func Handle(req []byte) string {
-        	return fmt.Sprintf("Hello, Go. You said: %s", string(req))
-        }
+3.  Make sure the function pod is up and running.
 
+4.  We are going to invoke OpenFaaS function on a message on Redis Subscriber.
 
-3. Make sure the function pod is up and running.
+5.  Let's set up the Redis Database, Redis PubSub event-source as specified [here](https://argoproj.github.io/argo-events/setup/redis/).
+    Do not create the Redis sensor, we are going to create it in next step.
 
-4. We are going to invoke OpenFaaS function on a message on Redis Subscriber.
-
-5. Let's set up the Redis Database, Redis PubSub event-source as specified [here](https://argoproj.github.io/argo-events/setup/redis/).
-   Do not create the Redis sensor, we are going to create it in next step.
-
-6. Let's create the sensor with OpenFaaS trigger.
+6.  Let's create the sensor with OpenFaaS trigger.
 
         apiVersion: argoproj.io/v1alpha1
         kind: Sensor
@@ -202,32 +200,32 @@ to invoke OpenFaaS function.
                       dest: bucket
                   method: POST
 
-7. Publish a message on `FOO` channel using `redis-cli`.
+7.  Publish a message on `FOO` channel using `redis-cli`.
 
         PUBLISH FOO hello
 
-8. As soon as you publish the message, the sensor will invoke the OpenFaaS function `gohash`.
+8.  As soon as you publish the message, the sensor will invoke the OpenFaaS function `gohash`.
 
 ## Kubeless
 
 Similar to REST API calls, you can easily invoke Kubeless functions using HTTP trigger.
 
-1. If you don't have Kubeless installed, follow the [installation](https://kubeless.io/docs/quick-start/).
+1.  If you don't have Kubeless installed, follow the [installation](https://kubeless.io/docs/quick-start/).
 
-2. Lets create a basic function.
+2.  Lets create a basic function.
 
         def hello(event, context):
           print event
           return event['data']
 
-3. Make sure the function pod and service is created.
+3.  Make sure the function pod and service is created.
 
-4. Now, we are going to invoke the Kubeless function when a message is placed on a NATS queue.
+4.  Now, we are going to invoke the Kubeless function when a message is placed on a NATS queue.
 
-5. Let's set up the NATS event-source. Follow [instructions](https://argoproj.github.io/argo-events/setup/nats/#setup) for details.
-   Do not create the NATS sensor, we are going to create it in next step.
+5.  Let's set up the NATS event-source. Follow [instructions](https://argoproj.github.io/argo-events/setup/nats/#setup) for details.
+    Do not create the NATS sensor, we are going to create it in next step.
 
-6. Let's create NATS sensor with HTTP trigger.
+6.  Let's create NATS sensor with HTTP trigger.
 
         apiVersion: argoproj.io/v1alpha1
         kind: Sensor
@@ -254,11 +252,11 @@ Similar to REST API calls, you can easily invoke Kubeless functions using HTTP t
                       dest: last_name
                   method: POST
 
-7. Once event-source and sensor pod are up and running, dispatch a message on `foo` subject using nats client.
+7.  Once event-source and sensor pod are up and running, dispatch a message on `foo` subject using nats client.
 
         go run main.go -s localhost foo '{"first_name": "foo", "last_name": "bar"}'
 
-8. It will invoke Kubeless function `hello`.
+8.  It will invoke Kubeless function `hello`.
 
         {'event-time': None, 'extensions': {'request': <LocalRequest: POST http://hello.kubeless.svc.cluster.local:8080/> }, 'event-type': None, 'event-namespace': None, 'data': '{"first_name":"foo","last_name":"bar"}', 'event-id': None}
 

--- a/eventsources/common/naivewatcher/watcher_test.go
+++ b/eventsources/common/naivewatcher/watcher_test.go
@@ -2,7 +2,6 @@ package naivewatcher
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -41,7 +40,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	}
 	defer watcher.Close()
 
-	tmpdir, err := ioutil.TempDir("", "naive-watcher-")
+	tmpdir, err := os.MkdirTemp("", "naive-watcher-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	}, events)
 
 	// Write a file
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "bar"), []byte("wow"), 0666)
+	err = os.WriteFile(filepath.Join(tmpdir, "bar"), []byte("wow"), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +110,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("wowwow"), 0666)
+	err = os.WriteFile(filepath.Join(tmpdir, "foo"), []byte("wowwow"), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +157,7 @@ func TestWatcherManualCheck(t *testing.T) {
 	}
 	defer watcher.Close()
 
-	tmpdir, err := ioutil.TempDir("", "naive-watcher-")
+	tmpdir, err := os.MkdirTemp("", "naive-watcher-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +192,7 @@ func TestWatcherManualCheck(t *testing.T) {
 	}, events)
 
 	// Write a file
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "bar"), []byte("wow"), 0666)
+	err = os.WriteFile(filepath.Join(tmpdir, "bar"), []byte("wow"), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +216,7 @@ func TestWatcherManualCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(tmpdir, "foo"), []byte("wowwow"), 0666)
+	err = os.WriteFile(filepath.Join(tmpdir, "foo"), []byte("wowwow"), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eventsources/sources/amqp/validate_test.go
+++ b/eventsources/sources/amqp/validate_test.go
@@ -19,7 +19,7 @@ package amqp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "either url or urlSecret must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "amqp.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "amqp.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/awssns/validate_test.go
+++ b/eventsources/sources/awssns/validate_test.go
@@ -19,7 +19,7 @@ package awssns
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "must specify topic arn", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "aws-sns.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "aws-sns.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/awssqs/validate_test.go
+++ b/eventsources/sources/awssqs/validate_test.go
@@ -19,7 +19,7 @@ package awssqs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -40,7 +40,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "must specify queue name", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "aws-sqs.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "aws-sqs.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/azureeventshub/validate_test.go
+++ b/eventsources/sources/azureeventshub/validate_test.go
@@ -19,7 +19,7 @@ package azureeventshub
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "FQDN is not specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "azure-events-hub.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "azure-events-hub.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/bitbucket/start.go
+++ b/eventsources/sources/bitbucket/start.go
@@ -20,7 +20,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"time"
@@ -76,7 +76,8 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	body, err := ioutil.ReadAll(request.Body)
+	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Desugar().Error("failed to parse request body", zap.Error(err))
 		common.SendErrorResponse(writer, err.Error())

--- a/eventsources/sources/bitbucket/validate_test.go
+++ b/eventsources/sources/bitbucket/validate_test.go
@@ -18,7 +18,7 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "project key can't be empty", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "bitbucket.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "bitbucket.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/bitbucketserver/validate_test.go
+++ b/eventsources/sources/bitbucketserver/validate_test.go
@@ -18,7 +18,7 @@ package bitbucketserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "at least one repository is required", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "bitbucketserver.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "bitbucketserver.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/calendar/validate_test.go
+++ b/eventsources/sources/calendar/validate_test.go
@@ -19,7 +19,7 @@ package calendar
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -39,7 +39,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "must have either schedule or interval", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "calendar.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "calendar.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/emitter/validate_test.go
+++ b/eventsources/sources/emitter/validate_test.go
@@ -19,7 +19,7 @@ package emitter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "broker url must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "emitter.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "emitter.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/file/validate_test.go
+++ b/eventsources/sources/file/validate_test.go
@@ -19,7 +19,7 @@ package file
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "type must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "file.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "file.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/gcppubsub/validate_test.go
+++ b/eventsources/sources/gcppubsub/validate_test.go
@@ -19,7 +19,7 @@ package gcppubsub
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "must specify topic or subscriptionID", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "gcp-pubsub.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "gcp-pubsub.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/generic/validate_test.go
+++ b/eventsources/sources/generic/validate_test.go
@@ -3,7 +3,7 @@ package generic
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -19,7 +19,7 @@ func TestEventListener_ValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "server url can't be empty", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "generic.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "generic.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/github/start_test.go
+++ b/eventsources/sources/github/start_test.go
@@ -19,7 +19,7 @@ package github
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -74,7 +74,7 @@ func TestRouteActiveHandler(t *testing.T) {
 			convey.So(err, convey.ShouldBeNil)
 
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewReader(body)),
+				Body: io.NopCloser(bytes.NewReader(body)),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusBadRequest)
 
@@ -82,7 +82,7 @@ func TestRouteActiveHandler(t *testing.T) {
 				route.Active = true
 
 				router.HandleRoute(writer, &http.Request{
-					Body: ioutil.NopCloser(bytes.NewReader(body)),
+					Body: io.NopCloser(bytes.NewReader(body)),
 				})
 
 				convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusBadRequest)
@@ -121,7 +121,7 @@ func TestRouteActiveHandlerDeprecated(t *testing.T) {
 			convey.So(err, convey.ShouldBeNil)
 
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewReader(body)),
+				Body: io.NopCloser(bytes.NewReader(body)),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusBadRequest)
 
@@ -129,7 +129,7 @@ func TestRouteActiveHandlerDeprecated(t *testing.T) {
 				route.Active = true
 
 				router.HandleRoute(writer, &http.Request{
-					Body: ioutil.NopCloser(bytes.NewReader(body)),
+					Body: io.NopCloser(bytes.NewReader(body)),
 				})
 
 				convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusBadRequest)

--- a/eventsources/sources/github/validate_test.go
+++ b/eventsources/sources/github/validate_test.go
@@ -19,7 +19,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -34,7 +34,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "either repositories or organizations is required", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "github.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "github.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/gitlab/start.go
+++ b/eventsources/sources/gitlab/start.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"reflect"
@@ -86,8 +86,8 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			return
 		}
 	}
-
-	body, err := ioutil.ReadAll(request.Body)
+	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse request body", zap.Error(err))
 		common.SendErrorResponse(writer, err.Error())

--- a/eventsources/sources/gitlab/validate_test.go
+++ b/eventsources/sources/gitlab/validate_test.go
@@ -19,7 +19,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "projects can't be empty", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "gitlab.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "gitlab.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/hdfs/validate_test.go
+++ b/eventsources/sources/hdfs/validate_test.go
@@ -3,7 +3,7 @@ package hdfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -19,7 +19,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "type is required", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "hdfs.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "hdfs.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/kafka/validate_test.go
+++ b/eventsources/sources/kafka/validate_test.go
@@ -19,7 +19,7 @@ package kafka
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "url must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "kafka.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "kafka.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/minio/validate_test.go
+++ b/eventsources/sources/minio/validate_test.go
@@ -19,7 +19,7 @@ package minio
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "access key can't be empty", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "minio.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "minio.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/mqtt/validate_test.go
+++ b/eventsources/sources/mqtt/validate_test.go
@@ -19,7 +19,7 @@ package mqtt
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "url must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "mqtt.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "mqtt.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/nats/validate_test.go
+++ b/eventsources/sources/nats/validate_test.go
@@ -19,7 +19,7 @@ package nats
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "url must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "nats.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "nats.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/nsq/validate_test.go
+++ b/eventsources/sources/nsq/validate_test.go
@@ -19,7 +19,7 @@ package nsq
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "host address must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "nsq.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "nsq.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/pulsar/validate_test.go
+++ b/eventsources/sources/pulsar/validate_test.go
@@ -18,7 +18,7 @@ package pulsar
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -34,7 +34,7 @@ func TestEventListener_ValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "topics can't be empty list", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "pulsar.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "pulsar.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/redis/validate_test.go
+++ b/eventsources/sources/redis/validate_test.go
@@ -19,7 +19,7 @@ package redis
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateRedisEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "host address must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "redis.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "redis.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/redisStream/validate_test.go
+++ b/eventsources/sources/redisStream/validate_test.go
@@ -19,7 +19,7 @@ package redisstream
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateRedisEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "host address must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "redis-streams.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "redis-streams.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/resource/validate_test.go
+++ b/eventsources/sources/resource/validate_test.go
@@ -19,7 +19,7 @@ package resource
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "version must be specified", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "resource.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "resource.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/slack/start.go
+++ b/eventsources/sources/slack/start.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -271,9 +271,9 @@ func (rc *Router) handleSlashCommand(request *http.Request) ([]byte, error) {
 
 func getRequestBody(request *http.Request) ([]byte, error) {
 	// Read request payload
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(io.LimitReader(request.Body, 65536))
 	// Reset request.Body ReadCloser to prevent side-effect if re-read
-	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	request.Body = io.NopCloser(bytes.NewBuffer(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse request body")
 	}

--- a/eventsources/sources/slack/start_test.go
+++ b/eventsources/sources/slack/start_test.go
@@ -22,7 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -64,7 +64,7 @@ func TestRouteActiveHandler(t *testing.T) {
 			convey.So(err, convey.ShouldBeNil)
 			convey.So(payload, convey.ShouldNotBeNil)
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewReader(payload)),
+				Body: io.NopCloser(bytes.NewReader(payload)),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusInternalServerError)
 		})
@@ -102,7 +102,7 @@ func TestSlackSignature(t *testing.T) {
 			}()
 
 			router.HandleRoute(writer, &http.Request{
-				Body:   ioutil.NopCloser(bytes.NewReader(payload)),
+				Body:   io.NopCloser(bytes.NewReader(payload)),
 				Header: h,
 				Method: "POST",
 			})
@@ -137,7 +137,7 @@ func TestInteractionHandler(t *testing.T) {
 			router.HandleRoute(writer, &http.Request{
 				Method: http.MethodPost,
 				Header: headers,
-				Body:   ioutil.NopCloser(strings.NewReader(buf.String())),
+				Body:   io.NopCloser(strings.NewReader(buf.String())),
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
@@ -173,7 +173,7 @@ func TestSlackCommandHandler(t *testing.T) {
 			router.HandleRoute(writer, &http.Request{
 				Method: http.MethodPost,
 				Header: headers,
-				Body:   ioutil.NopCloser(strings.NewReader(buf.String())),
+				Body:   io.NopCloser(strings.NewReader(buf.String())),
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
@@ -223,7 +223,7 @@ func TestEventHandler(t *testing.T) {
 			}()
 
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewBuffer(payload)),
+				Body: io.NopCloser(bytes.NewBuffer(payload)),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusInternalServerError)
 		})

--- a/eventsources/sources/slack/validate_test.go
+++ b/eventsources/sources/slack/validate_test.go
@@ -19,7 +19,7 @@ package slack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "token not provided", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "slack.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "slack.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/storagegrid/start.go
+++ b/eventsources/sources/storagegrid/start.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -141,7 +141,8 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 	}
 
 	logger.Info("parsing the request body...")
-	body, err := ioutil.ReadAll(request.Body)
+	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse request body", zap.Error(err))
 		common.SendErrorResponse(writer, "")

--- a/eventsources/sources/storagegrid/start_test.go
+++ b/eventsources/sources/storagegrid/start_test.go
@@ -19,7 +19,7 @@ package storagegrid
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -102,7 +102,7 @@ func TestRouteActiveHandler(t *testing.T) {
 			pbytes, err := yaml.Marshal(storageGridEventSource)
 			convey.So(err, convey.ShouldBeNil)
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewReader(pbytes)),
+				Body: io.NopCloser(bytes.NewReader(pbytes)),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusBadRequest)
 		})
@@ -117,7 +117,7 @@ func TestRouteActiveHandler(t *testing.T) {
 			}()
 
 			router.HandleRoute(writer, &http.Request{
-				Body: ioutil.NopCloser(bytes.NewReader([]byte(notification))),
+				Body: io.NopCloser(bytes.NewReader([]byte(notification))),
 			})
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
 		})

--- a/eventsources/sources/storagegrid/validate_test.go
+++ b/eventsources/sources/storagegrid/validate_test.go
@@ -19,7 +19,7 @@ package storagegrid
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -35,7 +35,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "topic arn must be provided", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "storage-grid.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "storage-grid.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/stripe/start.go
+++ b/eventsources/sources/stripe/start.go
@@ -19,7 +19,7 @@ package stripe
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -97,7 +97,7 @@ func (rc *Router) HandleRoute(writer http.ResponseWriter, request *http.Request)
 
 	const MaxBodyBytes = int64(65536)
 	request.Body = http.MaxBytesReader(writer, request.Body, MaxBodyBytes)
-	payload, err := ioutil.ReadAll(request.Body)
+	payload, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("error reading request body", zap.Error(err))
 		writer.WriteHeader(http.StatusServiceUnavailable)

--- a/eventsources/sources/stripe/validate_test.go
+++ b/eventsources/sources/stripe/validate_test.go
@@ -19,7 +19,7 @@ package stripe
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -40,7 +40,7 @@ func TestValidateEventSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "api key K8s secret selector not provided", err.Error())
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "stripe.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "stripe.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/eventsources/sources/webhook/start.go
+++ b/eventsources/sources/webhook/start.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -105,7 +105,8 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		route.Metrics.EventProcessingDuration(route.EventSourceName, route.EventName, float64(time.Since(start)/time.Millisecond))
 	}(time.Now())
 
-	body, err := ioutil.ReadAll(request.Body)
+	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse request body", zap.Error(err))
 		common.SendErrorResponse(writer, err.Error())

--- a/eventsources/sources/webhook/validate_test.go
+++ b/eventsources/sources/webhook/validate_test.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/eventsources/sources"
@@ -36,7 +36,7 @@ func TestValidateEventSource(t *testing.T) {
 	err := listener.ValidateEventSource(context.Background())
 	assert.Error(t, err)
 
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "webhook.yaml"))
+	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "webhook.yaml"))
 	assert.Nil(t, err)
 
 	var eventSource *v1alpha1.EventSource

--- a/hack/crds.go
+++ b/hack/crds.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 )
@@ -9,7 +9,7 @@ import (
 type obj = map[string]interface{}
 
 func cleanCRD(filename string) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ func cleanCRD(filename string) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(filename, data, 0666)
+	err = os.WriteFile(filename, data, 0666)
 	if err != nil {
 		panic(err)
 	}

--- a/hack/gen-openapi-spec/main.go
+++ b/hack/gen-openapi-spec/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -86,7 +85,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	err = ioutil.WriteFile(output, jsonBytes, 0644)
+	err = os.WriteFile(output, jsonBytes, 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -158,7 +157,7 @@ func swaggify(name string) string {
 }
 
 func getKubernetesSwagger(kubeSwaggerPath string) spec.Definitions {
-	data, err := ioutil.ReadFile(kubeSwaggerPath)
+	data, err := os.ReadFile(kubeSwaggerPath)
 	if err != nil {
 		panic(err)
 	}

--- a/sensors/artifacts/file.go
+++ b/sensors/artifacts/file.go
@@ -18,7 +18,7 @@ package artifacts
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/argoproj/argo-events/common/logging"
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
@@ -39,7 +39,7 @@ func NewFileReader(fileArtifact *v1alpha1.FileArtifact) (ArtifactReader, error) 
 }
 
 func (reader *FileReader) Read() ([]byte, error) {
-	content, err := ioutil.ReadFile(reader.fileArtifact.Path)
+	content, err := os.ReadFile(reader.fileArtifact.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/sensors/artifacts/file_test.go
+++ b/sensors/artifacts/file_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package artifacts
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ import (
 
 func TestFileReader(t *testing.T) {
 	content := []byte("temp content")
-	tmpfile, err := ioutil.TempFile("", "argo-events-temp")
+	tmpfile, err := os.CreateTemp("", "argo-events-temp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sensors/artifacts/git.go
+++ b/sensors/artifacts/git.go
@@ -18,7 +18,6 @@ package artifacts
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -78,7 +77,7 @@ func (g *GitArtifactReader) getRemote() string {
 }
 
 func getSSHKeyAuth(sshKeyFile string) (transport.AuthMethod, error) {
-	sshKey, err := ioutil.ReadFile(sshKeyFile)
+	sshKey, err := os.ReadFile(sshKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ssh key file. err: %+v", err)
 	}
@@ -198,7 +197,7 @@ func (g *GitArtifactReader) readFromRepository(r *git.Repository, dir string) ([
 	if isSymbolLink {
 		return nil, fmt.Errorf("%q is a symbol link which is not allowed", g.artifact.FilePath)
 	}
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 func (g *GitArtifactReader) getBranchOrTag() *git.CheckoutOptions {
@@ -222,7 +221,7 @@ func (g *GitArtifactReader) getBranchOrTag() *git.CheckoutOptions {
 func (g *GitArtifactReader) Read() ([]byte, error) {
 	cloneDir := g.artifact.CloneDirectory
 	if cloneDir == "" {
-		tempDir, err := ioutil.TempDir("", "git-tmp")
+		tempDir, err := os.MkdirTemp("", "git-tmp")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create a temp file to clone the repository")
 		}

--- a/sensors/artifacts/s3.go
+++ b/sensors/artifacts/s3.go
@@ -19,7 +19,7 @@ package artifacts
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -61,7 +61,7 @@ func (reader *S3Reader) Read() ([]byte, error) {
 		}
 	}()
 
-	b, err := ioutil.ReadAll(obj)
+	b, err := io.ReadAll(io.LimitReader(obj, 65536))
 	if err != nil {
 		return nil, err
 	}

--- a/sensors/artifacts/store_test.go
+++ b/sensors/artifacts/store_test.go
@@ -18,7 +18,7 @@ package artifacts
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
@@ -74,7 +74,7 @@ func TestGetArtifactReader(t *testing.T) {
 }
 
 func TestDecodeSensor(t *testing.T) {
-	b, err := ioutil.ReadFile("../../examples/sensors/multi-trigger-sensor.yaml")
+	b, err := os.ReadFile("../../examples/sensors/multi-trigger-sensor.yaml")
 	assert.Nil(t, err)
 	_, err = decodeAndUnstructure(b)
 	assert.Nil(t, err)

--- a/sensors/artifacts/url.go
+++ b/sensors/artifacts/url.go
@@ -2,7 +2,7 @@ package artifacts
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -45,7 +45,7 @@ func (reader *URLReader) Read() ([]byte, error) {
 		return nil, errors.Errorf("status code %v", resp.StatusCode)
 	}
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(io.LimitReader(resp.Body, 65536))
 	if err != nil {
 		log.Warnf("failed to read url body for %s: %s", reader.urlArtifact.Path, err)
 		return nil, err

--- a/sensors/triggers/argo-workflow/argo-workflow.go
+++ b/sensors/triggers/argo-workflow/argo-workflow.go
@@ -18,7 +18,6 @@ package argo_workflow
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -136,7 +135,7 @@ func (t *ArgoWorkflowTrigger) Execute(ctx context.Context, events map[string]*v1
 
 	switch op {
 	case v1alpha1.Submit:
-		file, err := ioutil.TempFile("", fmt.Sprintf("%s%s", name, obj.GetGenerateName()))
+		file, err := os.CreateTemp("", fmt.Sprintf("%s%s", name, obj.GetGenerateName()))
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create a temp file for the workflow %s", obj.GetName())
 		}

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -1,7 +1,7 @@
 package fixtures
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -91,7 +91,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 	if strings.HasPrefix(text, "@") {
 		file = strings.TrimPrefix(text, "@")
 	} else {
-		f, err := ioutil.TempFile("", "argo-events-e2e")
+		f, err := os.CreateTemp("", "argo-events-e2e")
 		if err != nil {
 			g.t.Fatal(err)
 		}
@@ -106,7 +106,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 		file = f.Name()
 	}
 
-	f, err := ioutil.ReadFile(file)
+	f, err := os.ReadFile(file)
 	if err != nil {
 		g.t.Fatal(err)
 	}

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -674,7 +673,7 @@ func readResource(text string, v metav1.Object) error {
 	if strings.HasPrefix(text, "@") {
 		file := strings.TrimPrefix(text, "@")
 		_, fileName, _, _ := runtime.Caller(0)
-		data, err = ioutil.ReadFile(filepath.Dir(fileName) + "/" + file)
+		data, err = os.ReadFile(filepath.Dir(fileName) + "/" + file)
 		if err != nil {
 			return fmt.Errorf("failed to read a file: %w", err)
 		}

--- a/webhook/validator/eventsource_test.go
+++ b/webhook/validator/eventsource_test.go
@@ -2,7 +2,7 @@ package validator
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -13,10 +13,13 @@ import (
 
 func TestValidateEventSource(t *testing.T) {
 	dir := "../../examples/event-sources"
-	files, err := ioutil.ReadDir(dir)
+	dirEntries, err := os.ReadDir(dir)
 	assert.Nil(t, err)
-	for _, file := range files {
-		content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", dir, file.Name()))
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(fmt.Sprintf("%s/%s", dir, entry.Name()))
 		assert.Nil(t, err)
 		var es *v1alpha1.EventSource
 		err = yaml.Unmarshal(content, &es)

--- a/webhook/validator/sensor_test.go
+++ b/webhook/validator/sensor_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -52,7 +52,7 @@ var (
 
 func TestValidateSensor(t *testing.T) {
 	dir := "../../examples/sensors"
-	files, err := ioutil.ReadDir(dir)
+	dirEntries, err := os.ReadDir(dir)
 	assert.Nil(t, err)
 
 	testBus := fakeBus.DeepCopy()
@@ -61,8 +61,11 @@ func TestValidateSensor(t *testing.T) {
 	_, err = fakeEventBusClient.ArgoprojV1alpha1().EventBus(testNamespace).Create(context.TODO(), testBus, metav1.CreateOptions{})
 	assert.Nil(t, err)
 
-	for _, file := range files {
-		content, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", dir, file.Name()))
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(fmt.Sprintf("%s/%s", dir, entry.Name()))
 		assert.Nil(t, err)
 		var sensor *v1alpha1.Sensor
 		err = yaml.Unmarshal(content, &sensor)


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

1. Stop using `ioutil`;
2. use limit reader to prevent large content caused crash.

Fixes: #1946

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
