### PR TITLE
chore: adding test coverage for file system events in argo-events

### DIFF
--- a/eventsources/common/fsevent/fileevent_test.go
+++ b/eventsources/common/fsevent/fileevent_test.go
@@ -1,8 +1,8 @@
 package fsevent
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestOpString(t *testing.T) {

--- a/eventsources/common/fsevent/fileevent_test.go
+++ b/eventsources/common/fsevent/fileevent_test.go
@@ -1,0 +1,56 @@
+package fsevent
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpString(t *testing.T) {
+	tests := []struct {
+		op       Op
+		expected string
+	}{
+		{Create, "CREATE"},
+		{Remove, "REMOVE"},
+		{Write, "WRITE"},
+		{Rename, "RENAME"},
+		{Chmod, "CHMOD"},
+		{Create | Write, "CREATE|WRITE"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.op.String(), "Op.String() for op %d", tt.op)
+	}
+}
+
+func TestNewOp(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Op
+	}{
+		{"CREATE", Create},
+		{"REMOVE", Remove},
+		{"WRITE", Write},
+		{"RENAME", Rename},
+		{"CHMOD", Chmod},
+		{"CREATE|WRITE", Create | Write},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, NewOp(tt.input), "NewOp(%q)", tt.input)
+	}
+}
+
+func TestEventString(t *testing.T) {
+	tests := []struct {
+		event    Event
+		expected string
+	}{
+		{Event{Name: "file1", Op: Create}, `"file1": CREATE`},
+		{Event{Name: "file2", Op: Remove | Write}, `"file2": REMOVE|WRITE`},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.event.String(), "Event.String() for event %#v", tt.event)
+	}
+}

--- a/eventsources/common/fsevent/fileevent_test.go
+++ b/eventsources/common/fsevent/fileevent_test.go
@@ -2,7 +2,7 @@ package fsevent
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/eventsources/common/fsevent/fileevent_test.go
+++ b/eventsources/common/fsevent/fileevent_test.go
@@ -1,8 +1,9 @@
 package fsevent
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+	
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOpString(t *testing.T) {


### PR DESCRIPTION
1. `TestOpString:` This test verifies that the `Op.String()` function correctly converts an Op value to its corresponding string representation. It checks multiple values and compares the expected string representation with the actual result. 
2. `TestNewOp:` This test validates the `NewOp()` function, which converts a given string to an Op value. It tests different input strings representing Op values and compares the value with the actual result.
3. `TestEventString:` This test ensures the correctness of the `Event.String()` function, which returns a string representation of an Event. It checks diff Event instances with specific names and Op values, and validates that it is working properly.

We need test coverage to test the conversion/string representation functionality of the Op and Event types, ensuring that they behave as intended in various scenarios. This functionality is being used in several places:

eventsources/sources/hdfs/validate.go‎
‎eventsources/sources/hdfs/start.go‎
‎eventsources/sources/file/start.go

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
