### PR TITLE
add labels to jetstream statefulset generated by eventbus controller

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -27,6 +27,7 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 1. [iFood](https://www.ifood.com.br)
 1. [InsideBoard](https://www.insideboard.com)
 1. [Intuit](https://www.intuit.com/)
+1. [FikaWorks](https://fika.works/)
 1. [Loam](https://www.getloam.com/)
 1. [Mobimeo GmbH](https://mobimeo.com/en/home/)
 1. [OneCause](https://www.onecause.com/)

--- a/controllers/eventbus/installer/jetstream.go
+++ b/controllers/eventbus/installer/jetstream.go
@@ -196,7 +196,7 @@ func (r *jetStreamInstaller) createStatefulSet(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.eventBus.Namespace,
 			Name:      generateJetStreamStatefulSetName(r.eventBus),
-			Labels:    r.labels,
+			Labels:    r.mergeEventBusLabels(r.labels),
 			Annotations: map[string]string{
 				common.AnnotationResourceSpecHash: hash,
 			},
@@ -750,6 +750,19 @@ func (r *jetStreamInstaller) getPVCs(ctx context.Context) ([]corev1.PersistentVo
 
 func generateJetStreamServerSecretName(eventBus *v1alpha1.EventBus) string {
 	return fmt.Sprintf("eventbus-%s-js-server", eventBus.Name)
+}
+
+func (r *jetStreamInstaller) mergeEventBusLabels(given map[string]string) map[string]string {
+	result := map[string]string{}
+	if r.eventBus.Labels != nil {
+		for k, v := range r.eventBus.Labels {
+			result[k] = v
+		}
+	}
+	for k, v := range given {
+		result[k] = v
+	}
+	return result
 }
 
 func generateJetStreamClientAuthSecretName(eventBus *v1alpha1.EventBus) string {


### PR DESCRIPTION
When migrating from the NATS EventBus to the JetStream EventBus I noticed that the deployment was blocked by our admission controller as it requires certain labels to be present on the StatefulSets and Deployments.

It seemed that the EventBus controller only appends the labels from the EventBus CRD to the EventBus StatefulSet for the NATS EventBus and not for the JetStream EventBus, this PR adds this for JetStream EventBuses as well.

Checklist:

- [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
