### PR TITLE
feat(sensor): disable leader election for jetstream eventbus

### DIFF
--- a/docs/sensors/ha.md
+++ b/docs/sensors/ha.md
@@ -12,8 +12,8 @@ behaviors!**
 ## Kubernetes Leader Election
 
 By default, Argo Events will use NATS for the HA leader election except when
-using a Kafka Eventbus, in which case a leader election is not required as a
-Sensor that uses a Kafka EventBus is capable of horizontally scaling. If using
+using a Kafka or JetStream Eventbus, in which case a leader election is not required as a
+Sensor that uses a Kafka/JetStream EventBus is capable of horizontally scaling. If using
 a different EventBus you can opt-in to a Kubernetes native leader election by
 specifying the following annotation.
 ```yaml

--- a/pkg/sensors/listener.go
+++ b/pkg/sensors/listener.go
@@ -58,9 +58,9 @@ func (sensorCtx *SensorContext) Start(ctx context.Context) error {
 	replicas := int(sensorCtx.sensor.Spec.GetReplicas())
 	leasename := fmt.Sprintf("sensor-%s", sensorCtx.sensor.Name)
 
-	// sensor for kafka eventbus can be scaled horizontally,
+	// sensor for kafka/jetstream eventbus can be scaled horizontally,
 	// therefore does not require an elector
-	if sensorCtx.eventBusConfig.Kafka != nil {
+	if sensorCtx.eventBusConfig.Kafka != nil || sensorCtx.eventBusConfig.JetStream != nil {
 		return sensorCtx.listenEvents(ctx)
 	}
 


### PR DESCRIPTION
Permit HA sensor when JetStream eventbus is used for sensors.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).
