### PR TITLE
chore: create .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @VaibhavPage @whynowy


### PR DESCRIPTION
This ensures PRs get reviewers.  Currently they do not


removed due to not having write permissions on repo anymore (according to the CODEOWNERS file itself)
 - @daniel-codefresh
 - @dtaniwaki

![Screenshot 2023-06-15 at 11 38 21 AM](https://github.com/argoproj/argo-events/assets/35014/52f4c5c6-4535-4c7c-bb48-ec5f470c2b5d)
