### PR TITLE
Fixed some broken markdowns

### DIFF
--- a/docs/eventsources/setup/gcp-pub-sub.md
+++ b/docs/eventsources/setup/gcp-pub-sub.md
@@ -40,22 +40,18 @@ GCP Pub/Sub event-source specification is available [here](https://github.com/ar
 
 1. Create a K8s secret called `gcp-credentials` to store the credentials file.
 
-    ```yaml
-    apiVersion: v1
-    data:
-      key.json: <YOUR_CREDENTIALS_STRING_FROM_JSON_FILE>
-    kind: Secret
-    metadata:
-      name: gcp-credentials
-      namespace: argo-events
-    type: Opaque
-    ```
+        apiVersion: v1
+        data:
+          key.json: <YOUR_CREDENTIALS_STRING_FROM_JSON_FILE>
+        kind: Secret
+        metadata:
+          name: gcp-credentials
+          namespace: argo-events
+        type: Opaque
 
 1. Create the event source by running the following command.
 
-    ```sh
-    kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/gcp-pubsub.yaml
-    ```
+        kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/gcp-pubsub.yaml
 
     If you use Workload Identity, omit `credentialSecret` field. Instead don't forget to configure appropriate service account (see [example](https://github.com/argoproj/argo-events/blob/stable/examples/event-sources/gcp-pubsub.yaml)).
 
@@ -63,9 +59,7 @@ GCP Pub/Sub event-source specification is available [here](https://github.com/ar
 
 1. Create the sensor by running the following command.
 
-    ```sh
-    kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/gcp-pubsub.yaml
-    ```
+        kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/gcp-pubsub.yaml
 
 1. Publish a message from GCP Pub/Sub console.
 

--- a/docs/eventsources/setup/redis-streams.md
+++ b/docs/eventsources/setup/redis-streams.md
@@ -30,6 +30,7 @@ The structure of an event dispatched by the event-source over the eventbus looks
         }
 
 Example:
+
         {
           "context": {
             "id": "64313638396337352d623565612d343639302d383262362d306630333562333437363637",

--- a/docs/sensors/filters/ctx.md
+++ b/docs/sensors/filters/ctx.md
@@ -67,21 +67,15 @@ spec:
 
 1. Create a webhook event-source
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
 1. Create a webhook sensor with context filter
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-context.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-context.yaml
 
 1. Send an HTTP request to event-source
 
-  ```bash
-  curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. You will notice in sensor logs that the event is invalid as the sensor expects `custom-webhook` as the value of the `source`
 

--- a/docs/sensors/filters/data.md
+++ b/docs/sensors/filters/data.md
@@ -177,29 +177,21 @@ The message `'{"message":"aGVsbG8gd29ybGQ="}'` will match with the above filter 
 
 1. Create a webhook event-source
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
 1. Create a webhook sensor with data filter
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-data-simple-1.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-data-simple-1.yaml
 
 1. Send an HTTP request to event-source
 
-  ```bash
-  curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. You will notice in sensor logs that the event is invalid as it expects for either `hello` or `hey` as the value of `body.message`
 
 1. Send another HTTP request to event-source
 
-  ```bash
-  curl -d '{"message":"hello"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{"message":"hello"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. Look for a workflow with name starting with `data-workflow-`
 

--- a/docs/sensors/filters/expr.md
+++ b/docs/sensors/filters/expr.md
@@ -107,29 +107,21 @@ To discover all options offered by govaluate, take a look at its [manual](https:
 
 1. Create a webhook event-source
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
 1. Create a webhook sensor with expr filter
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-expressions.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-expressions.yaml
 
 1. Send an HTTP request to event-source
 
-  ```bash
-  curl -d '{ "a": "b", "c": 11, "d": { "e": true } }' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{ "a": "b", "c": 11, "d": { "e": true } }' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. You will notice in sensor logs that the event is invalid as the sensor expects `e == false`
 
 1. Send another HTTP request to event-source
 
-  ```bash
-  curl -d '{ "a": "b", "c": 11, "d": { "e": false } }' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{ "a": "b", "c": 11, "d": { "e": false } }' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. Look for a workflow with name starting with `expr-workflow-`
 

--- a/docs/sensors/filters/script.md
+++ b/docs/sensors/filters/script.md
@@ -36,29 +36,21 @@ filters:
 
 1. Create a webhook event-source
 
-```sh
-kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
-```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
 1. Create a webhook sensor with context filter
 
-```sh
-kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-script.yaml
-```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-script.yaml
 
 1. Send an HTTP request to the event-source
 
-```sh
-kubectl port-forward svc/webhook-eventsource-svc 12000
-curl -d '{"hello": "world"}' -X POST http://localhost:12000/example
-```
+        kubectl port-forward svc/webhook-eventsource-svc 12000
+        curl -d '{"hello": "world"}' -X POST http://localhost:12000/example
 
 1. You will notice in sensor logs that the event did not trigger anything.
 
 1. Send another HTTP request the event-source
 
-```sh
-curl -X POST -d '{"a": "b", "d": {"e": "z"}}' http://localhost:12000/example
-```
+        curl -X POST -d '{"a": "b", "d": {"e": "z"}}' http://localhost:12000/example
 
 1. Then you will see the event successfully triggered a workflow creation.

--- a/docs/sensors/filters/time.md
+++ b/docs/sensors/filters/time.md
@@ -82,26 +82,20 @@ If `stop` is smaller than `start` (`stop` < `start`), the stop time is treated a
 
 1. Create a webhook event-source
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
 1. Create a webhook sensor with time filter
 
-  ```bash
-  kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-time.yaml
-  ```
+        kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/filter-with-time.yaml
 
 1. Send an HTTP request to event-source
 
-  ```bash
-  curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
-  ```
+        curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
 1. You will notice one of following behaviours:
 
-  - if you run this example between 02:30 and 04:30, the sensor logs the event is valid
-  - if you run this example outside time range between 02:30 and 04:30, the sensor logs the event is invalid
+    - if you run this example between 02:30 and 04:30, the sensor logs the event is valid
+    - if you run this example outside time range between 02:30 and 04:30, the sensor logs the event is invalid
 
 ## Further examples
 


### PR DESCRIPTION
I found some broken markdowns and have fixed them.

- https://argoproj.github.io/argo-events/eventsources/setup/gcp-pub-sub/#setup
- https://argoproj.github.io/argo-events/eventsources/setup/redis-streams/#event-structure
- https://argoproj.github.io/argo-events/sensors/filters/expr/#practical-example
- https://argoproj.github.io/argo-events/sensors/filters/data/#practical-examples-comparator
- https://argoproj.github.io/argo-events/sensors/filters/script/#practical-example
- https://argoproj.github.io/argo-events/sensors/filters/ctx/#practical-example
- https://argoproj.github.io/argo-events/sensors/filters/time/#practical-example

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
