### PR TITLE
fix: flaky e2e test cases

### DIFF
--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,15 @@ func (t *Then) ExpectEventBusDeleted() *Then {
 	_, err := t.eventBusClient.Get(ctx, t.eventBus.Name, metav1.GetOptions{})
 	if err == nil || !apierr.IsNotFound(err) {
 		t.t.Fatalf("expected event bus to be deleted: %v", err)
+	}
+	return t
+}
+
+func (t *Then) ExpectNoSensorPodFound() *Then {
+	ctx := context.Background()
+	labelSelector := fmt.Sprintf("controller=sensor-controller,sensor-name=%s", t.sensor.Name)
+	if err := testutil.WaitForNoPodFound(ctx, t.kubeClient, Namespace, labelSelector, 20*time.Second); err != nil {
+		t.t.Fatalf("expected no sensor pod found: %v", err)
 	}
 	return t
 }

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -455,7 +455,7 @@ func (s *FunctionalSuite) TestTriggerSpecChange() {
 	t1.ExpectEventSourcePodLogContains(LogPublishEventSuccessful, util.PodLogCheckOptionWithCount(1))
 
 	t2.TerminateAllPodPortForwards()
-	t2.When().DeleteSensor()
+	t2.When().DeleteSensor().Then().ExpectNoSensorPodFound()
 	time.Sleep(3 * time.Second)
 
 	// Change Sensor's spec


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Flaky test case `TestMultipleSensors` due to creating 2nd sensor too fast.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
