### PR TITLE
feat: argo_events_action_retries_failed_total metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ debug.test
 site/
 /go-diagrams/
 argo-events
+.swo
+.swp

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -84,6 +84,11 @@ How many actions have been triggered successfully.
 
 How many actions failed.
 
+#### argo_events_action_retries_failed_total
+
+How many actions failed after the retries have been exhausted.  
+This is also incremented if there is no `retryStrategy` specified.
+
 #### argo_events_action_duration_milliseconds
 
 Action triggering duration.
@@ -140,6 +145,7 @@ of monitoring your applications running with Argo Events.
   - `argo_events_events_processing_failed_total`
   - `argo_events_events_sent_failed_total`
   - `argo_events_action_failed_total`
+  - `argo_events_action_retries_failed_total`
 
 - Saturation
 

--- a/sensors/listener.go
+++ b/sensors/listener.go
@@ -220,6 +220,7 @@ func (sensorCtx *SensorContext) listenEvents(ctx context.Context) error {
 				})
 				if err != nil {
 					triggerLogger.Warnf("failed to trigger actions, %v", err)
+					sensorCtx.metrics.ActionRetriesFailed(sensor.Name, trigger.Template.Name)
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Taleb Zeghmi <talebz@zillowgroup.com>

To resolve [Prometheus metric for trigger exhaustion on retries #3185](https://github.com/argoproj/argo-events/issues/3185)

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
