### PR TITLE
fix: Emissary executor reads and writes to WorkflowTaskResults, not Pods

### DIFF
--- a/examples/rbac/workflow-rbac.yaml
+++ b/examples/rbac/workflow-rbac.yaml
@@ -1,35 +1,29 @@
+# This file enables a Workflow Pod (running Emissary executor) to be able to read and patch WorkflowTaskResults,
+# which get shared with the Workflow Controller. The Controller uses the results to update Workflow status.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: workflow-role
+  annotations:
+    workflows.argoproj.io/description: |
+      Recomended minimum permissions for the `emissary` executor.
+  name: executor
 rules:
-  # pod get/watch is used to identify the container IDs of the current pod
-  # pod patch is used to annotate the step's outputs back to controller (e.g. artifact location)
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - watch
-      - patch
-  # logs get/watch are used to get the pods logs for script outputs, and for log archival
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-      - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtaskresults
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: workflow-role-binding
+  name: executor-default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: workflow-role
+  name: executor
 subjects:
-  - kind: ServiceAccount
-    name: default
+- kind: ServiceAccount
+  name: default


### PR DESCRIPTION
Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

