### PR TITLE
feat: allow granular secret privileges. additional controller logging/leader-election options

### DIFF
--- a/cmd/commands/controller.go
+++ b/cmd/commands/controller.go
@@ -3,24 +3,42 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/argoproj/argo-events/common"
+	"github.com/argoproj/argo-events/common/logging"
 	controllercmd "github.com/argoproj/argo-events/controllers/cmd"
 	envpkg "github.com/argoproj/pkg/env"
 )
 
 func NewControllerCommand() *cobra.Command {
 	var (
+		leaderElection   bool
 		namespaced       bool
 		managedNamespace string
+		metricsPort      int32
+		healthPort       int32
+		klogLevel        int
 	)
 
 	command := &cobra.Command{
 		Use:   "controller",
 		Short: "Start the controller",
 		Run: func(cmd *cobra.Command, args []string) {
-			controllercmd.Start(namespaced, managedNamespace)
+			logging.SetKlogLevel(klogLevel)
+			eventOpts := controllercmd.ArgoEventsControllerOpts{
+				LeaderElection:   leaderElection,
+				ManagedNamespace: managedNamespace,
+				Namespaced:       namespaced,
+				MetricsPort:      metricsPort,
+				HealthPort:       healthPort,
+			}
+			controllercmd.Start(eventOpts)
 		},
 	}
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "Whether to run in namespaced scope, defaults to false.")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", envpkg.LookupEnvStringOr("NAMESPACE", "argo-events"), "The namespace that the controller watches when \"--namespaced\" is \"true\".")
+	command.Flags().BoolVar(&leaderElection, "leader-election", true, "Enable leader election")
+	command.Flags().Int32Var(&metricsPort, "metrics-port", common.ControllerMetricsPort, "Metrics port")
+	command.Flags().Int32Var(&healthPort, "health-port", common.ControllerHealthPort, "Health port")
+	command.Flags().IntVar(&klogLevel, "kloglevel", 0, "klog level")
 	return command
 }

--- a/common/common.go
+++ b/common/common.go
@@ -133,6 +133,7 @@ const (
 	SensorMetricsPort      = 7777
 	ControllerMetricsPort  = 7777
 	EventBusMetricsPort    = 7777
+	ControllerHealthPort   = 8081
 )
 
 var (

--- a/common/logging/logger.go
+++ b/common/logging/logger.go
@@ -18,9 +18,12 @@ package logging
 
 import (
 	"context"
+	"flag"
 	"os"
+	"strconv"
 
 	zap "go.uber.org/zap"
+	"k8s.io/klog/v2"
 
 	"github.com/argoproj/argo-events/common"
 )
@@ -56,6 +59,11 @@ func NewArgoEventsLogger() *zap.SugaredLogger {
 		panic(err)
 	}
 	return logger.Named("argo-events").Sugar()
+}
+
+func SetKlogLevel(level int) {
+	klog.InitFlags(nil)
+	_ = flag.Set("v", strconv.Itoa(level))
 }
 
 type loggerKey struct{}

--- a/controllers/eventbus/installer/installer.go
+++ b/controllers/eventbus/installer/installer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/argoproj/argo-events/common"
@@ -23,8 +24,8 @@ type Installer interface {
 }
 
 // Install function installs the event bus
-func Install(ctx context.Context, eventBus *v1alpha1.EventBus, client client.Client, config *controllers.GlobalConfig, logger *zap.SugaredLogger) error {
-	installer, err := getInstaller(eventBus, client, config, logger)
+func Install(ctx context.Context, eventBus *v1alpha1.EventBus, client client.Client, kubeClient kubernetes.Interface, config *controllers.GlobalConfig, logger *zap.SugaredLogger) error {
+	installer, err := getInstaller(eventBus, client, kubeClient, config, logger)
 	if err != nil {
 		logger.Errorw("failed to an installer", zap.Error(err))
 		return err
@@ -39,12 +40,12 @@ func Install(ctx context.Context, eventBus *v1alpha1.EventBus, client client.Cli
 }
 
 // GetInstaller returns Installer implementation
-func getInstaller(eventBus *v1alpha1.EventBus, client client.Client, config *controllers.GlobalConfig, logger *zap.SugaredLogger) (Installer, error) {
+func getInstaller(eventBus *v1alpha1.EventBus, client client.Client, kubeClient kubernetes.Interface, config *controllers.GlobalConfig, logger *zap.SugaredLogger) (Installer, error) {
 	if nats := eventBus.Spec.NATS; nats != nil {
 		if nats.Exotic != nil {
 			return NewExoticNATSInstaller(eventBus, logger), nil
 		} else if nats.Native != nil {
-			return NewNATSInstaller(client, eventBus, config, getLabels(eventBus), logger), nil
+			return NewNATSInstaller(client, eventBus, config, getLabels(eventBus), kubeClient, logger), nil
 		}
 	} else if js := eventBus.Spec.JetStream; js != nil {
 		return NewJetStreamInstaller(client, eventBus, config, getLabels(eventBus), logger), nil
@@ -68,7 +69,7 @@ func getLabels(bus *v1alpha1.EventBus) map[string]string {
 // separately.
 //
 // It could also be used to check if the EventBus object can be safely deleted.
-func Uninstall(ctx context.Context, eventBus *v1alpha1.EventBus, client client.Client, config *controllers.GlobalConfig, logger *zap.SugaredLogger) error {
+func Uninstall(ctx context.Context, eventBus *v1alpha1.EventBus, client client.Client, kubeClient kubernetes.Interface, config *controllers.GlobalConfig, logger *zap.SugaredLogger) error {
 	linkedEventSources, err := linkedEventSources(ctx, eventBus.Namespace, eventBus.Name, client)
 	if err != nil {
 		logger.Errorw("failed to query linked EventSources", zap.Error(err))
@@ -87,7 +88,7 @@ func Uninstall(ctx context.Context, eventBus *v1alpha1.EventBus, client client.C
 		return fmt.Errorf("Can not delete an EventBus with %v Sensors connected", linkedSensors)
 	}
 
-	installer, err := getInstaller(eventBus, client, config, logger)
+	installer, err := getInstaller(eventBus, client, kubeClient, config, logger)
 	if err != nil {
 		logger.Errorw("failed to get an installer", zap.Error(err))
 		return err

--- a/go.mod
+++ b/go.mod
@@ -310,7 +310,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog v1.0.0 // indirect
-	k8s.io/klog/v2 v2.60.1 // indirect
+	k8s.io/klog/v2 v2.60.1
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
+++ b/manifests/cluster-install/rbac/argo-events-cluster-role.yaml
@@ -49,7 +49,6 @@ rules:
       - pods
       - pods/exec
       - configmaps
-      - secrets
       - services
       - persistentvolumeclaims
     verbs:
@@ -57,6 +56,18 @@ rules:
       - get
       - list
       - watch
+      - update
+      - patch
+      - delete
+  # Secrets privileges are used to manage the NATs auth secrets. This can be removed from the ClusterRole and granted granularly per Namespace as needed
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
       - update
       - patch
       - delete

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -257,7 +257,6 @@ rules:
   - pods
   - pods/exec
   - configmaps
-  - secrets
   - services
   - persistentvolumeclaims
   verbs:
@@ -265,6 +264,17 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
   - update
   - patch
   - delete

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -176,7 +176,6 @@ rules:
   - pods
   - pods/exec
   - configmaps
-  - secrets
   - services
   - persistentvolumeclaims
   verbs:
@@ -185,6 +184,17 @@ rules:
   - list
   - watch
   - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
+  - list
   - patch
   - delete
 - apiGroups:

--- a/manifests/namespace-install/rbac/argo-events-role.yaml
+++ b/manifests/namespace-install/rbac/argo-events-role.yaml
@@ -49,7 +49,6 @@ rules:
       - pods
       - pods/exec
       - configmaps
-      - secrets
       - services
       - persistentvolumeclaims
     verbs:
@@ -58,6 +57,18 @@ rules:
       - list
       - watch
       - update
+      - patch
+      - delete
+  # Secrets privileges are used to manage the NATs auth secrets. This can be removed from the ClusterRole and granted granularly per Namespace as needed
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - update
+      - list
       - patch
       - delete
   - apiGroups:


### PR DESCRIPTION
Resolves https://github.com/argoproj/argo-events/issues/2403

## 1. Removes requirement of having cluster-scoped secret privileges.

Currently, argo-events requires secrets list/watch/get privileges at a cluster scope. However, the only reason it wants this is to requeue the eventbus to the eventbus controller in case the NATS auth credentials secrets becomes modified or deleted. The watch is largely unnecessary because:
  * the secret will not naturally become modified or deleted. It is owned by the eventbus resource and not something a user manages.
  * even if it does, it will eventually be reconciled by virtue of the eventbus sync interval

This change improves the security of argo-events by allowing Argo Events to run with only list/get secrets granted at a per-namespace basis (by creating a namespaced RoleBinding to map a ClusterRole to the argo-events:argo-events-sa ServiceAccount)

In order to achieve this, the following changes were made:
  * do not start the secret watch during startup. As I mentioned earlier, I feel this is unnecessary.
  * switch to a normal kubernetes client instead of the controller-runtime client. The reason this is necessary, is because the controller-runtime client still attempts to perform cluster-wide API list calls (even when a namspace is supplied to the `List()` call). 

## 2. Improved controller and developer convenience options

During development, I found it quite inconvenient to develop so I added the following:
  * option to start the controller without leader election (so we can set breakpoints and pause indefinitely)
  * option to increase the *kubernetes* log level (to see what API calls were being made)

Signed-off-by: Jesse Suen <jesse@akuity.io>

