### PR TITLE
docs(sensor): move parameters to template level

### DIFF
--- a/examples/tutorials/02-parameterization/sensor-05.yaml
+++ b/examples/tutorials/02-parameterization/sensor-05.yaml
@@ -41,16 +41,17 @@ spec:
                 dependencyName: THIS_WILL_BE_REPLACED
                 dataKey: THIS_WILL_BE_REPLACED
               dest: THIS_WILL_BE_REPLACED
-        parameters:
-          - src:
-              dependencyName: test-dep
-              dataKey: body.dependencyName
-            dest: argoWorkflow.parameters.0.src.dependencyName
-          - src:
-              dependencyName: test-dep
-              dataKey: body.dataKey
-            dest: argoWorkflow.parameters.0.src.dataKey
-          - src:
-              dependencyName: test-dep
-              dataKey: body.dest
-            dest: argoWorkflow.parameters.0.dest
+      # Apply parameters at the template level.              
+      parameters:
+        - src:
+            dependencyName: test-dep
+            dataKey: body.dependencyName
+          dest: argoWorkflow.parameters.0.src.dependencyName
+        - src:
+            dependencyName: test-dep
+            dataKey: body.dataKey
+          dest: argoWorkflow.parameters.0.src.dataKey
+        - src:
+            dependencyName: test-dep
+            dataKey: body.dest
+          dest: argoWorkflow.parameters.0.dest


### PR DESCRIPTION
Fix the trigger parameterization example from https://argoproj.github.io/argo-events/tutorials/02-parameterization/, as mentioned in #3432 and #3161.

The outer `parameters` section should be at template level, as defined in the Trigger spec (https://argoproj.github.io/argo-events/APIs/#argoproj.io/v1alpha1.Trigger). 

The other trigger parameterization example is configured correctly (https://github.com/argoproj/argo-events/blob/master/examples/sensors/complete-trigger-parameterization.yaml).

