### PR TITLE
Fix tuto exemple 02-parameterization/sensor-05.yaml

### DIFF
--- a/examples/tutorials/02-parameterization/sensor-05.yaml
+++ b/examples/tutorials/02-parameterization/sensor-05.yaml
@@ -41,16 +41,16 @@ spec:
                 dependencyName: THIS_WILL_BE_REPLACED
                 dataKey: THIS_WILL_BE_REPLACED
               dest: THIS_WILL_BE_REPLACED
-      parameters:
-        - src:
-            dependencyName: test-dep
-            dataKey: body.dependencyName
-          dest: k8s.parameters.0.src.dependencyName
-        - src:
-            dependencyName: test-dep
-            dataKey: body.dataKey
-          dest: k8s.parameters.0.src.dataKey
-        - src:
-            dependencyName: test-dep
-            dataKey: body.dest
-          dest: k8s.parameters.0.dest
+        parameters:
+          - src:
+              dependencyName: test-dep
+              dataKey: body.dependencyName
+            dest: argoWorkflow.parameters.0.src.dependencyName
+          - src:
+              dependencyName: test-dep
+              dataKey: body.dataKey
+            dest: argoWorkflow.parameters.0.src.dataKey
+          - src:
+              dependencyName: test-dep
+              dataKey: body.dest
+            dest: argoWorkflow.parameters.0.dest


### PR DESCRIPTION
Hi there!
Here are 2 small fixes for the tuto exemple `02-parameterization/sensor-05.yaml`:
- add one missing indent level for the `triggers.0.template.parameters.*` params
- fix for the 3 scr `dest: argoWorkflow.parameters.*` instead of `dest: k8t.parameters.*` 

---

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
