### PR TITLE
chore: upgrade Argo CLI version to v3.4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade && \
     apk add ca-certificates && \
     apk --no-cache add tzdata
 
-ENV ARGO_VERSION=v3.4.1
+ENV ARGO_VERSION=v3.4.8
 
 RUN wget -q https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${ARCH}.gz
 RUN gunzip -f argo-linux-${ARCH}.gz


### PR DESCRIPTION
Upgrade Argo CLI to the latest version which is v3.4.8. Solves: #2581 

Basic functionality of the argo-workflows trigger was tested with various WorkflowTemplates, including new features that have been added since the old version we used, such as the 'expr' format in 'when' conditions as requested in the issue itself.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
