### PR TITLE
chore: use human readable time format in the log

### DIFF
--- a/pkg/shared/logging/logger.go
+++ b/pkg/shared/logging/logger.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	zap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	klog "k8s.io/klog/v2"
 )
 
@@ -33,6 +34,7 @@ func NewArgoEventsLogger() *zap.SugaredLogger {
 	logLevel, _ := os.LookupEnv("LOG_LEVEL")
 	config := ConfigureLogLevelLogger(logLevel)
 	// Config customization goes here if any
+	config.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 	config.OutputPaths = []string{"stdout"}
 	logger, err := config.Build()
 	if err != nil {


### PR DESCRIPTION
Closes: #3499


```
{"level":"info","ts":"2025-03-02T00:23:01.00458634Z","logger":"argo-events.sensor" xxxx
```

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
