### PR TITLE
fix typo in examples/sensors/azure-events-hub.yaml

### DIFF
--- a/examples/sensors/azure-events-hub.yaml
+++ b/examples/sensors/azure-events-hub.yaml
@@ -39,5 +39,5 @@ spec:
           parameters:
             - src:
                 dependencyName: test-dep
-                dataKey: body.messsage
+                dataKey: body.message
               dest: spec.arguments.parameters.0.value


### PR DESCRIPTION
This has taken me 30 minutes to realize and might save some time for others

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
