### PR TITLE
fix: typo in gitlab example eventsource

### DIFF
--- a/examples/event-sources/gitlab.yaml
+++ b/examples/event-sources/gitlab.yaml
@@ -14,7 +14,7 @@ spec:
       projects:
         - "whynowy/test"
         - "3"
-      # Github will send events to following port and endpoint
+      # GitLab will send events to following port and endpoint
       webhook:
         # endpoint to listen to events on
         endpoint: /push


### PR DESCRIPTION
This example refers to GitLab usage, so I think this is a typo