### PR TITLE
fix(controller): use a copied object to update because of mutation

### DIFF
--- a/controllers/eventbus/controller.go
+++ b/controllers/eventbus/controller.go
@@ -58,7 +58,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Errorw("reconcile error", zap.Error(reconcileErr))
 	}
 	if r.needsUpdate(eventBus, busCopy) {
-		if err := r.client.Update(ctx, busCopy); err != nil {
+		// Use a DeepCopy to update, because it will be mutated afterwards, with empty Status.
+		if err := r.client.Update(ctx, busCopy.DeepCopy()); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/controllers/eventsource/controller.go
+++ b/controllers/eventsource/controller.go
@@ -55,7 +55,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Errorw("reconcile error", zap.Error(reconcileErr))
 	}
 	if r.needsUpdate(eventSource, esCopy) {
-		if err := r.client.Update(ctx, esCopy); err != nil {
+		// Use a DeepCopy to update, because it will be mutated afterwards, with empty Status.
+		if err := r.client.Update(ctx, esCopy.DeepCopy()); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/controllers/sensor/controller.go
+++ b/controllers/sensor/controller.go
@@ -74,7 +74,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Errorw("reconcile error", zap.Error(reconcileErr))
 	}
 	if r.needsUpdate(sensor, sensorCopy) {
-		if err := r.client.Update(ctx, sensorCopy); err != nil {
+		// Use a DeepCopy to update, because it will be mutated afterwards, with empty Status.
+		if err := r.client.Update(ctx, sensorCopy.DeepCopy()); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Derek Wang <whynowy@gmail.com>

Controller-runtime client.Update() will mutate the object, which makes the following up Status.Update() do nothing - it didn't cause any issue because there are couple of reconciliations, eventually the Status gets updated correctly. 

Thanks @dfarr @bilalba for reporting the issue. 

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
