### PR TITLE
chore: move from `streadway/amqp` to `rabbitmq/amqp091-go`

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -12,7 +12,7 @@
 |     minio/minio-go           |     Apache-2.0          |
 |     nats-io/go-nats          |     Apache-2.0          |
 |     robfig/cron              |     MIT                 |
-|     streadway/amqp           |     BSD-2-Clause        |
+|     rabbitmq/amqp091-go      |     BSD-2-Clause        |
 |     rs/zerolog               |     MIT                 |
 |     mitchellh/hashstructure  |     MIT                 |
 |     nats-io/gnatsd           |     Apache-2.0          |

--- a/api/event-source.html
+++ b/api/event-source.html
@@ -213,7 +213,7 @@ AMQPExchangeDeclareConfig
 <td>
 <em>(Optional)</em>
 <p>ExchangeDeclare holds the configuration for the exchange on the server
-For more information, visit <a href="https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare">https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare</a></p>
+For more information, visit <a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare</a></p>
 </td>
 </tr>
 <tr>
@@ -230,7 +230,7 @@ AMQPQueueDeclareConfig
 <p>QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers.
 Declaring creates a queue if it doesn&rsquo;t already exist, or ensures that an existing queue matches
 the same parameters
-For more information, visit <a href="https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare">https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare</a></p>
+For more information, visit <a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare</a></p>
 </td>
 </tr>
 <tr>
@@ -246,7 +246,7 @@ AMQPQueueBindConfig
 <em>(Optional)</em>
 <p>QueueBind holds the configuration that binds an exchange to a queue so that publishings to the
 exchange will be routed to the queue when the publishing routing key matches the binding routing key
-For more information, visit <a href="https://godoc.org/github.com/streadway/amqp#Channel.QueueBind">https://godoc.org/github.com/streadway/amqp#Channel.QueueBind</a></p>
+For more information, visit <a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind</a></p>
 </td>
 </tr>
 <tr>
@@ -261,7 +261,7 @@ AMQPConsumeConfig
 <td>
 <em>(Optional)</em>
 <p>Consume holds the configuration to immediately starts delivering queued messages
-For more information, visit <a href="https://godoc.org/github.com/streadway/amqp#Channel.Consume">https://godoc.org/github.com/streadway/amqp#Channel.Consume</a></p>
+For more information, visit <a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume</a></p>
 </td>
 </tr>
 <tr>

--- a/api/event-source.md
+++ b/api/event-source.md
@@ -226,7 +226,7 @@ AMQPExchangeDeclareConfig </a> </em>
 <p>
 ExchangeDeclare holds the configuration for the exchange on the server
 For more information, visit
-<a href="https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare">https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare</a>
+<a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare</a>
 </p>
 </td>
 </tr>
@@ -243,7 +243,7 @@ QueueDeclare holds the configuration of a queue to hold messages and
 deliver to consumers. Declaring creates a queue if it doesn’t already
 exist, or ensures that an existing queue matches the same parameters For
 more information, visit
-<a href="https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare">https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare</a>
+<a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare</a>
 </p>
 </td>
 </tr>
@@ -260,7 +260,7 @@ QueueBind holds the configuration that binds an exchange to a queue so
 that publishings to the exchange will be routed to the queue when the
 publishing routing key matches the binding routing key For more
 information, visit
-<a href="https://godoc.org/github.com/streadway/amqp#Channel.QueueBind">https://godoc.org/github.com/streadway/amqp#Channel.QueueBind</a>
+<a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind</a>
 </p>
 </td>
 </tr>
@@ -275,7 +275,7 @@ information, visit
 <p>
 Consume holds the configuration to immediately starts delivering queued
 messages For more information, visit
-<a href="https://godoc.org/github.com/streadway/amqp#Channel.Consume">https://godoc.org/github.com/streadway/amqp#Channel.Consume</a>
+<a href="https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume">https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume</a>
 </p>
 </td>
 </tr>

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -693,11 +693,11 @@
         },
         "consume": {
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPConsumeConfig",
-          "description": "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.Consume"
+          "description": "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume"
         },
         "exchangeDeclare": {
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPExchangeDeclareConfig",
-          "description": "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare"
+          "description": "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare"
         },
         "exchangeName": {
           "description": "ExchangeName is the exchange name For more information, visit https://www.rabbitmq.com/tutorials/amqp-concepts.html",
@@ -724,11 +724,11 @@
         },
         "queueBind": {
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPQueueBindConfig",
-          "description": "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueBind"
+          "description": "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind"
         },
         "queueDeclare": {
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPQueueDeclareConfig",
-          "description": "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare"
+          "description": "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare"
         },
         "routingKey": {
           "description": "Routing key for bindings",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -690,11 +690,11 @@
           "$ref": "#/definitions/io.argoproj.common.Backoff"
         },
         "consume": {
-          "description": "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.Consume",
+          "description": "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume",
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPConsumeConfig"
         },
         "exchangeDeclare": {
-          "description": "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare",
+          "description": "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare",
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPExchangeDeclareConfig"
         },
         "exchangeName": {
@@ -721,11 +721,11 @@
           }
         },
         "queueBind": {
-          "description": "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueBind",
+          "description": "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind",
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPQueueBindConfig"
         },
         "queueDeclare": {
-          "description": "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare",
+          "description": "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare",
           "$ref": "#/definitions/io.argoproj.eventsource.v1alpha1.AMQPQueueDeclareConfig"
         },
         "routingKey": {

--- a/eventsources/sources/amqp/start.go
+++ b/eventsources/sources/amqp/start.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/pkg/errors"
-	amqplib "github.com/streadway/amqp"
+	amqplib "github.com/rabbitmq/amqp091-go"
 	"go.uber.org/zap"
 
 	"github.com/argoproj/argo-events/common"

--- a/go.mod
+++ b/go.mod
@@ -56,13 +56,13 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
+	github.com/rabbitmq/amqp091-go v1.3.4
 	github.com/radovskyb/watcher v1.0.7
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.10.3
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
-	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.1
 	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/tidwall/gjson v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -1108,6 +1108,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
@@ -1195,8 +1197,6 @@ github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8q
 github.com/spf13/viper v1.11.0 h1:7OX/1FS6n7jHD1zGrZTM7WtY13ZELRyosK4k93oPr44=
 github.com/spf13/viper v1.11.0/go.mod h1:djo0X/bA5+tYVoCn+C7cAYJGcVn/qYLFTG8gdUsX7Zk=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
-github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
-github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/pkg/apis/eventsource/v1alpha1/generated.proto
+++ b/pkg/apis/eventsource/v1alpha1/generated.proto
@@ -87,25 +87,25 @@ message AMQPEventSource {
   map<string, string> metadata = 8;
 
   // ExchangeDeclare holds the configuration for the exchange on the server
-  // For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare
+  // For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare
   // +optional
   optional AMQPExchangeDeclareConfig exchangeDeclare = 9;
 
   // QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers.
   // Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches
   // the same parameters
-  // For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare
+  // For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare
   // +optional
   optional AMQPQueueDeclareConfig queueDeclare = 10;
 
   // QueueBind holds the configuration that binds an exchange to a queue so that publishings to the
   // exchange will be routed to the queue when the publishing routing key matches the binding routing key
-  // For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueBind
+  // For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind
   // +optional
   optional AMQPQueueBindConfig queueBind = 11;
 
   // Consume holds the configuration to immediately starts delivering queued messages
-  // For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.Consume
+  // For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume
   // +optional
   optional AMQPConsumeConfig consume = 12;
 

--- a/pkg/apis/eventsource/v1alpha1/openapi_generated.go
+++ b/pkg/apis/eventsource/v1alpha1/openapi_generated.go
@@ -207,25 +207,25 @@ func schema_pkg_apis_eventsource_v1alpha1_AMQPEventSource(ref common.ReferenceCa
 					},
 					"exchangeDeclare": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare",
+							Description: "ExchangeDeclare holds the configuration for the exchange on the server For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare",
 							Ref:         ref("github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1.AMQPExchangeDeclareConfig"),
 						},
 					},
 					"queueDeclare": {
 						SchemaProps: spec.SchemaProps{
-							Description: "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare",
+							Description: "QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers. Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches the same parameters For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare",
 							Ref:         ref("github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1.AMQPQueueDeclareConfig"),
 						},
 					},
 					"queueBind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueBind",
+							Description: "QueueBind holds the configuration that binds an exchange to a queue so that publishings to the exchange will be routed to the queue when the publishing routing key matches the binding routing key For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind",
 							Ref:         ref("github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1.AMQPQueueBindConfig"),
 						},
 					},
 					"consume": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.Consume",
+							Description: "Consume holds the configuration to immediately starts delivering queued messages For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume",
 							Ref:         ref("github.com/argoproj/argo-events/pkg/apis/eventsource/v1alpha1.AMQPConsumeConfig"),
 						},
 					},

--- a/pkg/apis/eventsource/v1alpha1/types.go
+++ b/pkg/apis/eventsource/v1alpha1/types.go
@@ -367,22 +367,22 @@ type AMQPEventSource struct {
 	// +optional
 	Metadata map[string]string `json:"metadata,omitempty" protobuf:"bytes,8,rep,name=metadata"`
 	// ExchangeDeclare holds the configuration for the exchange on the server
-	// For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.ExchangeDeclare
+	// For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.ExchangeDeclare
 	// +optional
 	ExchangeDeclare *AMQPExchangeDeclareConfig `json:"exchangeDeclare,omitempty" protobuf:"bytes,9,opt,name=exchangeDeclare"`
 	// QueueDeclare holds the configuration of a queue to hold messages and deliver to consumers.
 	// Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches
 	// the same parameters
-	// For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueDeclare
+	// For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueDeclare
 	// +optional
 	QueueDeclare *AMQPQueueDeclareConfig `json:"queueDeclare,omitempty" protobuf:"bytes,10,opt,name=queueDeclare"`
 	// QueueBind holds the configuration that binds an exchange to a queue so that publishings to the
 	// exchange will be routed to the queue when the publishing routing key matches the binding routing key
-	// For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.QueueBind
+	// For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.QueueBind
 	// +optional
 	QueueBind *AMQPQueueBindConfig `json:"queueBind,omitempty" protobuf:"bytes,11,opt,name=queueBind"`
 	// Consume holds the configuration to immediately starts delivering queued messages
-	// For more information, visit https://godoc.org/github.com/streadway/amqp#Channel.Consume
+	// For more information, visit https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.Consume
 	// +optional
 	Consume *AMQPConsumeConfig `json:"consume,omitempty" protobuf:"bytes,12,opt,name=consume"`
 	// Auth hosts secret selectors for username and password


### PR DESCRIPTION
The [`github.com/streadway/amqp`](https://github.com/streadway/amqp) library is no longer actively maintained. The new libary is now maintained by the RabbitMQ core team under a different package name [`github.com/rabbitmq/amqp091-go`](https://github.com/rabbitmq/amqp091-go).

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
