### PR TITLE
Fix: catastrophic data loss on NATS connectivity issues

### DIFF
--- a/pkg/eventsources/common/webhook/types.go
+++ b/pkg/eventsources/common/webhook/types.go
@@ -44,6 +44,16 @@ type Router interface {
 	PostInactivate() error
 }
 
+// Dispatch is sent by RouteHandler function through
+// the Route's DispatchChan and is used to coordinate writing to the
+// event bus
+type Dispatch struct {
+	// Data contains the webhook data to dispatch to the event bus
+	Data []byte
+	// SuccessChan contains true iff the dispatch of the Data was successful
+	SuccessChan chan bool
+}
+
 // Route contains general information about a route
 type Route struct {
 	// WebhookContext refers to the webhook context
@@ -60,7 +70,7 @@ type Route struct {
 	// or it is an inactive route
 	Active bool
 	// data channel to receive data on this endpoint
-	DataCh chan []byte
+	DispatchChan chan *Dispatch
 	// Stop channel to signal the end of the event source.
 	StopChan chan struct{}
 

--- a/pkg/eventsources/sources/awssns/start.go
+++ b/pkg/eventsources/sources/awssns/start.go
@@ -168,7 +168,6 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		router.subscriptionArn = response.SubscriptionArn
 
 	case messageTypeNotification:
-		logger.Info("dispatching notification on route's data channel")
 
 		eventData := &events.SNSEventData{
 			Header:   request.Header,
@@ -183,7 +182,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			route.Metrics.EventProcessingFailed(route.EventSourceName, route.EventName)
 			return
 		}
-		route.DataCh <- eventBytes
+		webhook.DispatchEvent(route, eventBytes, logger, writer)
 	}
 
 	logger.Info("request has been successfully processed")

--- a/pkg/eventsources/sources/bitbucket/start.go
+++ b/pkg/eventsources/sources/bitbucket/start.go
@@ -98,11 +98,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel")
-	route.DataCh <- eventBody
-
-	logger.Info("request successfully processed")
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, eventBody, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/bitbucketserver/start.go
+++ b/pkg/eventsources/sources/bitbucketserver/start.go
@@ -161,8 +161,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			return
 		}
 
-		logger.Info("dispatching event on route's data channel")
-		route.DataCh <- eventBody
+		webhook.DispatchEvent(route, eventBody, logger, writer)
 	}
 
 	logger.Info("request successfully processed")

--- a/pkg/eventsources/sources/gerrit/start.go
+++ b/pkg/eventsources/sources/gerrit/start.go
@@ -102,11 +102,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel")
-	route.DataCh <- eventBody
-
-	logger.Info("request successfully processed")
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, eventBody, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/github/start.go
+++ b/pkg/eventsources/sources/github/start.go
@@ -163,11 +163,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel")
-	route.DataCh <- eventBody
-	logger.Info("request successfully processed")
-
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, eventBody, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/github/start_test.go
+++ b/pkg/eventsources/sources/github/start_test.go
@@ -41,7 +41,7 @@ var (
 func TestRouteActiveHandler(t *testing.T) {
 	convey.Convey("Given a route configuration", t, func() {
 		route := router.route
-		route.DataCh = make(chan []byte)
+		route.DispatchChan = make(chan *webhook.Dispatch)
 
 		convey.Convey("Inactive route should return error", func() {
 			writer := &webhook.FakeHttpWriter{}
@@ -94,7 +94,7 @@ func TestRouteActiveHandler(t *testing.T) {
 func TestRouteActiveHandlerDeprecated(t *testing.T) {
 	convey.Convey("Given a route configuration", t, func() {
 		route := router.route
-		route.DataCh = make(chan []byte)
+		route.DispatchChan = make(chan *webhook.Dispatch)
 
 		convey.Convey("Inactive route should return error", func() {
 			writer := &webhook.FakeHttpWriter{}

--- a/pkg/eventsources/sources/gitlab/start.go
+++ b/pkg/eventsources/sources/gitlab/start.go
@@ -109,11 +109,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel")
-	route.DataCh <- eventBody
-
-	logger.Info("request successfully processed")
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, eventBody, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/slack/start.go
+++ b/pkg/eventsources/sources/slack/start.go
@@ -186,12 +186,11 @@ func (rc *Router) HandleRoute(writer http.ResponseWriter, request *http.Request)
 	}
 
 	if data != nil {
-		logger.Info("dispatching event on route's data channel...")
-		route.DataCh <- data
+		webhook.DispatchEvent(route, data, logger, writer)
+	} else {
+		logger.Debug("request successfully processed")
+		sharedutil.SendSuccessResponse(writer, "success")
 	}
-
-	logger.Debug("request successfully processed")
-	sharedutil.SendSuccessResponse(writer, "success")
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/storagegrid/start.go
+++ b/pkg/eventsources/sources/storagegrid/start.go
@@ -188,7 +188,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			route.Metrics.EventProcessingDuration(route.EventSourceName, route.EventName, float64(time.Since(start)/time.Millisecond))
 		}(time.Now())
 
-		logger.Info("new event received, dispatching event on route's data channel")
+		logger.Info("new event received")
 		eventData := &events.StorageGridEventData{
 			Notification: notification,
 			Metadata:     router.storageGridEventSource.Metadata,
@@ -199,7 +199,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 			route.Metrics.EventProcessingFailed(route.EventSourceName, route.EventName)
 			return
 		}
-		route.DataCh <- eventBody
+		webhook.DispatchEvent(route, eventBody, logger, writer)
 		return
 	}
 

--- a/pkg/eventsources/sources/storagegrid/start_test.go
+++ b/pkg/eventsources/sources/storagegrid/start_test.go
@@ -110,9 +110,9 @@ func TestRouteActiveHandler(t *testing.T) {
 		convey.Convey("Active route should return success", func() {
 			router.route.Active = true
 			router.storageGridEventSource = storageGridEventSource
-			dataCh := make(chan []byte)
+			dataCh := make(chan *webhook.Dispatch)
 			go func() {
-				resp := <-router.route.DataCh
+				resp := <-router.route.DispatchChan
 				dataCh <- resp
 			}()
 

--- a/pkg/eventsources/sources/stripe/start.go
+++ b/pkg/eventsources/sources/stripe/start.go
@@ -132,10 +132,7 @@ func (rc *Router) HandleRoute(writer http.ResponseWriter, request *http.Request)
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel...")
-	route.DataCh <- data
-	logger.Info("request successfully processed")
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, data, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/webhook/start.go
+++ b/pkg/eventsources/sources/webhook/start.go
@@ -133,10 +133,7 @@ func (router *Router) HandleRoute(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	logger.Info("dispatching event on route's data channel...")
-	route.DataCh <- data
-	logger.Info("successfully processed the request")
-	sharedutil.SendSuccessResponse(writer, "success")
+	webhook.DispatchEvent(route, data, logger, writer)
 }
 
 // PostActivate performs operations once the route is activated and ready to consume requests

--- a/pkg/eventsources/sources/webhook/start_test.go
+++ b/pkg/eventsources/sources/webhook/start_test.go
@@ -22,12 +22,14 @@ func TestHandleRoute(t *testing.T) {
 
 		convey.Convey("Test Get method with query parameters", func() {
 			url, _ := url.Parse("http://example.com/fake?aaa=b%20b&ccc=d%20d")
-			out := make(chan []byte)
+			out := make(chan *webhook.Dispatch)
 			router.route.Active = true
 			router.route.Context.Method = http.MethodGet
 
 			go func() {
-				out <- <-router.route.DataCh
+				temp := <-router.route.DispatchChan
+				temp.SuccessChan <- true
+				out <- temp
 			}()
 
 			router.HandleRoute(writer, &http.Request{
@@ -36,16 +38,18 @@ func TestHandleRoute(t *testing.T) {
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
-			convey.So(string(result), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
+			convey.So(string(result.Data), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
 		})
 		convey.Convey("Test Get method without query parameter", func() {
 			url, _ := url.Parse("http://example.com/fake")
-			out := make(chan []byte)
+			out := make(chan *webhook.Dispatch)
 			router.route.Active = true
 			router.route.Context.Method = http.MethodGet
 
 			go func() {
-				out <- <-router.route.DataCh
+				temp := <-router.route.DispatchChan
+				temp.SuccessChan <- true
+				out <- temp
 			}()
 
 			router.HandleRoute(writer, &http.Request{
@@ -54,17 +58,19 @@ func TestHandleRoute(t *testing.T) {
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
-			convey.So(string(result), convey.ShouldContainSubstring, `"body":{}`)
+			convey.So(string(result.Data), convey.ShouldContainSubstring, `"body":{}`)
 		})
 		convey.Convey("Test POST method with form-urlencoded", func() {
 			payload := []byte(`aaa=b%20b&ccc=d%20d`)
 
-			out := make(chan []byte)
+			out := make(chan webhook.Dispatch)
 			router.route.Active = true
 			router.route.Context.Method = http.MethodPost
 
 			go func() {
-				out <- <-router.route.DataCh
+				temp := <-router.route.DispatchChan
+				temp.SuccessChan <- true
+				out <- *temp
 			}()
 
 			var buf bytes.Buffer
@@ -80,17 +86,19 @@ func TestHandleRoute(t *testing.T) {
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
-			convey.So(string(result), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
+			convey.So(string(result.Data), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
 		})
 		convey.Convey("Test POST method with json", func() {
 			payload := []byte(`{"aaa":["b b"],"ccc":["d d"]}`)
 
-			out := make(chan []byte)
+			out := make(chan webhook.Dispatch)
 			router.route.Active = true
 			router.route.Context.Method = http.MethodPost
 
 			go func() {
-				out <- <-router.route.DataCh
+				temp := <-router.route.DispatchChan
+				temp.SuccessChan <- true
+				out <- *temp
 			}()
 
 			var buf bytes.Buffer
@@ -106,7 +114,7 @@ func TestHandleRoute(t *testing.T) {
 			})
 			result := <-out
 			convey.So(writer.HeaderStatus, convey.ShouldEqual, http.StatusOK)
-			convey.So(string(result), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
+			convey.So(string(result.Data), convey.ShouldContainSubstring, `"body":{"aaa":["b b"],"ccc":["d d"]}`)
 		})
 	})
 }


### PR DESCRIPTION
# Problem

Closes #3448 

We discovered an issue where the current argo-events webhook implementation will drop data when experiencing connectivity issues with NATS while still returning HTTP 200 status codes to the client. This breaks common webhook specifications including CloudEvent's and will result in catastrophic data loss for those who are using argo-events as a part of their core infrastructure.

This impacts all of the following EventSources:

- awssns
- bitbucket
- bitbucketserver
- github
- gitlab
- slack
- gerrit
- slack
- storagegrid
- stripe
- webhook

# Changes

This PR introduces a few changes to address the immediate problem. The goal was to keep the changes as small as possible while also ensuring the problem is thoroughly addressed for all of the impacted EventSources.

1. Instead of using a unidirectional channel for sending event payloads to the dispatch function, the `DataCh` is now a `DispatchChan` which takes `Dispatch` structs. The `Dispatch` struct is a wrapper around the original `[]byte` data that also includes a bundled `SuccessChan` so that the dispatch caller can indicate to `Dispatch` sender whether the dispatch was successful or not.
2. A new `DispatchEvent` function has been introduced that is called at the end of the `HandleRoute` methods of the above EventSource types. The logic was already essentially the same for all of them, so it made sense to abstract that out to ensure this critical code path remains correct for all EventSource types.
3. `DispatchEvent` now waits until the caller of `dispatch` (in `manageRouteChannels`) sends either `true` or `false` on `Dispatch.SuccessChan`. If `false` is sent, `SendInternalErrorResponse` is called which sends a 500 HTTP status code to the webhook client to correctly indicate that the saving of the webhook event data failed.
4. I have updated the unit tests and some of the log messages to reflect the new names and data structures.

# Testing

I have deployed this in a live Kubernetes system and verified that if the EventSources are cut off from NATS (e.g., NATS is spun down, network partition, etc.) a `500` response code is returned (instead of the original `200`).

I have also performed some basic load testing to ensure that this did not hinder the overall system performance (though I would argue correctness around data integrity is significantly more important).

When running the new argo-event build on a very small instance (50m cpu, 50Mi memory), I was able to achieve 400 reqs / sec with a very slow client parallelism number (5). This was similar enough to my load testing prior to these changes that I do not believe this impacted overall system performance for the majority of use cases.
