### PR TITLE
docs: fix service account name in OpenShift install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,7 +29,7 @@
          * On OpenShift:
              - Make sure to grant `anyuid` scc to the service account.
 
-                oc adm policy add-scc-to-user anyuid system:serviceaccount:argo-events:default
+                oc adm policy add-scc-to-user anyuid system:serviceaccount:argo-events:argo-events-sa
 
              - Add update permissions for the `deployments/finalizers` and `clusterroles/finalizers` of the argo-events-webhook ClusterRole(this is necessary for the validating admission controller)
 


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
Fix the service account name which will be granted 'anyuid' scc.
Tested on OpenShift 4.11.5