### PR TITLE
chore: fixed sbom download path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: sbom.tar.gz
-          path: /tmp/sbom.tar.gz
+          path: /tmp
 
       - name: Registry Login
         uses: docker/login-action@v2


### PR DESCRIPTION
Signed-off-by: Justin Marquis <34fathombelow@protonmail.com>

Apparently the path for the download action should not contain the file name in it. :facepalm: 

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
