### PR TITLE
fix: wrap JS_KEY in quotes in nats-cluster.conf and nats.conf

### DIFF
--- a/pkg/reconciler/eventbus/installer/assets/jetstream/nats-cluster.conf
+++ b/pkg/reconciler/eventbus/installer/assets/jetstream/nats-cluster.conf
@@ -14,7 +14,7 @@ server_name: $POD_NAME
 #                                 #
 ###################################
 jetstream {
-  key: $JS_KEY
+  key: "$JS_KEY"
   store_dir: "/data/jetstream/store"
   {{.Settings}}
 }

--- a/pkg/reconciler/eventbus/installer/assets/jetstream/nats.conf
+++ b/pkg/reconciler/eventbus/installer/assets/jetstream/nats.conf
@@ -14,7 +14,7 @@ server_name: $POD_NAME
 #                                 #
 ###################################
 jetstream {
-  key: $JS_KEY
+  key: "$JS_KEY"
   store_dir: "/data/jetstream/store"
   {{.Settings}}
 }


### PR DESCRIPTION
Fixes an issue where the EventBus fails to start if the JS_KEY environment variable begins with a number, causing the following error on startup:

> nats-server: variable reference for 'JS_KEY' on line 17 could not be parsed: Parse error on line 1: 'Expected a top-level value to end with a new line, comment or EOF, but got '1' instead.'

Fixes #3231 