### PR TITLE
fix: remove the secret watch privilege dependency from js eb ctrler

### DIFF
--- a/controllers/eventbus/installer/installer.go
+++ b/controllers/eventbus/installer/installer.go
@@ -48,7 +48,7 @@ func getInstaller(eventBus *v1alpha1.EventBus, client client.Client, kubeClient 
 			return NewNATSInstaller(client, eventBus, config, getLabels(eventBus), kubeClient, logger), nil
 		}
 	} else if js := eventBus.Spec.JetStream; js != nil {
-		return NewJetStreamInstaller(client, eventBus, config, getLabels(eventBus), logger), nil
+		return NewJetStreamInstaller(client, eventBus, config, getLabels(eventBus), kubeClient, logger), nil
 	}
 	return nil, fmt.Errorf("invalid eventbus spec")
 }
@@ -76,7 +76,7 @@ func Uninstall(ctx context.Context, eventBus *v1alpha1.EventBus, client client.C
 		return fmt.Errorf("failed to check if there is any EventSource linked, %w", err)
 	}
 	if linkedEventSources > 0 {
-		return fmt.Errorf("Can not delete an EventBus with %v EventSources connected", linkedEventSources)
+		return fmt.Errorf("can not delete an EventBus with %v EventSources connected", linkedEventSources)
 	}
 
 	linkedSensors, err := linkedSensors(ctx, eventBus.Namespace, eventBus.Name, client)
@@ -85,7 +85,7 @@ func Uninstall(ctx context.Context, eventBus *v1alpha1.EventBus, client client.C
 		return fmt.Errorf("failed to check if there is any Sensor linked, %w", err)
 	}
 	if linkedSensors > 0 {
-		return fmt.Errorf("Can not delete an EventBus with %v Sensors connected", linkedSensors)
+		return fmt.Errorf("can not delete an EventBus with %v Sensors connected", linkedSensors)
 	}
 
 	installer, err := getInstaller(eventBus, client, kubeClient, config, logger)

--- a/controllers/eventbus/installer/jetstream.go
+++ b/controllers/eventbus/installer/jetstream.go
@@ -18,8 +18,9 @@ import (
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -54,20 +55,22 @@ const (
 )
 
 type jetStreamInstaller struct {
-	client   client.Client
-	eventBus *v1alpha1.EventBus
-	config   *controllers.GlobalConfig
-	labels   map[string]string
-	logger   *zap.SugaredLogger
+	client     client.Client
+	eventBus   *v1alpha1.EventBus
+	kubeClient kubernetes.Interface
+	config     *controllers.GlobalConfig
+	labels     map[string]string
+	logger     *zap.SugaredLogger
 }
 
-func NewJetStreamInstaller(client client.Client, eventBus *v1alpha1.EventBus, config *controllers.GlobalConfig, labels map[string]string, logger *zap.SugaredLogger) Installer {
+func NewJetStreamInstaller(client client.Client, eventBus *v1alpha1.EventBus, config *controllers.GlobalConfig, labels map[string]string, kubeClient kubernetes.Interface, logger *zap.SugaredLogger) Installer {
 	return &jetStreamInstaller{
-		client:   client,
-		eventBus: eventBus,
-		config:   config,
-		labels:   labels,
-		logger:   logger.With("eventbus", eventBus.Name),
+		client:     client,
+		kubeClient: kubeClient,
+		eventBus:   eventBus,
+		config:     config,
+		labels:     labels,
+		logger:     logger.With("eventbus", eventBus.Name),
 	}
 }
 
@@ -488,12 +491,25 @@ func (r *jetStreamInstaller) buildStatefulSetSpec(jsVersion *controllers.JetStre
 	return spec
 }
 
+func (r *jetStreamInstaller) getSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	sl, err := r.kubeClient.CoreV1().Secrets(r.eventBus.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range sl.Items {
+		if s.Name == name && metav1.IsControlledBy(&s, r.eventBus) {
+			return &s, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+}
+
 func (r *jetStreamInstaller) createSecrets(ctx context.Context) error {
 	// first check to see if the secrets already exist
 	oldServerObjExisting, oldClientObjExisting := true, true
 
-	oldSObj := &corev1.Secret{}
-	if err := r.client.Get(ctx, apitypes.NamespacedName{Namespace: r.eventBus.Namespace, Name: generateJetStreamServerSecretName(r.eventBus)}, oldSObj); err != nil {
+	oldSObj, err := r.getSecret(ctx, generateJetStreamServerSecretName(r.eventBus))
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			oldServerObjExisting = false
 		} else {
@@ -501,8 +517,8 @@ func (r *jetStreamInstaller) createSecrets(ctx context.Context) error {
 		}
 	}
 
-	oldCObj := &corev1.Secret{}
-	if err := r.client.Get(ctx, apitypes.NamespacedName{Namespace: r.eventBus.Namespace, Name: generateJetStreamClientAuthSecretName(r.eventBus)}, oldCObj); err != nil {
+	oldCObj, err := r.getSecret(ctx, generateJetStreamClientAuthSecretName(r.eventBus))
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			oldClientObjExisting = false
 		} else {

--- a/controllers/eventbus/installer/jetstream_test.go
+++ b/controllers/eventbus/installer/jetstream_test.go
@@ -14,6 +14,7 @@ import (
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -40,11 +41,12 @@ func TestJetStreamBadInstallation(t *testing.T) {
 		badEventBus := testJetStreamEventBus.DeepCopy()
 		badEventBus.Spec.JetStream = nil
 		installer := &jetStreamInstaller{
-			client:   fake.NewClientBuilder().Build(),
-			eventBus: badEventBus,
-			config:   fakeConfig,
-			labels:   testLabels,
-			logger:   zaptest.NewLogger(t).Sugar(),
+			client:     fake.NewClientBuilder().Build(),
+			kubeClient: k8sfake.NewSimpleClientset(),
+			eventBus:   badEventBus,
+			config:     fakeConfig,
+			labels:     testLabels,
+			logger:     zaptest.NewLogger(t).Sugar(),
 		}
 		_, err := installer.Install(context.TODO())
 		assert.Error(t, err)
@@ -70,11 +72,12 @@ func TestJetStreamCreateObjects(t *testing.T) {
 	cl := fake.NewClientBuilder().Build()
 	ctx := context.TODO()
 	i := &jetStreamInstaller{
-		client:   cl,
-		eventBus: testJetStreamEventBus,
-		config:   fakeConfig,
-		labels:   testLabels,
-		logger:   zaptest.NewLogger(t).Sugar(),
+		client:     cl,
+		kubeClient: k8sfake.NewSimpleClientset(),
+		eventBus:   testJetStreamEventBus,
+		config:     fakeConfig,
+		labels:     testLabels,
+		logger:     zaptest.NewLogger(t).Sugar(),
 	}
 
 	t.Run("test create sts", func(t *testing.T) {

--- a/manifests/base/controller-manager/controller-config.yaml
+++ b/manifests/base/controller-manager/controller-config.yaml
@@ -62,4 +62,3 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-

--- a/manifests/base/controller-manager/controller-config.yaml
+++ b/manifests/base/controller-manager/controller-config.yaml
@@ -28,7 +28,7 @@ data:
           duplicates: 300s
         versions:
         - version: latest
-          natsImage: nats:2.9.1
+          natsImage: nats:2.9.12
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
@@ -57,3 +57,9 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -307,7 +307,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller-config.yaml: |+
+  controller-config.yaml: |
     eventBus:
       nats:
         versions:
@@ -366,7 +366,6 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-
 kind: ConfigMap
 metadata:
   name: argo-events-controller-config

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -307,7 +307,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller-config.yaml: |
+  controller-config.yaml: |+
     eventBus:
       nats:
         versions:
@@ -332,7 +332,7 @@ data:
           duplicates: 300s
         versions:
         - version: latest
-          natsImage: nats:2.9.1
+          natsImage: nats:2.9.12
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
@@ -361,6 +361,12 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+
 kind: ConfigMap
 metadata:
   name: argo-events-controller-config

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -227,7 +227,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller-config.yaml: |
+  controller-config.yaml: |+
     eventBus:
       nats:
         versions:
@@ -252,7 +252,7 @@ data:
           duplicates: 300s
         versions:
         - version: latest
-          natsImage: nats:2.9.1
+          natsImage: nats:2.9.12
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
@@ -281,6 +281,12 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+
 kind: ConfigMap
 metadata:
   name: argo-events-controller-config

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -227,7 +227,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  controller-config.yaml: |+
+  controller-config.yaml: |
     eventBus:
       nats:
         versions:
@@ -286,7 +286,6 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-
 kind: ConfigMap
 metadata:
   name: argo-events-controller-config


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Fixes: https://github.com/argoproj/argo-events/issues/2452
Also updated supported JetStream EventBus version.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
