### PR TITLE
bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,41 @@
-run:
-  timeout: 5m
-issues:
-  exclude-dirs:
-    - pkg/client
-    - vendor
-    - "eventsources/common/naivewatcher"
-  exclude-files:
-    - ".*generated.*"
+version: "2"
 linters:
   enable:
-   # - depguard
     - dogsled
     - goconst
     - gocritic
-    - gofmt
-    - goimports
     - goprintffuncname
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
     - nakedret
     - rowserrcheck
-    - staticcheck
-    - typecheck
     - unconvert
-    - unused
     - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - .*generated.*
+      - pkg/client
+      - vendor
+      - eventsources/common/naivewatcher
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .*generated.*
+      - pkg/client
+      - vendor
+      - eventsources/common/naivewatcher
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/apis/events/v1alpha1/eventbus_types_test.go
+++ b/pkg/apis/events/v1alpha1/eventbus_types_test.go
@@ -156,7 +156,7 @@ func TestEventBusStatusGetCondition(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.s.Status.GetCondition(test.qCondition)
+			got := test.s.GetCondition(test.qCondition)
 			ignoreFields := cmpopts.IgnoreFields(Condition{},
 				"LastTransitionTime")
 			if diff := cmp.Diff(test.expect, got, ignoreFields); diff != "" {

--- a/pkg/eventsources/sources/file/start.go
+++ b/pkg/eventsources/sources/file/start.go
@@ -241,7 +241,7 @@ func (el *EventListener) listenEventsPolling(ctx context.Context, dispatch func(
 	}()
 	log.Info("Starting watcher...")
 	if err = watcher.Start(time.Millisecond * 100); err != nil {
-		return fmt.Errorf("Failed to start watcher for %s, %w", el.GetEventName(), err)
+		return fmt.Errorf("failed to start watcher for %s, %w", el.GetEventName(), err)
 	}
 	return nil
 }

--- a/pkg/eventsources/sources/github/validate.go
+++ b/pkg/eventsources/sources/github/validate.go
@@ -41,14 +41,14 @@ func validate(githubEventSource *v1alpha1.GithubEventSource) error {
 	}
 
 	if githubEventSource.ContentType != "" {
-		if !(githubEventSource.ContentType == "json" || githubEventSource.ContentType == "form") {
+		if !(githubEventSource.ContentType == "json" || githubEventSource.ContentType == "form") { //nolint:staticcheck
 			return fmt.Errorf("content type must be \"json\" or \"form\"")
 		}
 	}
 
 	// in order to avoid requests ending accidentally to public GitHub,
 	// make sure that both are set if either one is provided
-	if githubEventSource.GithubBaseURL != "" || githubEventSource.GithubUploadURL != "" {
+	if githubEventSource.GithubBaseURL != "" || githubEventSource.GithubUploadURL != "" { //nolint:staticcheck
 		if githubEventSource.GithubBaseURL == "" {
 			return fmt.Errorf("githubBaseURL is required when githubUploadURL is set")
 		}

--- a/pkg/eventsources/sources/hdfs/client.go
+++ b/pkg/eventsources/sources/hdfs/client.go
@@ -155,5 +155,5 @@ func createKrbClient(krbOptions *KrbOptions) (*krb.Client, error) {
 		return &client, nil
 	}
 
-	return nil, fmt.Errorf("Failed to get a Kerberos client")
+	return nil, fmt.Errorf("failed to get a Kerberos client")
 }

--- a/pkg/eventsources/sources/hdfs/validate.go
+++ b/pkg/eventsources/sources/hdfs/validate.go
@@ -47,7 +47,7 @@ func validate(eventSource *v1alpha1.HDFSEventSource) error {
 			return fmt.Errorf("failed to parse interval")
 		}
 	}
-	err := eventSource.WatchPathConfig.Validate()
+	err := eventSource.Validate()
 	if err != nil {
 		return err
 	}

--- a/pkg/eventsources/sources/kafka/start.go
+++ b/pkg/eventsources/sources/kafka/start.go
@@ -337,9 +337,10 @@ func getSaramaConfig(kafkaEventSource *v1alpha1.KafkaEventSource, log *zap.Sugar
 		config.Net.SASL.Enable = true
 
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(kafkaEventSource.SASL.GetMechanism())
-		if config.Net.SASL.Mechanism == "SCRAM-SHA-512" {
+		switch config.Net.SASL.Mechanism {
+		case "SCRAM-SHA-512":
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &sharedutil.XDGSCRAMClient{HashGeneratorFcn: sharedutil.SHA512New} }
-		} else if config.Net.SASL.Mechanism == "SCRAM-SHA-256" {
+		case "SCRAM-SHA-256":
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &sharedutil.XDGSCRAMClient{HashGeneratorFcn: sharedutil.SHA256New} }
 		}
 

--- a/pkg/reconciler/eventbus/installer/nats.go
+++ b/pkg/reconciler/eventbus/installer/nats.go
@@ -270,8 +270,8 @@ func (i *natsInstaller) createAuthSecrets(ctx context.Context, strategy v1alpha1
 			return nil, nil, err
 		}
 		if sSecret != nil {
-			sSecret.ObjectMeta.Labels = expectedSSecret.Labels
-			sSecret.ObjectMeta.Annotations = expectedSSecret.Annotations
+			sSecret.Labels = expectedSSecret.Labels
+			sSecret.Annotations = expectedSSecret.Annotations
 			sSecret.Data = expectedSSecret.Data
 			err = i.client.Update(ctx, sSecret)
 			if err != nil {

--- a/pkg/reconciler/eventsource/resource.go
+++ b/pkg/reconciler/eventsource/resource.go
@@ -457,8 +457,8 @@ func buildService(args *AdaptorArgs) (*corev1.Service, error) {
 		}
 	}
 
-	svc.ObjectMeta.SetLabels(labels)
-	svc.ObjectMeta.SetAnnotations(annotations)
+	svc.SetLabels(labels)
+	svc.SetAnnotations(annotations)
 
 	if err := controllerscommon.SetObjectMeta(eventSource, svc, v1alpha1.EventSourceGroupVersionKind); err != nil {
 		return nil, err

--- a/pkg/sensors/listener.go
+++ b/pkg/sensors/listener.go
@@ -508,7 +508,7 @@ func (sensorCtx *SensorContext) getDependencyExpression(ctx context.Context, tri
 
 func eventToString(event *v1alpha1.Event) string {
 	return fmt.Sprintf("ID '%s', Source '%s', Time '%s', Data '%s'",
-		event.Context.ID, event.Context.Source, event.Context.Time.Time.Format(time.RFC3339), string(event.Data))
+		event.Context.ID, event.Context.Source, event.Context.Time.Format(time.RFC3339), string(event.Data))
 }
 
 func convertEvent(event cloudevents.Event) *v1alpha1.Event {

--- a/pkg/sensors/triggers/kafka/kafka.go
+++ b/pkg/sensors/triggers/kafka/kafka.go
@@ -74,9 +74,10 @@ func NewKafkaTrigger(sensor *v1alpha1.Sensor, trigger *v1alpha1.Trigger, kafkaPr
 		if kafkatrigger.SASL != nil {
 			config.Net.SASL.Enable = true
 			config.Net.SASL.Mechanism = sarama.SASLMechanism(kafkatrigger.SASL.GetMechanism())
-			if config.Net.SASL.Mechanism == "SCRAM-SHA-512" {
+			switch kafkatrigger.SASL.Mechanism {
+			case "SCRAM-SHA-512":
 				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &sharedutil.XDGSCRAMClient{HashGeneratorFcn: sharedutil.SHA512New} }
-			} else if config.Net.SASL.Mechanism == "SCRAM-SHA-256" {
+			case "SCRAM-SHA-256":
 				config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &sharedutil.XDGSCRAMClient{HashGeneratorFcn: sharedutil.SHA256New} }
 			}
 

--- a/pkg/sensors/triggers/standard-k8s/standard-k8s_test.go
+++ b/pkg/sensors/triggers/standard-k8s/standard-k8s_test.go
@@ -191,7 +191,7 @@ func TestStandardK8sTrigger_Execute(t *testing.T) {
 
 	sensorObj.Spec.Triggers[0].Template.K8s.Operation = v1alpha1.Delete
 
-	client.Fake.PrependReactor("delete", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.PrependReactor("delete", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		deleteAction := action.(k8stesting.DeleteAction)
 		if deleteAction.GetName() == deployment.GetName() && deleteAction.GetNamespace() == deployment.GetNamespace() {
 			deleted = true

--- a/pkg/shared/leaderelection/leaderelection.go
+++ b/pkg/shared/leaderelection/leaderelection.go
@@ -124,9 +124,10 @@ func (e *natsEventBusElector) RunOrDie(ctx context.Context, callbacks LeaderCall
 	// Will never give up
 	opts.MaxReconnect = -1
 	opts.Url = e.url
-	if e.auth.Strategy == aev1.AuthStrategyToken {
+	switch e.auth.Strategy {
+	case aev1.AuthStrategyToken:
 		opts.Token = e.auth.Credential.Token
-	} else if e.auth.Strategy == aev1.AuthStrategyBasic {
+	case aev1.AuthStrategyBasic:
 		opts.User = e.auth.Credential.Username
 		opts.Password = e.auth.Credential.Password
 	}

--- a/pkg/shared/util/cronutil.go
+++ b/pkg/shared/util/cronutil.go
@@ -124,8 +124,8 @@ WRAP:
 // restrictions are satisfied by the given time.
 func dayMatches(s *cronlib.SpecSchedule, t time.Time) bool {
 	var (
-		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
-		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
+		domMatch = 1<<uint(t.Day())&s.Dom > 0
+		dowMatch = 1<<uint(t.Weekday())&s.Dow > 0
 	)
 	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
 		return domMatch && dowMatch

--- a/pkg/shared/util/scram_client.go
+++ b/pkg/shared/util/scram_client.go
@@ -19,11 +19,11 @@ type XDGSCRAMClient struct {
 }
 
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
-	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	x.Client, err = x.NewClient(userName, password, authzID)
 	if err != nil {
 		return err
 	}
-	x.ClientConversation = x.Client.NewConversation()
+	x.ClientConversation = x.NewConversation()
 	return nil
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -199,7 +199,7 @@ func (ac *AdmissionController) register(
 		if !reflect.DeepEqual(configuredWebhook.Webhooks, webhook.Webhooks) {
 			ac.Logger.Info("Updating webhook")
 			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
+			webhook.ResourceVersion = configuredWebhook.ResourceVersion
 			if _, err := client.Update(ctx, webhook, metav1.UpdateOptions{}); err != nil {
 				return fmt.Errorf("failed to update webhook, %w", err)
 			}
@@ -293,7 +293,7 @@ func (ac *AdmissionController) generateSecret(ctx context.Context) (*corev1.Secr
 	}
 	deployment, err := ac.Client.AppsV1().Deployments(ac.Options.Namespace).Get(ctx, ac.Options.DeploymentName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch webhook deployment, %w", err)
+		return nil, fmt.Errorf("failed to fetch webhook deployment, %w", err)
 	}
 	deploymentRef := metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment"))
 	secret := &corev1.Secret{

--- a/test/e2e/fixtures/e2e_suite.go
+++ b/test/e2e/fixtures/e2e_suite.go
@@ -170,10 +170,12 @@ func (s *E2ESuite) Given() *Given {
 
 func GetBusDriverSpec() string {
 	x := strings.ToUpper(os.Getenv("EventBusDriver"))
-	if x == "JETSTREAM" {
+	switch x {
+	case "JETSTREAM":
 		return E2EEventBusJetstream
-	} else if x == "KAFKA" {
+	case "KAFKA":
 		return E2EEventBusKafka
+	default:
+		return E2EEventBusSTAN
 	}
-	return E2EEventBusSTAN
 }

--- a/test/stress/generator/cmd/sqs.go
+++ b/test/stress/generator/cmd/sqs.go
@@ -16,7 +16,7 @@ func NewSqsCommand() *cobra.Command {
 			validateGlobalParameters(cmd, args)
 
 			stressRun(signals.SetupSignalHandler(), func() error {
-				return fmt.Errorf("To be implemented.")
+				return fmt.Errorf("to be implemented")
 			})
 		},
 	}

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -231,7 +231,7 @@ func (o *options) createSensor(ctx context.Context) (*v1alpha1.Sensor, error) {
 		return nil, fmt.Errorf("expected to see sensor pod contains something: %w", err)
 	}
 	if !contains {
-		return nil, fmt.Errorf("Sensor Pod does look good, it might have started failed")
+		return nil, fmt.Errorf("sensor Pod does look good, it might have started failed")
 	}
 	return result, nil
 }


### PR DESCRIPTION
Updates golangci-lint to v2 using `golangci-lint migrate` from v2 cli and fixes associated lints
