### PR TITLE
chore: Better examples for expr.fields

### DIFF
--- a/examples/sensors/filter-with-expressions.yaml
+++ b/examples/sensors/filter-with-expressions.yaml
@@ -2,9 +2,13 @@
 #
 #  {
 #    "a": "b",
-#    "c": 10,
-#    "d": {
-#      "e": false
+#    "a-longer-name": 10,
+#    "nested": {
+#      "path": {
+#        "can-get": {
+#          "longer": false
+#        }
+#      }
 #    }
 #  }
 #
@@ -22,15 +26,17 @@ spec:
         # If event payload passes ALL following expr filters, the event is considered a valid event.
         exprs:   # result: EVENT PASS
           - expr: a == "b" || c == 10   # true
+            # In 'fields', 'name' works as a small alias used inside 'expr' above,
+            # while 'path' refers to a potentially-long JSON path in the payload.
             fields:
               - name: a
                 path: a
               - name: c
-                path: c
+                path: a-longer-name
           - expr: e == false   # true
             fields:
               - name: e
-                path: d.e
+                path: nested.path.can-get.longer
   triggers:
     - template:
         name: workflow

--- a/examples/sensors/filter-with-multiple-expr-filters-in-or.yaml
+++ b/examples/sensors/filter-with-multiple-expr-filters-in-or.yaml
@@ -2,9 +2,13 @@
 #
 #  {
 #    "a": "b",
-#    "c": 10,
-#    "d": {
-#      "e": false
+#    "a-longer-name": 10,
+#    "nested": {
+#      "path": {
+#        "can-get": {
+#          "longer": false
+#        }
+#      }
 #    }
 #  }
 #
@@ -23,15 +27,17 @@ spec:
         exprLogicalOperator: "or"
         exprs:
           - expr: a == "b" || c != 10   # FALSE
+            # In 'fields', 'name' works as a small alias used inside 'expr' above,
+            # while 'path' refers to a potentially-long JSON path in the payload.
             fields:
               - name: a
                 path: a
               - name: c
-                path: c
+                path: a-longer-name
           - expr: e == false   # true
             fields:
               - name: e
-                path: d.e
+                path: nested.path.can-get.longer
         # result: EVENT PASS
   triggers:
     - template:


### PR DESCRIPTION
I've seen people struggling to understand what `fields.name` and `fields.path` are meant for. 

I hope the proposed examples will make it easier for everyone.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
