### PR TITLE
fix: compare errors with string to avoid log spew in jetstream sensor

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -58,3 +58,4 @@ Organizations below are **officially** using Argo Events. Please send a PR with 
 1. [WooliesX](https://wooliesx.com.au/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
 1. [Zillow Group](https://www.zillow.com)
+1. [AlpacaTech](https://www.alpaca-tech.ai)

--- a/pkg/eventbus/jetstream/sensor/trigger_conn.go
+++ b/pkg/eventbus/jetstream/sensor/trigger_conn.go
@@ -197,7 +197,7 @@ func (conn *JetstreamTriggerConn) pullSubscribe(
 		// call Fetch with timeout
 		msgs, fetchErr := subscription.Fetch(1, nats.MaxWait(time.Second*1))
 		if fetchErr != nil && !errors.Is(fetchErr, nats.ErrTimeout) {
-			if previousErr != fetchErr || time.Since(previousErrTime) > 10*time.Second {
+			if (previousErr != nil && previousErr.Error() != fetchErr.Error()) || time.Since(previousErrTime) > 10*time.Second {
 				// avoid log spew - only log error every 10 seconds
 				conn.Logger.Errorf("failed to fetch messages for subscription %+v, %v, previousErr=%v, previousErrTime=%v", subscription, fetchErr, previousErr, previousErrTime)
 			}


### PR DESCRIPTION
This PR fixes an issue in the error comparison to avoid log spew. Instead of comparing the errors directly, compare the string versions.


Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

