### PR TITLE
Add sleep in sqs eventsource

### DIFF
--- a/eventsources/sources/awssqs/start.go
+++ b/eventsources/sources/awssqs/start.go
@@ -137,6 +137,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 					}
 				}
 			}, log)
+			time.Sleep(50 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
fixes https://github.com/argoproj/argo-events/issues/2450
should also aid https://github.com/argoproj/argo-events/issues/1547 as can workaround eventbus's comparison on nanosecond