### PR TITLE
chore: add kafka-ttl sensor example

### DIFF
--- a/examples/sensors/kafka-ttl.yaml
+++ b/examples/sensors/kafka-ttl.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: kafka
+spec:
+  template:
+    serviceAccountName: operate-workflow-sa
+  dependencies:
+    - name: test-dep
+      eventSourceName: kafka
+      eventName: example
+  triggers:
+    - template:
+        name: kafka-workflow-trigger
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: kafka-workflow-with-ttl-
+              spec:
+                ttlStrategy:
+                  secondsAfterCompletion: 10 # Time to live after workflow is completed, replaces ttlSecondsAfterFinished
+                  secondsAfterSuccess: 5     # Time to live after workflow is successful
+                  secondsAfterFailure: 5     # Time to live after workflow fails
+                entrypoint: whalesay
+                arguments:
+                  parameters:
+                  - name: message
+                    # this is the value that should be overridden
+                    value: hello world
+                templates:
+                - name: whalesay
+                  inputs:
+                    parameters:
+                    - name: message
+                  container:
+                    image: docker/whalesay:latest
+                    command: [cowsay]
+                    args: ["{{inputs.parameters.message}}"]
+          parameters:
+            - src:
+                dependencyName: test-dep
+                dataKey: body
+              dest: spec.arguments.parameters.0.value


### PR DESCRIPTION
Why this PR: No example in `sensors` folder with the usage of `ttlStrategy`
Change I made: added `kafka-ttl` yaml file as an example on how to use `ttlStrategy`
