### PR TITLE
Set a unique name to each sensor in order to deploy all sensors together

### DIFF
--- a/examples/sensors/aws-lambda-trigger.yaml
+++ b/examples/sensors/aws-lambda-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: aws-lambda-trigger
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/azure-event-hubs-sensor.yaml
+++ b/examples/sensors/azure-event-hubs-sensor.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: azure-events-hub
+  name: azure-event-hubs-sensor
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/azure-service-bus-sensor.yaml
+++ b/examples/sensors/azure-service-bus-sensor.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: azure-service-bus
+  name: azure-service-bus-sensor
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/complete-trigger-parameterization.yaml
+++ b/examples/sensors/complete-trigger-parameterization.yaml
@@ -19,7 +19,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: complete-trigger-parameterization
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/context-filter-webhook.yaml
+++ b/examples/sensors/context-filter-webhook.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: context-filter-webhook
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/custom-trigger.yaml
+++ b/examples/sensors/custom-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: custom-trigger
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/dependencies-conditions.yaml
+++ b/examples/sensors/dependencies-conditions.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: dependencies-conditions
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/email-trigger.yaml
+++ b/examples/sensors/email-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: email-trigger
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/http-trigger-secure-headers.yaml
+++ b/examples/sensors/http-trigger-secure-headers.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: http-trigger
+  name: http-trigger-secure-headers
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/http-trigger.yaml
+++ b/examples/sensors/http-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: minio
+  name: http-trigger
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/kafka-ttl.yaml
+++ b/examples/sensors/kafka-ttl.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: kafka
+  name: kafka-ttl
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/log-debug.yaml
+++ b/examples/sensors/log-debug.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: log
+  name: log-debug
 spec:
   template:
     container:

--- a/examples/sensors/multi-trigger-sensor.yaml
+++ b/examples/sensors/multi-trigger-sensor.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: multi-trigger-sensor
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/slack-trigger.yaml
+++ b/examples/sensors/slack-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: slack-trigger
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/special-workflow-trigger-shortened.yaml
+++ b/examples/sensors/special-workflow-trigger-shortened.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: special-workflow-trigger-shortened
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/special-workflow-trigger.yaml
+++ b/examples/sensors/special-workflow-trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: special-workflow-trigger
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/time-filter-webhook.yaml
+++ b/examples/sensors/time-filter-webhook.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: time-filter-webhook
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/transform.yaml
+++ b/examples/sensors/transform.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: transform
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-nats-messages.yaml
+++ b/examples/sensors/trigger-nats-messages.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: minio
+  name: trigger-nats-messages
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/trigger-openwhisk.yaml
+++ b/examples/sensors/trigger-openwhisk.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: minio
+  name: trigger-openwhisk
 spec:
   dependencies:
     - name: test-dep

--- a/examples/sensors/trigger-source-configmap.yaml
+++ b/examples/sensors/trigger-source-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-source-configmap
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-source-file.yaml
+++ b/examples/sensors/trigger-source-file.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-source-file
 spec:
   template:
     container:

--- a/examples/sensors/trigger-source-git.yaml
+++ b/examples/sensors/trigger-source-git.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-source-git
 spec:
   template:
     container:

--- a/examples/sensors/trigger-standard-k8s-resource-shortened.yaml
+++ b/examples/sensors/trigger-standard-k8s-resource-shortened.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-standard-k8s-resource-shortened
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-standard-k8s-resource.yaml
+++ b/examples/sensors/trigger-standard-k8s-resource.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-standard-k8s-resource
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-with-atleast-once-semantics.yaml
+++ b/examples/sensors/trigger-with-atleast-once-semantics.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-with-atleast-once-semantics
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-with-policy.yaml
+++ b/examples/sensors/trigger-with-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-with-policy
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/trigger-with-template.yaml
+++ b/examples/sensors/trigger-with-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: trigger-with-template
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/url-sensor.yaml
+++ b/examples/sensors/url-sensor.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: url-sensor
 spec:
   template:
     serviceAccountName: operate-workflow-sa

--- a/examples/sensors/webhook-shortened.yaml
+++ b/examples/sensors/webhook-shortened.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: webhook
+  name: webhook-shortened
 spec:
   template:
     serviceAccountName: operate-workflow-sa


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

In examples/sensors/, some sensors have not a unique metadata name prohibiting to deploy all sensors together. This PR fixes sensors' metadata name to be unique.

Following diagram generated with [KubeDiagrams](https://github.com/philippemerle/KubeDiagrams) illustrates the composition of all resources defined in examples/:

![argoproj-argo-events-examples](https://github.com/user-attachments/assets/cda7c996-4378-49ba-87fd-eef5e18006dc)
 
