### PR TITLE
Add more EventSource event logs for failed to publish events

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -52,3 +52,4 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 1. [Yubo](https://www.yubo.live/)
 1. [WooliesX](https://wooliesx.com.au/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
+1. [Zillow Group](https://www.zillow.com)

--- a/eventsources/eventing.go
+++ b/eventsources/eventing.go
@@ -579,12 +579,12 @@ func (e *EventSourceAdaptor) run(ctx context.Context, servers map[apicommon.Even
 							},
 							Body: eventBody,
 						}
-
+						logger.Debugw(string(data), zap.String("eventID", event.ID()))
 						if err = common.DoWithRetry(&common.DefaultBackoff, func() error {
 							return e.eventBusConn.Publish(ctx, msg)
 						}); err != nil {
 							logger.Errorw("Failed to publish an event", zap.Error(err), zap.String(logging.LabelEventName,
-								s.GetEventName()), zap.Any(logging.LabelEventSourceType, s.GetEventSourceType()))
+								s.GetEventName()), zap.Any(logging.LabelEventSourceType, s.GetEventSourceType()), zap.String("eventID", event.ID()))
 							e.metrics.EventSentFailed(s.GetEventSourceName(), s.GetEventName())
 							return eventbuscommon.NewEventBusError(err)
 						}


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Adds a debug log in the EventSource which logs the incoming event body with the CloudEvents event ID for better correlation in the EventSource. Also adds the CloudEvents EventID to the `Failed to publish an event` log so we can actually know what event failed to publish to the EventBus. This ID was not available in that log before and when a failure occurred where the event failed to publish to the EventBus we were unable to pinpoint exactly what event failed to publish. This PR is meant to add more transparency to event failures in the EventSource so we have the ability to see what failed, similar to how we can debug the event in the Trigger.
