### PR TITLE
chore: EventSource example, added githubApp auth

### DIFF
--- a/examples/event-sources/github.yaml
+++ b/examples/event-sources/github.yaml
@@ -19,6 +19,13 @@ spec:
           names:
             - argo-events
             - argo-workflows
+      # Github application auth. Instead of using personal token `apiToken` use app PEM            
+#     githubApp:
+#       privateKey:
+#         name: github-app-pem
+#         key: privateKey.pem
+#       appID: <app id>
+#       installationID: <app installation id>
       # Github will send events to following port and endpoint
       webhook:
         # endpoint to listen to events on


### PR DESCRIPTION
Update github EventSource example, added githubApp auth example

Signed-off-by: mike-serchenia <michael_serchenia@epam.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
