### PR TITLE
docs: add CONTRIBUTING.md at root of repo, directing to docs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).


### PR DESCRIPTION
Add a root CONTRIBUTING.md that directs to docs/CONTRIBUTING.md

# Details

- having a `CONTRIBUTING.md` at the root of the repo is a common convention
  - I looked at the root of the repo initially, didn't find it, then checked the website, but potential contributors may think it doesn't exist as a result

Shamelessly copied from https://github.com/argoproj/argo-workflows/pull/10969 (thank you @agilgur5)

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
