### PR TITLE
Fix typo in calendar.yaml

### DIFF
--- a/examples/event-sources/calendar.yaml
+++ b/examples/event-sources/calendar.yaml
@@ -29,7 +29,7 @@ spec:
 #      # metadata contains key-value pairs that will be send to the sensor with each event payload
 #      # whatever you put here is blindly delivered to sensor.
 #      # access in resourceParameters or templateParameters via the path metadata.hello
-#      matadata:
+#      metadata:
 #        hello: world
 #
 #    schedule-in-specific-timezone:


### PR DESCRIPTION
Fix typo `matadata` in calendar.yaml