### PR TITLE
fix: fix bug in evaluation of filters with filtersLogicalOperator=or

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -4,6 +4,7 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 
 1. [3Rein](https://www.3rein.com)
 1. [7shifts](https://www.7shifts.com)
+1. [Adobe](https://adobe.com/)
 1. [Akuity](https://akuity.io/)
 1. [Alibaba Group](https://www.alibabagroup.com/)
 1. [Ant Group](https://www.antgroup.com/)

--- a/sensors/dependencies/filter.go
+++ b/sensors/dependencies/filter.go
@@ -94,11 +94,16 @@ func filterEvent(filter *v1alpha1.EventDependencyFilter, operator v1alpha1.Logic
 	}
 
 	if operator == v1alpha1.OrLogicalOperator {
+		pass := (filter.Exprs != nil && exprFilter) ||
+			(filter.Data != nil && dataFilter) ||
+			(filter.Context != nil && ctxFilter) ||
+			(filter.Time != nil && timeFilter) ||
+			(filter.Script != "" && scriptFilter)
+
 		if len(errMessages) > 0 {
-			return exprFilter || dataFilter || ctxFilter || timeFilter || scriptFilter,
-				errors.New(strings.Join(errMessages, errMsgListSeparator))
+			return pass, errors.New(strings.Join(errMessages, errMsgListSeparator))
 		}
-		return exprFilter || dataFilter || ctxFilter || timeFilter || scriptFilter, nil
+		return pass, nil
 	}
 	return exprFilter && dataFilter && ctxFilter && timeFilter && scriptFilter, nil
 }

--- a/sensors/dependencies/filter_test.go
+++ b/sensors/dependencies/filter_test.go
@@ -628,45 +628,39 @@ func TestFilter(t *testing.T) {
 		filter := &v1alpha1.EventDependencyFilter{
 			Exprs: []v1alpha1.ExprFilter{
 				{
-					// C
-					Expr: `committer_email == "definitely-wrong"`, // this will be wrong
+					Expr: `A == "not-valid"`, // this will evaluate to false
 					Fields: []v1alpha1.PayloadField{
 						{
-							Path: "body.head_commit.committer.email",
-							Name: "committer_email",
+							Path: "a.b",
+							Name: "A",
 						},
 					},
 				},
 			},
 			Data: []v1alpha1.DataFilter{ // these evaluate to false
 				{
-					Path:  "body.ref",
+					Path:  "a.d.e.f",
 					Type:  "string",
-					Value: []string{"definitely-wrong"},
+					Value: []string{"not-valid"},
 				},
 				{
-					Path:  "body.repository.full_name",
+					Path:  "a.h.i",
 					Type:  "string",
-					Value: []string{"foo/bar"},
-				},
-				{
-					Path:  "[body.commits.#.modified.#()#,body.commits.#.added.#()#,body.commits.#.removed.#()#]|@flatten|@flatten",
-					Type:  "string",
-					Value: []string{"^.*README.*$", "^.*service_metadata.*$"},
+					Value: []string{"not-valid", "not-valid-2"},
 				},
 			},
 		}
 
 		eventDataBytes, err := json.Marshal(map[string]interface{}{
-			"body": map[string]interface{}{
-				"ref": "foo",
-				"head_commit": map[string]interface{}{
-					"committer": map[string]interface{}{
-						"email": "aaren@adobe.com",
+			"a": map[string]interface{}{
+				"b": "c",
+				"d": map[string]interface{}{
+					"e": map[string]interface{}{
+						"f": "g",
 					},
 				},
-				"repository": map[string]interface{}{
-					"full_name": "anything/anything",
+				"h": map[string]interface{}{
+					"i": "j",
 				},
 			},
 		})


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

This PR fixes a bug where when specifying only a subset of filters, in our case an expr filter and data filter, the filter would always evaluate to a 'pass'ing condition. 

This happens because the code doesn't check that we specified a filter before attempting to evaluate it, at which point it will default to `true`. 

The PR changes that behavior to check if the filter was `nil` before looking at what it evaluates to.
