### PR TITLE
fix: if key/value store already exists use that

### DIFF
--- a/eventbus/jetstream/sensor/sensor_jetstream.go
+++ b/eventbus/jetstream/sensor/sensor_jetstream.go
@@ -55,7 +55,8 @@ func (stream *SensorJetstream) Initialize() error {
 	}
 	// create Key/Value store for this Sensor (seems to be okay to call this if it already exists)
 	stream.keyValueStore, err = stream.MgmtConnection.JSContext.CreateKeyValue(&nats.KeyValueConfig{Bucket: stream.sensorName})
-	if err == nats.ErrStreamNameAlreadyInUse {
+	switch err {
+	case nats.ErrStreamNameAlreadyInUse:
 		// get the existing one
 		stream.keyValueStore, err = stream.MgmtConnection.JSContext.KeyValue(stream.sensorName)
 		if err != nil {
@@ -64,13 +65,12 @@ func (stream *SensorJetstream) Initialize() error {
 			return err
 		}
 		stream.Logger.Infof("found existing K/V store for sensor %s, using that", stream.sensorName)
-	} else if err != nil {
+	case nil:
 		errStr := fmt.Sprintf("failed to Create Key/Value Store for sensor %s, err: %v", stream.sensorName, err)
 		stream.Logger.Error(errStr)
 		return err
-	} else {
-		stream.Logger.Infof("successfully created K/V store for sensor %s", stream.sensorName)
 	}
+	stream.Logger.Infof("successfully created/located K/V store for sensor %s", stream.sensorName)
 
 	// Here we can take the sensor specification and clean up the K/V store so as to remove any old
 	// Triggers for this Sensor that no longer exist and any old Dependencies (and also Drain any corresponding Connections)


### PR DESCRIPTION
Fixes #2278 

Use the existing key/value store if it already exists.

I tested this with the following experiments involving a webhook and a sensor with a trigger that is configured as "A&&B":
- start up new jetstream bus where key/value store doesn't already exist 
- use existing jetstream bus, send "A", modify jetstream version and `kubectl apply` it, send "B", verify trigger occurs
- use existing jetstream bus, send "A", delete sensor pod and see it restart, send "B", verify trigger occurs

Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>


