### PR TITLE
chore: Reduce naivewatcher interval

### DIFF
--- a/eventsources/common/naivewatcher/watcher_test.go
+++ b/eventsources/common/naivewatcher/watcher_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/argoproj/argo-events/eventsources/common/fsevent"
+	"github.com/stretchr/testify/assert"
 )
 
 type WatchableTestFS struct {
@@ -51,7 +50,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = watcher.Start(100 * time.Millisecond)
+	err = watcher.Start(50 * time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +65,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events := readEvents(t, watcher)
 	assert.Equal(t, []fsevent.Event{
 		{Op: fsevent.Create, Name: filepath.Join(tmpdir, "foo")},
@@ -77,7 +76,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events = readEvents(t, watcher)
 	assert.Equal(t, []fsevent.Event{
 		{Op: fsevent.Rename, Name: filepath.Join(tmpdir, "bar")},
@@ -88,7 +87,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events = readEvents(t, watcher)
 	assert.Equal(t, []fsevent.Event{
 		{Op: fsevent.Write, Name: filepath.Join(tmpdir, "bar")},
@@ -99,7 +98,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events = readEvents(t, watcher)
 	assert.Equal(t, []fsevent.Event{
 		{Op: fsevent.Chmod, Name: filepath.Join(tmpdir, "bar")},
@@ -119,7 +118,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	var actualOps fsevent.Op
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events = readEvents(t, watcher)
 	for _, event := range events {
 		if event.Name == filepath.Join(tmpdir, "foo") {
@@ -133,7 +132,7 @@ func TestWatcherAutoCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 	events = readEvents(t, watcher)
 	assert.Equal(t, []fsevent.Event{
 		{Op: fsevent.Remove, Name: filepath.Join(tmpdir, "foo")},


### PR DESCRIPTION
The naivewatcher test (specifically the `TestWatcherAutoCheck` test) exhibits nondeterministic behaviour. On occasion, the test will see unexpected file system events, causing the test to fail. Generally, there are two types of causes of failure:
1. Duplicate events
2. A remove+create event where we would expect to see a rename event

You can reproduce this locally by running (may take quite a few iterations before a failure occurs).
```
while true; do go clean -testcache && go test github.com/argoproj/argo-events/eventsources/common/naivewatcher; done
```

The issue appears to be due the way `watcher.Start` works, calling the `Check` function at a specified interval, and making timing issues possible. This fix tunes the parameters to make test failure less likely, I have not been able to reproduce an error in 1000+ iterations of the test locally, and 100+ iterations of the test in GH Actions.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).
