### PR TITLE
fix:eventsource crash on cast #3238

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -36,6 +36,7 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 1. [Mobimeo GmbH](https://mobimeo.com/en/home/)
 1. [OneCause](https://www.onecause.com/)
 1. [Pinnacle Reliability](https://pinnaclereliability.com/)
+1. [PDOK](https://pdok.nl)
 1. [Phrase](https://www.phrase.com/)
 1. [Produvar](https://www.produvar.com/)
 1. [ProPoint Solutions](https://supersalon.com)

--- a/eventsources/sources/resource/start.go
+++ b/eventsources/sources/resource/start.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -287,7 +288,15 @@ func passFilters(event *InformerEvent, filter *v1alpha1.ResourceFilter, startTim
 	if filter == nil {
 		return true
 	}
-	uObj := event.Obj.(*unstructured.Unstructured)
+
+	var uObj *unstructured.Unstructured
+	if castEventObject, ok := event.Obj.(*unstructured.Unstructured); ok {
+		uObj = castEventObject
+	} else {
+		log.Infof("event object is not of type '*unstructured.Unstructured' but of type '%s'\n", reflect.TypeOf(event.Obj).Name())
+		return false
+	}
+
 	if len(filter.Prefix) > 0 && !strings.HasPrefix(uObj.GetName(), filter.Prefix) {
 		log.Infof("resource name does not match prefix. resource-name: %s, prefix: %s\n", uObj.GetName(), filter.Prefix)
 		return false


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Fixes #3238

This fix prevents argo-events from crashing when an unexpected, that is not a `*unstructured.Unstructured`, is encountered. The solution is to filter out those objects as they cannot be parsed and will not have information that can be used in the rest of process.

In the old situation argo-events would crash on receiving the unexpected object.
In the new situation argo-events will ignore the unexpected object.

In case that the object is indeed a `*unstructured.Unstructured`, the program will behave as it did before.