### PR TITLE
feat: Add golang metrics to argo-events metrics registry.

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -167,8 +168,9 @@ func (m *Metrics) ActionDuration(sensorName, triggerName string, num float64) {
 func (m *Metrics) Run(ctx context.Context, addr string) {
 	log := logging.FromContext(ctx)
 	metricsRegistry := prometheus.NewRegistry()
-	metricsRegistry.MustRegister(m)
+	metricsRegistry.MustRegister(collectors.NewGoCollector(), m)
 	http.Handle("/metrics", promhttp.HandlerFor(metricsRegistry, promhttp.HandlerOpts{}))
+	
 	log.Info("starting metrics server")
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatalw("failed to start metrics server", zap.Error(err))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -170,7 +170,7 @@ func (m *Metrics) Run(ctx context.Context, addr string) {
 	metricsRegistry := prometheus.NewRegistry()
 	metricsRegistry.MustRegister(collectors.NewGoCollector(), m)
 	http.Handle("/metrics", promhttp.HandlerFor(metricsRegistry, promhttp.HandlerOpts{}))
-	
+
 	log.Info("starting metrics server")
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatalw("failed to start metrics server", zap.Error(err))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,8 +2,9 @@ package metrics
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
The golang metrics are not available from argo-events metrics repository. This PR add the default golang metrics to the repository.