### PR TITLE
chore: adding eventbus/base/kafka tests

### DIFF
--- a/eventbus/kafka/base/kafka_test.go
+++ b/eventbus/kafka/base/kafka_test.go
@@ -1,0 +1,105 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/eventbus/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestBrokers(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL: "broker1:9092,broker2:9092",
+	}
+
+	logger := zap.NewNop().Sugar()
+	kafka := NewKafka(config, logger)
+
+	expectedBrokers := []string{"broker1:9092", "broker2:9092"}
+	actualBrokers := kafka.Brokers()
+
+	assert.Equal(t, expectedBrokers, actualBrokers)
+}
+
+func TestConfig(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL: "localhost:9092",
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	kafka := NewKafka(config, logger)
+
+	saramaConfig, err := kafka.Config()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, saramaConfig)
+	assert.Equal(t, sarama.OffsetNewest, saramaConfig.Consumer.Offsets.Initial)
+	assert.Equal(t, sarama.WaitForAll, saramaConfig.Producer.RequiredAcks)
+}
+
+func TestConfig_StartOldest(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL: "localhost:9092",
+		ConsumerGroup: &eventbusv1alpha1.KafkaConsumerGroup{
+			StartOldest: true,
+		},
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	kafka := NewKafka(config, logger)
+
+	saramaConfig, err := kafka.Config()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, saramaConfig)
+	assert.Equal(t, sarama.OffsetOldest, saramaConfig.Consumer.Offsets.Initial)
+}
+
+func TestConfig_NoSASL(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL:  "localhost:9092",
+		SASL: nil,
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	kafka := NewKafka(config, logger)
+
+	saramaConfig, err := kafka.Config()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, saramaConfig)
+	assert.False(t, saramaConfig.Net.SASL.Enable)
+}
+
+func TestNewKafka(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL: "localhost:9092",
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	kafka := NewKafka(config, logger)
+
+	assert.NotNil(t, kafka)
+	assert.NotNil(t, kafka.Logger)
+	assert.NotNil(t, kafka.config)
+}
+
+func TestNewKafka_EmptyURL(t *testing.T) {
+	config := &eventbusv1alpha1.KafkaBus{
+		URL: "",
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	kafka := NewKafka(config, logger)
+
+	assert.NotNil(t, kafka)
+	assert.NotNil(t, kafka.Logger)
+	assert.NotNil(t, kafka.config)
+}


### PR DESCRIPTION
Adding tests for `eventbus/base/kafka.go:`

`func TestBrokers`

The Brokers method basically splits the comma-separated broker URLs and return them as a slice of strings.

In the test:

A sample `eventbusv1alpha1.KafkaBus` configuration is created with two broker URLs: "broker1:9092" and "broker2:9092".
Then the Brokers method of the created kafka instance is called to get the actual list of broker addresses. This test will ensure that the Brokers method correctly parses the comma-separated broker URLs and returns them as a list of strings.

`func TestConfig`

This test is verifying the behavior of the `Config` func in the context of the Kafka struct. The Config func is responsible for generating a `sarama.Config` instance with specific configuration settings based on the KafkaBus configuration. It's validating that the logic for translating the higher-level configuration to the lower-level Kafka client library's configuration is working.

`func TestConfig_NoSASL`

This test is checking the behavior when SASL configuration is not provided, by setting SASL to nil. 

`func TestNewKafka`

This test validates the `NewKafka` func, which initializes a `kafka` object with a given configuration and logger. It ensures that the `kafka` object and its logger are properly initialized.



* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
