### PR TITLE
fix: allow gitlab eventsource to work without projects or groups

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -2087,7 +2087,7 @@
           "type": "string"
         },
         "projects": {
-          "description": "List of project IDs or project namespace paths like \"whynowy/test\". Projects and groups cannot be empty at the same time.",
+          "description": "List of project IDs or project namespace paths like \"whynowy/test\". If neither a project nor a group is defined, the EventSource will not manage webhooks.",
           "items": {
             "type": "string"
           },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2078,7 +2078,7 @@
           "type": "string"
         },
         "projects": {
-          "description": "List of project IDs or project namespace paths like \"whynowy/test\". Projects and groups cannot be empty at the same time.",
+          "description": "List of project IDs or project namespace paths like \"whynowy/test\". If neither a project nor a group is defined, the EventSource will not manage webhooks.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -10099,8 +10099,9 @@ event payload.
 <em>(Optional)</em>
 <p>
 
-List of project IDs or project namespace paths like “whynowy/test”.
-Projects and groups cannot be empty at the same time.
+List of project IDs or project namespace paths like “whynowy/test”. If
+neither a project nor a group is defined, the EventSource will not
+manage webhooks.
 </p>
 
 </td>

--- a/pkg/apis/events/v1alpha1/eventsource_types.go
+++ b/pkg/apis/events/v1alpha1/eventsource_types.go
@@ -859,6 +859,7 @@ type GitlabEventSource struct {
 	// +optional
 	Metadata map[string]string `json:"metadata,omitempty" protobuf:"bytes,9,rep,name=metadata"`
 	// List of project IDs or project namespace paths like "whynowy/test".
+	// If neither a project nor a group is defined, the EventSource will not manage webhooks.
 	// +optional
 	Projects []string `json:"projects,omitempty" protobuf:"bytes,10,rep,name=projects"`
 	// SecretToken references to k8 secret which holds the Secret Token used by webhook config

--- a/pkg/apis/events/v1alpha1/eventsource_types.go
+++ b/pkg/apis/events/v1alpha1/eventsource_types.go
@@ -858,7 +858,7 @@ type GitlabEventSource struct {
 	// Metadata holds the user defined metadata which will passed along the event payload.
 	// +optional
 	Metadata map[string]string `json:"metadata,omitempty" protobuf:"bytes,9,rep,name=metadata"`
-	// List of project IDs or project namespace paths like "whynowy/test". Projects and groups cannot be empty at the same time.
+	// List of project IDs or project namespace paths like "whynowy/test".
 	// +optional
 	Projects []string `json:"projects,omitempty" protobuf:"bytes,10,rep,name=projects"`
 	// SecretToken references to k8 secret which holds the Secret Token used by webhook config

--- a/pkg/apis/events/v1alpha1/generated.proto
+++ b/pkg/apis/events/v1alpha1/generated.proto
@@ -1430,7 +1430,8 @@ message GitlabEventSource {
   // +optional
   map<string, string> metadata = 9;
 
-  // List of project IDs or project namespace paths like "whynowy/test". Projects and groups cannot be empty at the same time.
+  // List of project IDs or project namespace paths like "whynowy/test".
+  // If neither a project nor a group is defined, the EventSource will not manage webhooks.
   // +optional
   repeated string projects = 10;
 

--- a/pkg/apis/events/v1alpha1/openapi_generated.go
+++ b/pkg/apis/events/v1alpha1/openapi_generated.go
@@ -3982,7 +3982,7 @@ func schema_pkg_apis_events_v1alpha1_GitlabEventSource(ref common.ReferenceCallb
 					},
 					"projects": {
 						SchemaProps: spec.SchemaProps{
-							Description: "List of project IDs or project namespace paths like \"whynowy/test\". Projects and groups cannot be empty at the same time.",
+							Description: "List of project IDs or project namespace paths like \"whynowy/test\". If neither a project nor a group is defined, the EventSource will not manage webhooks.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/eventsources/sources/gitlab/validate.go
+++ b/pkg/eventsources/sources/gitlab/validate.go
@@ -30,9 +30,6 @@ func validate(eventSource *v1alpha1.GitlabEventSource) error {
 	if eventSource == nil {
 		return v1alpha1.ErrNilEventSource
 	}
-	if len(eventSource.GetProjects()) == 0 && len(eventSource.GetGroups()) == 0 {
-		return fmt.Errorf("projects and groups cannot be empty at the same time")
-	}
 	if eventSource.Events == nil {
 		return fmt.Errorf("events can't be empty")
 	}

--- a/pkg/eventsources/sources/gitlab/validate_test.go
+++ b/pkg/eventsources/sources/gitlab/validate_test.go
@@ -34,7 +34,6 @@ func TestValidateEventSource(t *testing.T) {
 
 	err := listener.ValidateEventSource(context.Background())
 	assert.Error(t, err)
-	assert.Equal(t, "projects and groups cannot be empty at the same time", err.Error())
 
 	content, err := os.ReadFile(fmt.Sprintf("%s/%s", sources.EventSourceDir, "gitlab.yaml"))
 	assert.Nil(t, err)


### PR DESCRIPTION
## Summary
This PR modifies the Gitab EventSource validation logic to allow configurations without `projects` or `groups`. This change ensures that users can manage webhooks externally while still using Argo Events.

## Changes
- Removed the mandatory validation check for `projects` and `groups` in `validate.go`.
- Updated the test cases in `validate_test.go` to reflect the new behavior.

## Testing
- Ran `go test -v ./pkg/eventsources/sources/gitlab/ -run TestValidateEventSource` successfully.
- Verified that Argo EventSource no longer requires projects/groups.

@ryancurrah 