### PR TITLE
fix github sensor example to use generateName

### DIFF
--- a/examples/sensors/github.yaml
+++ b/examples/sensors/github.yaml
@@ -42,7 +42,7 @@ spec:
               apiVersion: argoproj.io/v1alpha1
               kind: Workflow
               metadata:
-                name: github-
+                generateName: github-
               spec:
                 entrypoint: whalesay
                 arguments:


### PR DESCRIPTION
Just fixing a booboo that tripped me up when implementing the github sensor.
