### PR TITLE
docs: Use new Google Analytics 4 site tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ theme:
 extra:
   analytics:
     provider: google
-    property: UA-105170809-9
+    property: G-5Z1VTPDL73
 markdown_extensions:
   - codehilite
   - admonition


### PR DESCRIPTION
- Contributes to https://github.com/argoproj/argo-site/issues/102
- As mentioned in that umbrella issue, the UA site tag is [connected] from the new GA4 site tag and so will continue receiving events. In fact, it will start receiving consolidated events forwarded from the GA4 site tag.

/cc @alexmt @alexec 

[connected]: https://support.google.com/analytics/answer/9973999