### PR TITLE
chore: fixed sbom output path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,10 @@ jobs:
       - run: go install sigs.k8s.io/bom/cmd/bom@v0.2.0
       - run: go install github.com/spdx/spdx-sbom-generator/cmd/generator@v0.0.13
       - run: mkdir -p dist
-      - run: generator -o dist -p .
-      - run: bom generate --image quay.io/argoproj/argo-events:$VERSION -o dist/argo-events.spdx
+      - run: generator -o /tmp -p .
+      - run: bom generate --image quay.io/argoproj/argo-events:$VERSION -o /tmp/argo-events.spdx
       # pack the boms into one file to make it easy to download
-      - run: cd /tmp && tar -zcf sbom.tar.gz dist/*.spdx
+      - run: cd /tmp && tar -zcf sbom.tar.gz *.spdx
       - uses: actions/upload-artifact@v3
         with:
           name: sbom.tar.gz


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

fixed the output path for the sbom.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
