### PR TITLE
Move fuzzers upstream from cncf-fuzzing

### DIFF
--- a/pkg/reconciler/sensor/fuzz_test.go
+++ b/pkg/reconciler/sensor/fuzz_test.go
@@ -95,3 +95,20 @@ func FuzzSensorControllerReconcile(f *testing.F) {
 		_ = Reconcile(cl, nil, args, logging.NewArgoEventsLogger())
 	})
 }
+
+func FuzzValidateSensor(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		eventBus := &eventbusv1alpha1.EventBus{}
+		err := fdp.GenerateStruct(eventBus)
+		if err != nil {
+			return
+		}
+		sensor := &eventbusv1alpha1.Sensor{}
+		err = fdp.GenerateStruct(sensor)
+		if err != nil {
+			return
+		}
+		_ = ValidateSensor(sensor, eventBus)
+	})
+}

--- a/pkg/sensors/fuzz_test.go
+++ b/pkg/sensors/fuzz_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Argoproj Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sensors
+
+import (
+	"context"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+)
+
+func FuzzGetDependencyExpression(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		templ := &v1alpha1.TriggerTemplate{}
+		err := fdp.GenerateStruct(templ)
+		if err != nil {
+			return
+		}
+		sensorObj := &v1alpha1.Sensor{}
+		err = fdp.GenerateStruct(sensorObj)
+		if err != nil {
+			return
+		}
+		ft := &v1alpha1.Trigger{}
+		err = fdp.GenerateStruct(ft)
+		if err != nil {
+			return
+		}
+		ft.Template = templ
+		sensorObj.Spec.Triggers = []v1alpha1.Trigger{*ft}
+		sensorCtx := &SensorContext{
+			sensor: sensorObj,
+		}
+		_, _ = sensorCtx.getDependencyExpression(context.Background(), *ft)
+	})
+}

--- a/pkg/sensors/triggers/argo-workflow/fuzz_test.go
+++ b/pkg/sensors/triggers/argo-workflow/fuzz_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Argoproj Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package argo_workflow
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func bytesToUnstructuredFuzz(jsonBytes []byte) (*unstructured.Unstructured, error) {
+	obj := make(map[string]interface{})
+	err := yaml.Unmarshal(jsonBytes, &obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+func FuzzArgoWorkflowTriggerExecute(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ctx := context.Background()
+		var actual string
+		firstArg := "--foo"
+		secondArg := "--bar"
+		unstr, err := bytesToUnstructuredFuzz(data)
+		if err != nil {
+			return
+		}
+		trigger := storingCmdTrigger(&actual, firstArg, secondArg)
+		_, err = namespacedClientFrom(trigger).Namespace(unstr.GetNamespace()).Create(ctx, unstr, metav1.CreateOptions{})
+		if err != nil {
+			return
+		}
+		_, _ = trigger.Execute(ctx, nil, unstr)
+	})
+}

--- a/pkg/shared/expr/fuzz_test.go
+++ b/pkg/shared/expr/fuzz_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Argoproj Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expr
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzExpr(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, input string) {
+		env := make(map[string]interface{})
+		err := json.Unmarshal(data, &env)
+		if err != nil {
+			return
+		}
+		_, _ = EvalBool(input, env)
+	})
+}


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

Moves more fuzzers in similar fashion as https://github.com/argoproj/argo-events/pull/3414