### PR TITLE
ci: disable docker build attestations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ image-linux-%: dist/$(BINARY_NAME)-linux-%
 	@if [ "$(DOCKER_PUSH)" = "true" ]; then docker push $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION)-linux-$*; fi
 
 image-multi: set-qemu dist/$(BINARY_NAME)-linux-arm64.gz dist/$(BINARY_NAME)-linux-amd64.gz
-	docker buildx build --tag $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) --platform linux/amd64,linux/arm64 --file ./Dockerfile ${PUSH_OPTION} .
+	docker buildx build --sbom=false --provenance=false --tag $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --target $(BINARY_NAME) --platform linux/amd64,linux/arm64 --file ./Dockerfile ${PUSH_OPTION} .
 
 set-qemu:
 	docker pull tonistiigi/binfmt:latest


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

docker buildx build started to generating [attestation manifests](https://docs.docker.com/build/attestations/attestation-storage/#attestation-manifest-descriptor) by default, which generates extra `unknown/unknown` manifests in the image artifactory. This makes `bom generate -i quay.io/argoproj/argo-events:xxxx` fail because `bom` does not recognize those manifests.

This PR disable the `docker buildx build` command generating attestation manifests to workaround the issue.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
