### PR TITLE
Add commonly used cluster-scoped resources to standard k8s trigger

### DIFF
--- a/pkg/sensors/triggers/standard-k8s/standard-k8s.go
+++ b/pkg/sensors/triggers/standard-k8s/standard-k8s.go
@@ -40,8 +40,11 @@ import (
 )
 
 var clusterResources = map[string]bool{
-	"namespaces": true,
-	"nodes":      true,
+	"namespaces":          true,
+	"nodes":               true,
+	"persistentvolumes":   true,
+	"clusterroles":        true,
+	"clusterrolebindings": true,
 }
 
 // StandardK8STrigger implements Trigger interface for standard Kubernetes resources


### PR DESCRIPTION
Fixes #3300 by adding some more commonly used cluster-scoped resources for manipulation by the kubernetes object trigger.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
