### PR TITLE
chore: adding tests for source_jetstream

### DIFF
--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -19,33 +19,24 @@ func TestNewSourceJetstream(t *testing.T) {
 	logger := zap.NewExample().Sugar()
 	defer logger.Sync()
 
+	if logger == nil {
+		t.Error("logger is nil")
+	}
+
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }
 
-func TestSourceJetstream_Initialize(t *testing.T) {
-	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
+// func TestSourceJetstream_Connect(t *testing.T) {
+// 	logger := zap.NewExample().Sugar()
+// 	defer logger.Sync()
 
-	auth := &common.Auth{}
-	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
-	assert.NotNil(t, sourceJetstream)
-	assert.Nil(t, err)
+// 	auth := &common.Auth{}
+// 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+// 	sourceJetstream.Connect(testClientID) // error check this
 
-	err = sourceJetstream.Initialize()
-	assert.NoError(t, err, "error should be nil")
-}
-
-func TestSourceJetstream_Connect(t *testing.T) {
-	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
-
-	auth := &common.Auth{}
-	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
-	sourceJetstream.Connect(testClientID) // error check this
-
-	assert.NotNil(t, sourceJetstream)
-	assert.Nil(t, err)
-}
+// 	assert.NotNil(t, sourceJetstream)
+// 	assert.Nil(t, err)
+// }

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -1,0 +1,50 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-events/eventbus/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNewSourceJetstream(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+	defer logger.Sync()
+
+	url := "test-url"
+	eventSourceName := "test-event-source-name"
+	streamConfig := "test-stream-config"
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+}
+
+func TestSourceJetstream_Initialize(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+	defer logger.Sync()
+
+	url := "test-url"
+	eventSourceName := "test-event-source-name"
+	streamConfig := "test-stream-config"
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
+	sourceJetstream.Initialize()
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+}
+
+func TestSourceJetstream_Connect(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+	defer logger.Sync()
+
+	url := "test-url"
+	eventSourceName := "test-event-source-name"
+	streamConfig := "test-stream-config"
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
+	sourceJetstream.Connect("test-client-id")
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+}

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/argoproj/argo-events/eventbus/common"
+	"github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
@@ -33,5 +34,19 @@ func TestSourceJetstream_Connect(t *testing.T) {
 
 	conn, err := sourceJetstream.Connect("test-client-id")
 	assert.Nil(t, conn)
+	assert.NotNil(t, err)
+}
+
+func TestSourceJetstream_Initialize_Failure(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+
+	auth := &common.Auth{
+		Strategy: v1alpha1.AuthStrategyNone,
+	}
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+
+	err = sourceJetstream.Initialize()
 	assert.NotNil(t, err)
 }

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -22,3 +22,16 @@ func TestNewSourceJetstream(t *testing.T) {
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }
+
+func TestSourceJetstream_Connect(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+
+	conn, err := sourceJetstream.Connect("test-client-id")
+	assert.Nil(t, conn)
+	assert.NotNil(t, err)
+}

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -17,13 +17,7 @@ const (
 
 func TestNewSourceJetstream(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-
-	defer func() {
-		logger.Sync()
-		if r := recover(); r != nil {
-			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
-		}
-	}()
+	defer logger.Sync()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
@@ -33,30 +27,20 @@ func TestNewSourceJetstream(t *testing.T) {
 
 func TestSourceJetstream_Initialize(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-
-	defer func() {
-		logger.Sync()
-		if r := recover(); r != nil {
-			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
-		}
-	}()
+	defer logger.Sync()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
-	sourceJetstream.Initialize()
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
+
+	err = sourceJetstream.Initialize()
+	assert.NoError(t, err, "error should be nil")
 }
 
 func TestSourceJetstream_Connect(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-
-	defer func() {
-		logger.Sync()
-		if r := recover(); r != nil {
-			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
-		}
-	}()
+	defer logger.Sync()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -17,7 +17,13 @@ const (
 
 func TestNewSourceJetstream(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
+
+	defer func() {
+		logger.Sync()
+		if r := recover(); r != nil {
+			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
+		}
+	}()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
@@ -27,7 +33,13 @@ func TestNewSourceJetstream(t *testing.T) {
 
 func TestSourceJetstream_Initialize(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
+
+	defer func() {
+		logger.Sync()
+		if r := recover(); r != nil {
+			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
+		}
+	}()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
@@ -38,11 +50,18 @@ func TestSourceJetstream_Initialize(t *testing.T) {
 
 func TestSourceJetstream_Connect(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
+
+	defer func() {
+		logger.Sync()
+		if r := recover(); r != nil {
+			assert.Equal(t, "runtime error: invalid memory address or nil pointer dereference", r)
+		}
+	}()
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
-	sourceJetstream.Connect(testClientID)
+	sourceJetstream.Connect(testClientID) // error check this
+
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -12,31 +12,13 @@ const (
 	testURL          = "test-url"
 	testEventSource  = "test-event-source-name"
 	testStreamConfig = "test-stream-config"
-	testClientID     = "test-client-id"
 )
 
 func TestNewSourceJetstream(t *testing.T) {
 	logger := zap.NewExample().Sugar()
-	defer logger.Sync()
-
-	if logger == nil {
-		t.Error("logger is nil")
-	}
 
 	auth := &common.Auth{}
 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }
-
-// func TestSourceJetstream_Connect(t *testing.T) {
-// 	logger := zap.NewExample().Sugar()
-// 	defer logger.Sync()
-
-// 	auth := &common.Auth{}
-// 	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
-// 	sourceJetstream.Connect(testClientID) // error check this
-
-// 	assert.NotNil(t, sourceJetstream)
-// 	assert.Nil(t, err)
-// }

--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -8,15 +8,19 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	testURL          = "test-url"
+	testEventSource  = "test-event-source-name"
+	testStreamConfig = "test-stream-config"
+	testClientID     = "test-client-id"
+)
+
 func TestNewSourceJetstream(t *testing.T) {
 	logger := zap.NewExample().Sugar()
 	defer logger.Sync()
 
-	url := "test-url"
-	eventSourceName := "test-event-source-name"
-	streamConfig := "test-stream-config"
 	auth := &common.Auth{}
-	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }
@@ -25,11 +29,8 @@ func TestSourceJetstream_Initialize(t *testing.T) {
 	logger := zap.NewExample().Sugar()
 	defer logger.Sync()
 
-	url := "test-url"
-	eventSourceName := "test-event-source-name"
-	streamConfig := "test-stream-config"
 	auth := &common.Auth{}
-	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
 	sourceJetstream.Initialize()
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
@@ -39,12 +40,9 @@ func TestSourceJetstream_Connect(t *testing.T) {
 	logger := zap.NewExample().Sugar()
 	defer logger.Sync()
 
-	url := "test-url"
-	eventSourceName := "test-event-source-name"
-	streamConfig := "test-stream-config"
 	auth := &common.Auth{}
-	sourceJetstream, err := NewSourceJetstream(url, eventSourceName, streamConfig, auth, logger)
-	sourceJetstream.Connect("test-client-id")
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	sourceJetstream.Connect(testClientID)
 	assert.NotNil(t, sourceJetstream)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Adding tests for `source_jetstream:`

`TestNewSourceJetstream:`

- It checks that a new SourceJetstream instance is created without no errors.
- It ensures that the EventSourceName field of the SourceJetstream instance is set correctly.

`TestSourceJetstream_Connect:` 

- It asserts sourceJetstream is not nil, letting us know that the creation of the SourceJetstream instance was successful.
- It asserts that err is nil, indicating that no error occurred during the creation of the SourceJetstream instance.
- It calls the Connect method on the sourceJetstream instance, passing the "test-client-id" as the clientID argument, and assigns the returned conn and err values.


Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
