### PR TITLE
fix: Reduce Sensor log verbosity for filtered events

### DIFF
--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -196,10 +196,10 @@ func (sensorCtx *SensorContext) listenEvents(ctx context.Context) error {
 				result, err := sensordependencies.Filter(argoEvent, dep.Filters, dep.FiltersLogicalOperator)
 				if err != nil {
 					if !result {
-						triggerLogger.Debugf("Event [%s] discarded due to filtering error: %s",
+						triggerLogger.Warnf("Event [%s] discarded due to filtering error: %s",
 							eventToString(argoEvent), err.Error())
 					} else {
-						triggerLogger.Debugf("Event [%s] passed but with filtering error: %s",
+						triggerLogger.Warnf("Event [%s] passed but with filtering error: %s",
 							eventToString(argoEvent), err.Error())
 					}
 				} else {

--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -196,15 +196,15 @@ func (sensorCtx *SensorContext) listenEvents(ctx context.Context) error {
 				result, err := sensordependencies.Filter(argoEvent, dep.Filters, dep.FiltersLogicalOperator)
 				if err != nil {
 					if !result {
-						triggerLogger.Warnf("Event [%s] discarded due to filtering error: %s",
+						triggerLogger.Debugf("Event [%s] discarded due to filtering error: %s",
 							eventToString(argoEvent), err.Error())
 					} else {
-						triggerLogger.Warnf("Event [%s] passed but with filtering error: %s",
+						triggerLogger.Debugf("Event [%s] passed but with filtering error: %s",
 							eventToString(argoEvent), err.Error())
 					}
 				} else {
 					if !result {
-						triggerLogger.Warnf("Event [%s] discarded due to filtering", eventToString(argoEvent))
+						triggerLogger.Debugf("Event [%s] discarded due to filtering", eventToString(argoEvent))
 					}
 				}
 				return result


### PR DESCRIPTION
Changing log level from `WARN` to `DEBUG` when events do not match a Sensor filter, as suggested by @whynowy in this [issue comment](https://github.com/argoproj/argo-events/issues/2672#issuecomment-1630131794). This represented ~400GB of logs per day in my cluster at scale, and logging the entire payload for discarded events is only useful for occasional debugging purposes.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
