### PR TITLE
move fuzz tests upstream from cncf-fuzzing

### DIFF
--- a/pkg/eventsources/sources/awssns/fuzz_test.go
+++ b/pkg/eventsources/sources/awssns/fuzz_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awssns
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/argoproj/argo-events/pkg/eventsources/common/webhook"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzAWSSNSsource(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fRoute := webhook.GetFakeRoute()
+		router := &Router{
+			Route:       fRoute,
+			eventSource: &v1alpha1.SNSEventSource{},
+		}
+		router.Route.Active = true
+		writer := &webhook.FakeHttpWriter{}
+		r := &http.Request{
+			Body: io.NopCloser(bytes.NewReader(data)),
+		}
+		r.Header = make(map[string][]string)
+		r.Header.Set("Content-Type", "application/json")
+		router.HandleRoute(writer, r)
+	})
+}

--- a/pkg/eventsources/sources/github/fuzz_test.go
+++ b/pkg/eventsources/sources/github/fuzz_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/argoproj/argo-events/pkg/eventsources/common/webhook"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzGithubEventsource(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fRoute := webhook.GetFakeRoute()
+		router := &Router{
+			route:             fRoute,
+			githubEventSource: &v1alpha1.GithubEventSource{},
+		}
+		router.route.Active = true
+		writer := &webhook.FakeHttpWriter{}
+		r := &http.Request{
+			Body: io.NopCloser(bytes.NewReader(data)),
+		}
+		r.Header = make(map[string][]string)
+		r.Header.Set("Content-Type", "application/json")
+		router.HandleRoute(writer, r)
+	})
+}

--- a/pkg/eventsources/sources/slack/fuzz_test.go
+++ b/pkg/eventsources/sources/slack/fuzz_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slack
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/argoproj/argo-events/pkg/eventsources/common/webhook"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzSlackEventsource(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fRoute := webhook.GetFakeRoute()
+		router := &Router{
+			route:            fRoute,
+			slackEventSource: &v1alpha1.SlackEventSource{},
+		}
+		router.route.Active = true
+		writer := &webhook.FakeHttpWriter{}
+		r := &http.Request{
+			Body: io.NopCloser(bytes.NewReader(data)),
+		}
+		r.Header = make(map[string][]string)
+		r.Header.Set("Content-Type", "application/json")
+		router.HandleRoute(writer, r)
+	})
+}

--- a/pkg/eventsources/sources/stripe/fuzz_test.go
+++ b/pkg/eventsources/sources/stripe/fuzz_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stripe
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/argoproj/argo-events/pkg/eventsources/common/webhook"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzStripeEventsource(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fRoute := webhook.GetFakeRoute()
+		router := &Router{
+			route:             fRoute,
+			stripeEventSource: &v1alpha1.StripeEventSource{},
+		}
+		router.route.Active = true
+		writer := &webhook.FakeHttpWriter{}
+		r := &http.Request{
+			Body: io.NopCloser(bytes.NewReader(data)),
+		}
+		r.Header = make(map[string][]string)
+		r.Header.Set("Content-Type", "application/json")
+		router.HandleRoute(writer, r)
+	})
+}

--- a/pkg/reconciler/eventsource/fuzz_test.go
+++ b/pkg/reconciler/eventsource/fuzz_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventsource
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+	"github.com/argoproj/argo-events/pkg/shared/logging"
+)
+
+var initter sync.Once
+
+func initScheme() {
+	_ = v1alpha1.AddToScheme(scheme.Scheme)
+	_ = appv1.AddToScheme(scheme.Scheme)
+	_ = corev1.AddToScheme(scheme.Scheme)
+}
+
+func FuzzEventsourceReconciler(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(initScheme)
+		f := fuzz.NewConsumer(data)
+		testEventSource := &v1alpha1.EventSource{}
+		err := f.GenerateStruct(testEventSource)
+		if err != nil {
+			return
+		}
+		cl := fake.NewClientBuilder().Build()
+		testStreamingImage := "test-steaming-image"
+		r := &reconciler{
+			client:           cl,
+			scheme:           scheme.Scheme,
+			eventSourceImage: testStreamingImage,
+			logger:           logging.NewArgoEventsLogger(),
+		}
+		ctx := context.Background()
+		_ = r.reconcile(ctx, testEventSource)
+	})
+}
+
+func FuzzResourceReconcile(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		testImage := "test-image"
+		initter.Do(initScheme)
+		f := fuzz.NewConsumer(data)
+		testEventSource := &v1alpha1.EventSource{}
+		err := f.GenerateStruct(testEventSource)
+		if err != nil {
+			return
+		}
+		testLabels := make(map[string]string)
+		err = f.FuzzMap(&testLabels)
+		if err != nil {
+			return
+		}
+		testBus := &v1alpha1.EventBus{}
+		err = f.GenerateStruct(testBus)
+		if err != nil {
+			return
+		}
+		cl := fake.NewClientBuilder().Build()
+		err = cl.Create(context.Background(), testBus)
+		if err != nil {
+			return
+		}
+		args := &AdaptorArgs{
+			Image:       testImage,
+			EventSource: testEventSource,
+			Labels:      testLabels,
+		}
+		_ = Reconcile(cl, args, logging.NewArgoEventsLogger())
+	})
+}

--- a/pkg/reconciler/sensor/fuzz_test.go
+++ b/pkg/reconciler/sensor/fuzz_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sensor
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	eventbusv1alpha1 "github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+	"github.com/argoproj/argo-events/pkg/shared/logging"
+)
+
+var initter sync.Once
+
+func initFunc() {
+	_ = eventbusv1alpha1.AddToScheme(scheme.Scheme)
+	_ = appv1.AddToScheme(scheme.Scheme)
+	_ = corev1.AddToScheme(scheme.Scheme)
+}
+
+func FuzzSensorControllerreconcile(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(initFunc)
+		testImage := "test-image"
+		f := fuzz.NewConsumer(data)
+		sensorObj := &eventbusv1alpha1.Sensor{}
+		err := f.GenerateStruct(sensorObj)
+		if err != nil {
+			return
+		}
+		ctx := context.Background()
+		cl := fake.NewClientBuilder().Build()
+		r := &reconciler{
+			client:      cl,
+			scheme:      scheme.Scheme,
+			sensorImage: testImage,
+			logger:      logging.NewArgoEventsLogger(),
+		}
+		_ = r.reconcile(ctx, sensorObj)
+	})
+}
+
+func FuzzSensorControllerReconcile(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(initFunc)
+		testImage := "test-image"
+		f := fuzz.NewConsumer(data)
+		testBus := &eventbusv1alpha1.EventBus{}
+		err := f.GenerateStruct(testBus)
+		if err != nil {
+			return
+		}
+		sensorObj := &eventbusv1alpha1.Sensor{}
+		err = f.GenerateStruct(sensorObj)
+		if err != nil {
+			return
+		}
+		testLabels := make(map[string]string)
+		err = f.FuzzMap(&testLabels)
+		if err != nil {
+			return
+		}
+		ctx := context.Background()
+		cl := fake.NewClientBuilder().Build()
+		err = cl.Create(ctx, testBus)
+		if err != nil {
+			return
+		}
+		args := &AdaptorArgs{
+			Image:  testImage,
+			Sensor: sensorObj,
+			Labels: testLabels,
+		}
+		_ = Reconcile(cl, nil, args, logging.NewArgoEventsLogger())
+	})
+}

--- a/pkg/sensors/triggers/fuzz_test.go
+++ b/pkg/sensors/triggers/fuzz_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package triggers
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzConstructPayload(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		f := fuzz.NewConsumer(data)
+		events := make(map[string]*v1alpha1.Event)
+		err := f.FuzzMap(&events)
+		if err != nil {
+			return
+		}
+		parameters := make([]v1alpha1.TriggerParameter, 0)
+		err = f.FuzzMap(&parameters)
+		if err != nil {
+			return
+		}
+		_, _ = ConstructPayload(events, parameters)
+	})
+}


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

This moves over several of argo-events fuzz tests from [cncf-fuzzing](https://github.com/cncf/cncf-fuzzing/tree/main/projects/argo). These fuzz tests have been running for several years continuously on OSS-Fuzz, but due to recent refactoring in argo-events they broke. I have fixed the fuzz tests and rewritten them to native golang fuzzers (that use std libs fuzzing engine). Having them upstream will make maintenance much easier.