### PR TITLE
Chore: golang 1.21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: "1.21"
       - name: Restore go build cache
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: "1.21"
       - name: Restore go build cache
@@ -95,7 +95,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: "1.21"
       - name: Restore go build cache
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: "1.21"
       - name: Restore go build cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Create k3d registry and cluster
         run: |
           k3d registry create e2e-registry --port 5111
-          k3d cluster create e2e -i rancher/k3s:v1.21.7-k3s1 --registry-use k3d-e2e-registry:5111
+          k3d cluster create e2e -i rancher/k3s:v1.27.10-k3s2 --registry-use k3d-e2e-registry:5111
           echo '127.0.0.1 k3d-e2e-registry' | sudo tee -a /etc/hosts
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,11 +141,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install k3d
-        run: curl -sfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash &
+        run: curl -sfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash &
       - name: Create k3d registry and cluster
         run: |
           k3d registry create e2e-registry --port 5111
-          k3d cluster create e2e -i rancher/k3s:v1.27.10-k3s2 --registry-use k3d-e2e-registry:5111
+          k3d cluster create -i rancher/k3s:v1.27.10-k3s2 --registry-use k3d-e2e-registry:5111
           echo '127.0.0.1 k3d-e2e-registry' | sudo tee -a /etc/hosts
       - name: Run tests
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,6 @@ run:
     - ".*generated.*"
 linters:
   enable:
-    - deadcode
-   # - depguard
     - dogsled
     - goconst
     - gocritic
@@ -23,9 +21,7 @@ linters:
     - nakedret
     - rowserrcheck
     - staticcheck
-   # - structcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ ARG ARCH=$TARGETARCH
 ####################################################################################################
 # base
 ####################################################################################################
-FROM alpine:3.16.2 as base
+FROM alpine:3.19.1 as base
 ARG ARCH
 RUN apk update && apk upgrade && \
     apk add ca-certificates && \
     apk --no-cache add tzdata
 
-ENV ARGO_VERSION=v3.4.8
+ENV ARGO_VERSION=v3.5.5
 
 RUN wget -q https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${ARCH}.gz
 RUN gunzip -f argo-linux-${ARCH}.gz

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ start: image
 	kubectl -n argo-events wait --for=condition=Ready --timeout 60s pod --all
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.54.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.57.2
 
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ override LDFLAGS += -X ${PACKAGE}.gitTag=${GIT_TAG}
 endif
 
 K3D ?= $(shell [ "`command -v kubectl`" != '' ] && [ "`command -v k3d`" != '' ] && [[ "`kubectl config current-context`" =~ k3d-* ]] && echo true || echo false)
+K3DCLUSTER?=k3s-default
 
 # Check that the needed executables are available, else exit before the build
 K := $(foreach exec,$(EXECUTABLES), $(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH")))
@@ -74,7 +75,7 @@ image: clean $(BUILD_DIST)
 	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION)  --target $(BINARY_NAME) -f $(DOCKERFILE) .
 	@if [ "$(DOCKER_PUSH)" = "true" ]; then docker push $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION); fi
 ifeq ($(K3D),true)
-	k3d image import $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION)
+	k3d image import $(IMAGE_NAMESPACE)/$(BINARY_NAME):$(VERSION) --cluster $(K3DCLUSTER)
 endif
 
 image-linux-%: dist/$(BINARY_NAME)-linux-%

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PACKAGE=github.com/argoproj/argo-events
+SHELL := /usr/bin/env bash # Make will use bash instead of sh
 CURRENT_DIR=$(shell pwd)
 DIST_DIR=${CURRENT_DIR}/dist
 

--- a/controllers/eventbus/installer/jetstream_test.go
+++ b/controllers/eventbus/installer/jetstream_test.go
@@ -18,6 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// Workarounds for golangci-lint errors:
+// string `STRING` has N occurrences, make it a constant (goconst)
+const eventBusPrefix = "eventbus-"
+
 var (
 	testJetStreamEventBus = &v1alpha1.EventBus{
 		TypeMeta: metav1.TypeMeta{
@@ -71,17 +75,17 @@ func TestJetStreamBadInstallation(t *testing.T) {
 
 func TestJetStreamGenerateNames(t *testing.T) {
 	n := generateJetStreamStatefulSetName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js", n)
 	n = generateJetStreamServerSecretName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js-server", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js-server", n)
 	n = generateJetStreamClientAuthSecretName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js-client-auth", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js-client-auth", n)
 	n = generateJetStreamConfigMapName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js-config", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js-config", n)
 	n = generateJetStreamPVCName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js-vol", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js-vol", n)
 	n = generateJetStreamServiceName(testJetStreamEventBus)
-	assert.Equal(t, "eventbus-"+testJetStreamEventBus.Name+"-js-svc", n)
+	assert.Equal(t, eventBusPrefix+testJetStreamEventBus.Name+"-js-svc", n)
 }
 
 func TestJetStreamCreateObjects(t *testing.T) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -17,8 +17,12 @@ import (
 	sensorpkg "github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned/typed/sensor/v1alpha1"
 )
 
+// Workarounds for golangci-lint errors:
+// string `STRING` has N occurrences, make it a constant (goconst)
+const fieldSelectorMetadataName = "metadata.name="
+
 func WaitForEventBusReady(ctx context.Context, eventBusClient eventbuspkg.EventBusInterface, eventBusName string, timeout time.Duration) error {
-	fieldSelector := "metadata.name=" + eventBusName
+	fieldSelector := fieldSelectorMetadataName + eventBusName
 	opts := metav1.ListOptions{FieldSelector: fieldSelector}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -62,7 +66,7 @@ func WaitForEventBusStatefulSetReady(ctx context.Context, kubeClient kubernetes.
 }
 
 func WaitForEventSourceReady(ctx context.Context, eventSourceClient eventsourcepkg.EventSourceInterface, eventSourceName string, timeout time.Duration) error {
-	fieldSelector := "metadata.name=" + eventSourceName
+	fieldSelector := fieldSelectorMetadataName + eventSourceName
 	opts := metav1.ListOptions{FieldSelector: fieldSelector}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -89,7 +93,7 @@ func WaitForEventSourceDeploymentReady(ctx context.Context, kubeClient kubernete
 }
 
 func WaitForSensorReady(ctx context.Context, sensorClient sensorpkg.SensorInterface, sensorName string, timeout time.Duration) error {
-	fieldSelector := "metadata.name=" + sensorName
+	fieldSelector := fieldSelectorMetadataName + sensorName
 	opts := metav1.ListOptions{FieldSelector: fieldSelector}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/third_party/prometheus-nats-exporter-docker/amd64/Dockerfile
+++ b/third_party/prometheus-nats-exporter-docker/amd64/Dockerfile
@@ -1,7 +1,7 @@
 # Golang binary building stage
-FROM golang:1.21.6
+FROM golang:1.21
 WORKDIR $GOPATH/src/github.com/nats-io/prometheus-nats-exporter
-RUN git clone --branch v0.10.1 https://github.com/nats-io/prometheus-nats-exporter.git .
+RUN git clone --branch v0.14.0 https://github.com/nats-io/prometheus-nats-exporter.git .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w"
 
 # Final docker image building stage

--- a/third_party/prometheus-nats-exporter-docker/amd64/Dockerfile
+++ b/third_party/prometheus-nats-exporter-docker/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # Golang binary building stage
-FROM golang:1.20.2
+FROM golang:1.21.6
 WORKDIR $GOPATH/src/github.com/nats-io/prometheus-nats-exporter
 RUN git clone --branch v0.10.1 https://github.com/nats-io/prometheus-nats-exporter.git .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w"


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

- Fixes https://github.com/argoproj/argo-events/issues/2742
- Bumps alpine base to 3.19 and ArgoWF client

This has also gone bigger than anticipated:
- bump golangci-lint; drop abandoned linters && add recommendations
- move k3d to 1.27 and fix CI
- update github action setup-go to v5
- ...
<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
