### PR TITLE
Property name typo in Expr filter documentation

### DIFF
--- a/docs/sensors/filters/expr.md
+++ b/docs/sensors/filters/expr.md
@@ -30,7 +30,7 @@ An expr filter has following fields:
 ```yaml
 filters:
   exprLogicalOperator: logical_operator_applied
-  expr:
+  exprs:
     - expr: expression_to_evaluate
       fields:
         - name: parameter_name


### PR DESCRIPTION
In other examples on this page and all of the examples in examples/sensors the top level property of the Expr filter is `exprs`, not `expr`. This is the list of the filters, not the one with the details (that's correctly `expr`).

The actual definition showing `exprs` appears to be here: https://github.com/argoproj/argo-events/blob/a9b5dd79c7341be999a526aacb77c87f7f7b3c08/pkg/apis/sensor/v1alpha1/generated.proto#L277

Here's some use in the examples showing `exprs` as opposed to `expr`. https://github.com/argoproj/argo-events/blob/b963de5607466a94bdc631d4f470d92913882178/examples/sensors/filter-with-multiple-filters.yaml#L25

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
