### PR TITLE
chore: improve CLOMonitor score

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -3,7 +3,7 @@ name: Approve and enable auto-merge for dependabot
 on: pull_request
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   review:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3832/badge)](https://bestpractices.coreinfrastructure.org/projects/3832)
 [![GoDoc](https://godoc.org/github.com/argoproj/argo-events?status.svg)](https://godoc.org/github.com/argoproj/argo-events/pkg/apis)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/argo-events)](https://artifacthub.io/packages/helm/argo/argo-events)
 
 ## What is Argo Events?
 


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Part of #2250 

Use least permissive permissions by default on `.github/workflows/dependabot-reviewer.yml`.  Review job has proper permissions set.

Add Artifact Hub Badge.



Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
