### PR TITLE
[examples] fix filter for github sensor example

### DIFF
--- a/examples/sensors/github.yaml
+++ b/examples/sensors/github.yaml
@@ -13,7 +13,7 @@ spec:
         data:
           # Name of the event that triggered the delivery: [pull_request, push, yadayadayada]
           # https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads
-          - path: body.X-GitHub-Event
+          - path: header.X-Github-Event
             type: string
             value:
               - pull_request


### PR DESCRIPTION
This PR fixes the github sensor example, there was a typo on X-Github-Event (capital H), plus it's in the header part instead of the body one

Cheers 

