### PR TITLE
fix: crash eventsource resource

### DIFF
--- a/pkg/eventsources/sources/resource/start.go
+++ b/pkg/eventsources/sources/resource/start.go
@@ -365,6 +365,9 @@ func getEventTime(obj *unstructured.Unstructured, eventType v1alpha1.ResourceEve
 	case v1alpha1.UPDATE:
 		t := obj.GetCreationTimestamp()
 		for _, f := range obj.GetManagedFields() {
+			if f.Time == nil {
+				continue
+			}
 			if f.Operation == metav1.ManagedFieldsOperationUpdate && f.Time.UTC().After(t.UTC()) {
 				t = *f.Time
 			}


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

Related with: https://github.com/argoproj/argo-events/issues/3494

This PR avoids nil pointer dereference when the event has no `Time` field.

Tested in kubernetes v1.30.10

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
