### PR TITLE
fix: use cluster domain neutral svc dns

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -19,6 +19,7 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 1. [Dazz](https://dazz.io/)
 1. [DevSamurai](https://www.devsamurai.com/)
 1. [Elastic](https://elastic.co/)
+1. [Enso Security](https://enso.security)
 1. [Fairwinds](https://fairwinds.com/)
 1. [Gepardec](https://gepardec.com/)
 1. [GHGSat](https://www.ghgsat.com/)


### PR DESCRIPTION
[#2657](https://github.com/argoproj/argo-events/issues/2657)

Current implementation of NATS eventbus assumes the cluster has 'cluster.local' domain defined, which not always the case.

### Solution
Use cluster domain invariant service name - `evenbus-name.eventbus-namespace.svc` instead of `evenbus-name.eventbus-namespace.svc.cluster.local`

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

