### PR TITLE
chore: adding unit tests for source_jetstream

### DIFF
--- a/eventbus/jetstream/eventsource/source_jetstream_test.go
+++ b/eventbus/jetstream/eventsource/source_jetstream_test.go
@@ -1,0 +1,52 @@
+package eventsource
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-events/eventbus/common"
+	"github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+const (
+	testURL          = "test-url"
+	testEventSource  = "test-event-source-name"
+	testStreamConfig = "test-stream-config"
+)
+
+func TestNewSourceJetstream(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+}
+
+func TestSourceJetstream_Connect(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+
+	auth := &common.Auth{}
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+
+	conn, err := sourceJetstream.Connect("test-client-id")
+	assert.Nil(t, conn)
+	assert.NotNil(t, err)
+}
+
+func TestSourceJetstream_Initialize_Failure(t *testing.T) {
+	logger := zap.NewExample().Sugar()
+
+	auth := &common.Auth{
+		Strategy: v1alpha1.AuthStrategyNone,
+	}
+	sourceJetstream, err := NewSourceJetstream(testURL, testEventSource, testStreamConfig, auth, logger)
+	assert.NotNil(t, sourceJetstream)
+	assert.Nil(t, err)
+
+	err = sourceJetstream.Initialize()
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Adding tests for `source_jetstream:`

`TestNewSourceJetstream:`

It checks that a new SourceJetstream instance is created without no errors.
It ensures that the EventSourceName field of the SourceJetstream instance is set correctly.

`TestSourceJetstream_Connect:`

It asserts sourceJetstream is not nil, letting us know that the creation of the SourceJetstream instance was successful.
It asserts that err is nil, indicating that no error occurred during the creation of the SourceJetstream instance.
It calls the Connect method on the sourceJetstream instance, passing the "test-client-id" as the clientID argument, and assigns the returned conn and err values.

`TestSourceJetstream_Initialize_Failure:`

This test case covers the failure scenario where the Initialize method encounters an error, ensuring that the test provides the expected behavior

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
