### PR TITLE
 chore: adding tests for the removeConflicts function & the Convert2WaitBackoff function

### DIFF
--- a/common/expr/eval_test.go
+++ b/common/expr/eval_test.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +61,45 @@ func TestEvalBool(t *testing.T) {
 	pass, err = EvalBool("(uuid == 'test-case-hyphen')", env)
 	assert.NoError(t, err)
 	assert.True(t, pass)
+}
+
+func TestRemoveConflictingKeys(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  map[string]interface{}
+		output map[string]interface{}
+	}{
+		{
+			name: "remove conflicting keys",
+			input: map[string]interface{}{
+				"a.b": 1,
+				"a":   2,
+			},
+			output: map[string]interface{}{
+				"a.b": 1,
+			},
+		},
+		{
+			name: "no conflicts",
+			input: map[string]interface{}{
+				"a":   1,
+				"b":   2,
+				"c.d": 3,
+			},
+			output: map[string]interface{}{
+				"a":   1,
+				"b":   2,
+				"c.d": 3,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := removeConflicts(tc.input)
+			if !reflect.DeepEqual(result, tc.output) {
+				t.Errorf("expected %v, but got %v", tc.output, result)
+			}
+		})
+	}
 }

--- a/common/retry_test.go
+++ b/common/retry_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	apicommon "github.com/argoproj/argo-events/pkg/apis/common"
 )
@@ -116,4 +117,24 @@ func TestRetryFailure(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "after retries")
 	assert.Contains(t, err.Error(), "this is an error")
+}
+
+func TestConvert2WaitBackoff(t *testing.T) {
+	factor := apicommon.NewAmount("1.0")
+	jitter := apicommon.NewAmount("1")
+	duration := apicommon.FromString("1s")
+	backoff := apicommon.Backoff{
+		Duration: &duration,
+		Factor:   &factor,
+		Jitter:   &jitter,
+		Steps:    2,
+	}
+	waitBackoff, err := Convert2WaitBackoff(&backoff)
+	assert.NoError(t, err)
+	assert.Equal(t, wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.0,
+		Jitter:   1.0,
+		Steps:    2,
+	}, *waitBackoff)
 }


### PR DESCRIPTION
1. The `Convert2WaitBackoff` func converts `apicommon.Backoff` struct to a wait.Backoff struct used by the k8s.io/apimachinery/pkg/util/wait package. It extracts the fields from the input struct and converts them to the appropriate types for the output struct. Having a unit test for the `Convert2WaitBackoff` function is important to ensure that it converts the input `apicommon.Backoff` object to a `wait.Backoff` object with the correct values. The function has to parse and convert various fields, and the unit test verifies that the conversions are done correctly. 
2. The `removeConflicts` func removes any conflicting keys from a map. If there are two or more keys that share the same prefix, where one is a parent of the other, then the less-specific key is removed. This func is used in the `Expand` function to remove any conflicts before expanding environment variables in the given map. This test is important because it plays a critical role in ensuring that the map used to evaluate expressions is valid. If conflicts are not properly handled, the expressions being evaluated may produce incorrect results for Argo Events users.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
