### PR TITLE
docs: add WorkflowTemplate trigger from a sensor example - Fixes #2234

### DIFF
--- a/docs/concepts/trigger.md
+++ b/docs/concepts/trigger.md
@@ -17,3 +17,7 @@ dependencies are resolved.
 1. Azure Event Hubs Messages
 1. Create any Kubernetes Objects
 1. Log (for debugging event bus messages)
+
+## Examples
+
+Examples are located under [examples/triggers](https://github.com/argoproj/argo-events/tree/master/examples/triggers).

--- a/examples/triggers/workflow-template-trigger.yaml
+++ b/examples/triggers/workflow-template-trigger.yaml
@@ -1,0 +1,50 @@
+# Example of a WorkflowTemplate trigger in a Sensor, triggered by a GitHub webhook event. The WorkflowTemplate is triggered when a push event is received from a GitHub repository. The WorkflowTemplate is passed parameters from the webhook event payload, including the repository URL, branch, user name, and email address.
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: github-push-workflow-sensor # Sensor Name
+  namespace: argo-events # Namespace
+spec:
+  dependencies:
+    - name: github-webhook # Event source dependency for the sensor
+      eventSourceName: github-push-webhook # Event Source Name
+      eventName: github # Name of the webhook event
+  triggers:
+    - template:
+        name: webhook-workflow-trigger # Trigger Name
+        k8s:
+          source:
+            resource: # Specifying the resource to trigger
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: ci-workflow-
+              spec:
+                arguments:
+                  parameters:
+                    - name: repo # Parameters to pass to pass to the WorkflowTemplate
+                    - name: branch
+                    - name: name
+                    - name: email
+                workflowTemplateRef:
+                  name: ci-workflow # Name of the WorkflowTemplate
+          operation: create # Creates the workflow when triggered
+          parameters:
+            - src:
+                dependencyName: github-webhook # Event source dependency
+                dataKey: body.repository.html_url # Selector for request body data (GitHub repo url)
+              dest: spec.arguments.parameters.0.value # Destination for data selection
+            - src:
+                dependencyName: github-webhook
+                dataKey: body.ref # (GitHub branch)
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: github-webhook
+                dataKey: body.pusher.name # (GitHub user name)
+              dest: spec.arguments.parameters.2.value
+            - src:
+                dependencyName: github-webhook
+                dataKey: body.pusher.email # (GitHub user email)
+              dest: spec.arguments.parameters.3.value
+  template:
+    serviceAccountName: operate-workflow-sa # Service account to use - Required to create workflows


### PR DESCRIPTION
## A detailed example of a `WorkflowTemplate` trigger from a sensor using `workflowTemplateRef`.

Fixes https://github.com/argoproj/argo-events/issues/2234

## Motivation

This issue was more than 2 years old and I wanted to contribute to the project. I also work with Argo everyday and I'm CAPA certified (Certified Argo Project Associate).
