### PR TITLE
fix(docs): context filter documentation

### DIFF
--- a/docs/sensors/filters/ctx.md
+++ b/docs/sensors/filters/ctx.md
@@ -44,7 +44,7 @@ You can also specify id, specversion and time fields in the YAML manifest, but t
 
 ## How it works
 
-Context filter takes a `start` and `stop` time in `HH:MM:SS` format in UTC.
+Specify one or more of the available context fields:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
Fixes a bug in the context filter documentation (#2276)
<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
