### PR TITLE
fix: added Errors() read from kafkaSensor's producer

### DIFF
--- a/eventbus/kafka/sensor/kafka_sensor.go
+++ b/eventbus/kafka/sensor/kafka_sensor.go
@@ -132,6 +132,13 @@ func (s *KafkaSensor) Initialize() error {
 		return err
 	}
 
+	// producer is at risk of deadlocking if Errors channel isn't read.
+	go func() {
+		for err := range producer.Errors() {
+			s.Logger.Errorf("Kafka producer error", zap.Error(err))
+		}
+	}()
+
 	s.client = client
 	s.consumer = consumer
 	s.kafkaHandler = &KafkaHandler{


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Fix issue https://github.com/argoproj/argo-events/issues/2958, added procuder.Errors() read and log to stop kafka sensor's producer from deadlocking. 
