### PR TITLE
chore: increase io.ReadAll size limit for variable use cases

### DIFF
--- a/eventsources/sources/awssns/start.go
+++ b/eventsources/sources/awssns/start.go
@@ -115,7 +115,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		route.Metrics.EventProcessingDuration(route.EventSourceName, route.EventName, float64(time.Since(start)/time.Millisecond))
 	}(time.Now())
 
-	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	request.Body = http.MaxBytesReader(writer, request.Body, 256*1024) // SNS message size limit is 256KB
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse the request body", zap.Error(err))
@@ -319,7 +319,7 @@ func (m *httpNotification) verify() error {
 	}
 	defer res.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(res.Body, 65536))
+	body, err := io.ReadAll(io.LimitReader(res.Body, 65*1024))
 	if err != nil {
 		return errors.Wrap(err, "failed to read signing cert body")
 	}

--- a/eventsources/sources/bitbucket/start.go
+++ b/eventsources/sources/bitbucket/start.go
@@ -77,7 +77,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	request.Body = http.MaxBytesReader(writer, request.Body, 256*1024)
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Desugar().Error("failed to parse request body", zap.Error(err))

--- a/eventsources/sources/bitbucketserver/start.go
+++ b/eventsources/sources/bitbucketserver/start.go
@@ -397,7 +397,7 @@ func (router *Router) createRequestBodyFromWebhook(hook bitbucketv1.Webhook) ([]
 }
 
 func (router *Router) parseAndValidateBitbucketServerRequest(writer http.ResponseWriter, request *http.Request) ([]byte, error) {
-	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	request.Body = http.MaxBytesReader(writer, request.Body, 256*1024)
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse request body")

--- a/eventsources/sources/gitlab/start.go
+++ b/eventsources/sources/gitlab/start.go
@@ -86,7 +86,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			return
 		}
 	}
-	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	request.Body = http.MaxBytesReader(writer, request.Body, 256*1024)
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse request body", zap.Error(err))

--- a/eventsources/sources/storagegrid/start.go
+++ b/eventsources/sources/storagegrid/start.go
@@ -141,7 +141,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 	}
 
 	logger.Info("parsing the request body...")
-	request.Body = http.MaxBytesReader(writer, request.Body, 65536)
+	request.Body = http.MaxBytesReader(writer, request.Body, 1024*1024)
 	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		logger.Errorw("failed to parse request body", zap.Error(err))

--- a/eventsources/sources/stripe/start.go
+++ b/eventsources/sources/stripe/start.go
@@ -95,7 +95,7 @@ func (rc *Router) HandleRoute(writer http.ResponseWriter, request *http.Request)
 		route.Metrics.EventProcessingDuration(route.EventSourceName, route.EventName, float64(time.Since(start)/time.Millisecond))
 	}(time.Now())
 
-	const MaxBodyBytes = int64(65536)
+	const MaxBodyBytes = int64(1024 * 1024)
 	request.Body = http.MaxBytesReader(writer, request.Body, MaxBodyBytes)
 	payload, err := io.ReadAll(request.Body)
 	if err != nil {

--- a/eventsources/sources/webhook/start.go
+++ b/eventsources/sources/webhook/start.go
@@ -188,7 +188,7 @@ func GetBody(writer *http.ResponseWriter, request *http.Request, route *webhook.
 			return &ret, nil
 		// default including "application/json" is parsing body as JSON
 		default:
-			request.Body = http.MaxBytesReader(*writer, request.Body, 65536)
+			request.Body = http.MaxBytesReader(*writer, request.Body, 1024*1024)
 			body, err := getRequestBody(request)
 			if err != nil {
 				logger.Errorw("failed to read request body", zap.Error(err))

--- a/sensors/artifacts/s3.go
+++ b/sensors/artifacts/s3.go
@@ -61,7 +61,7 @@ func (reader *S3Reader) Read() ([]byte, error) {
 		}
 	}()
 
-	b, err := io.ReadAll(io.LimitReader(obj, 65536))
+	b, err := io.ReadAll(io.LimitReader(obj, 1024*1224))
 	if err != nil {
 		return nil, err
 	}

--- a/sensors/artifacts/url.go
+++ b/sensors/artifacts/url.go
@@ -45,7 +45,7 @@ func (reader *URLReader) Read() ([]byte, error) {
 		return nil, errors.Errorf("status code %v", resp.StatusCode)
 	}
 
-	content, err := io.ReadAll(io.LimitReader(resp.Body, 65536))
+	content, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
 	if err != nil {
 		log.Warnf("failed to read url body for %s: %s", reader.urlArtifact.Path, err)
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

All the function `io.ReadAll()` invoked in Argo Events have ratelimit, which is around 65536, this is not enough for some of the use cases. This PR increases the limit for different cases.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
