### PR TITLE
fix: add SCRAM support in Kafka triggers

### DIFF
--- a/common/scram_client.go
+++ b/common/scram_client.go
@@ -1,4 +1,4 @@
-package kafka
+package common
 
 import (
 	"crypto/sha256"
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	SHA256 scram.HashGeneratorFcn = sha256.New
-	SHA512 scram.HashGeneratorFcn = sha512.New
+	SHA256New scram.HashGeneratorFcn = sha256.New
+	SHA512New scram.HashGeneratorFcn = sha512.New
 )
 
 type XDGSCRAMClient struct {

--- a/eventsources/sources/kafka/start.go
+++ b/eventsources/sources/kafka/start.go
@@ -280,9 +280,9 @@ func getSaramaConfig(kafkaEventSource *v1alpha1.KafkaEventSource, log *zap.Sugar
 
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(kafkaEventSource.SASL.GetMechanism())
 		if config.Net.SASL.Mechanism == "SCRAM-SHA-512" {
-			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &common.XDGSCRAMClient{HashGeneratorFcn: common.SHA512New} }
 		} else if config.Net.SASL.Mechanism == "SCRAM-SHA-256" {
-			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &common.XDGSCRAMClient{HashGeneratorFcn: common.SHA256New} }
 		}
 
 		user, err := common.GetSecretFromVolume(kafkaEventSource.SASL.UserSecret)

--- a/sensors/triggers/kafka/kafka.go
+++ b/sensors/triggers/kafka/kafka.go
@@ -67,6 +67,11 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 		if kafkatrigger.SASL != nil {
 			config.Net.SASL.Enable = true
 			config.Net.SASL.Mechanism = sarama.SASLMechanism(kafkatrigger.SASL.GetMechanism())
+			if config.Net.SASL.Mechanism == "SCRAM-SHA-512" {
+				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &common.XDGSCRAMClient{HashGeneratorFcn: common.SHA512New} }
+			} else if config.Net.SASL.Mechanism == "SCRAM-SHA-256" {
+				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &common.XDGSCRAMClient{HashGeneratorFcn: common.SHA256New} }
+			}
 
 			user, err := common.GetSecretFromVolume(kafkatrigger.SASL.UserSecret)
 			if err != nil {


### PR DESCRIPTION
Checked this change in our deployment against properly configured Kafka cluster, and it actually fixes argoproj#2087.
Have no idea how to check this configuration issue in unit tests, so didn't touch them in the PR.

