### PR TITLE
Upgrade Argo CLI version to v3.6.0 due to CVE-2024-27304

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade && \
     apk add ca-certificates && \
     apk --no-cache add tzdata
 
-ENV ARGO_VERSION=v3.4.8
+ENV ARGO_VERSION=v3.6.0
 
 RUN wget -q https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${ARCH}.gz
 RUN gunzip -f argo-linux-${ARCH}.gz


### PR DESCRIPTION
Just a small update to fix high rated CVE in Argo CLI