### PR TITLE
fix: Fix Sensor Validation for admission webhook

### DIFF
--- a/pkg/webhook/validator/sensor.go
+++ b/pkg/webhook/validator/sensor.go
@@ -33,6 +33,9 @@ func (s *sensor) ValidateCreate(ctx context.Context) *admissionv1.AdmissionRespo
 	if len(s.newSensor.Spec.EventBusName) > 0 {
 		eventBusName = s.newSensor.Spec.EventBusName
 	}
+	if s.eventBusClient == nil {
+		return DeniedResponse("invalid EventBus: eventBusClient is nil")
+	}
 	eventBus, err := s.eventBusClient.Get(ctx, eventBusName, metav1.GetOptions{})
 	if err != nil {
 		return DeniedResponse("failed to get EventBus eventBusName=%s; err=%v", eventBusName, err)
@@ -46,7 +49,7 @@ func (s *sensor) ValidateCreate(ctx context.Context) *admissionv1.AdmissionRespo
 
 func (s *sensor) ValidateUpdate(ctx context.Context) *admissionv1.AdmissionResponse {
 	if s.oldSensor.Generation == s.newSensor.Generation {
-		AllowedResponse()
+		return AllowedResponse()
 	}
 	return s.ValidateCreate(ctx)
 }

--- a/pkg/webhook/validator/sensor_test.go
+++ b/pkg/webhook/validator/sensor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -46,6 +47,42 @@ var (
 			},
 		},
 	}
+	fakeSensorWithFinalizer = &aev1.Sensor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: aev1.SchemeGroupVersion.String(),
+			Kind:       "Sensor",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  testNamespace,
+			Name:       "test-sensor",
+			Generation: 1,
+			Finalizers: []string{"test-finalizer"},
+		},
+		Spec: aev1.SensorSpec{
+			Dependencies: []aev1.EventDependency{
+				{
+					Name:            "test-dep",
+					EventSourceName: "test-source",
+					EventName:       "test-event",
+				},
+			},
+			Triggers: []aev1.Trigger{
+				{
+					Template: &aev1.TriggerTemplate{
+						Name: "test-trigger",
+						K8s: &aev1.StandardK8STrigger{
+							Operation: aev1.Create,
+							Source: &aev1.ArtifactLocation{
+								Resource: &aev1.K8SResource{
+									Value: []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-trigger"}}`),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 func TestValidateSensor(t *testing.T) {
@@ -56,8 +93,12 @@ func TestValidateSensor(t *testing.T) {
 	testBus := fakeBus.DeepCopy()
 	testBus.Status.MarkDeployed("test", "test")
 	testBus.Status.MarkConfigured()
+
+	// Try to create the EventBus, but ignore "already exists" errors
 	_, err = fakeEventsClient.EventBus(testNamespace).Create(context.TODO(), testBus, metav1.CreateOptions{})
-	assert.Nil(t, err)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		assert.Nil(t, err)
+	}
 
 	for _, entry := range dirEntries {
 		if entry.IsDir() {
@@ -77,4 +118,86 @@ func TestValidateSensor(t *testing.T) {
 		r = v.ValidateUpdate(contextWithLogger(t))
 		assert.True(t, r.Allowed)
 	}
+}
+
+// TestValidateSensorUpdateSameGeneration tests that ValidateUpdate allows metadata-only changes, such as finalizer removal
+func TestValidateSensorUpdateSameGeneration(t *testing.T) {
+	testSensor := fakeSensorWithFinalizer.DeepCopy()
+	testSensor.Finalizers = []string{}
+	testSensor.Labels = map[string]string{"test": "label"}
+
+	assert.Equal(t, fakeSensorWithFinalizer.Generation, testSensor.Generation, "Test setup: generations should be the same")
+
+	v := NewSensorValidator(fakeK8sClient, nil, nil, nil, fakeSensorWithFinalizer, testSensor)
+	r := v.ValidateUpdate(contextWithLogger(t))
+
+	assert.True(t, r.Allowed, "ValidateUpdate should allow changes when generation is unchanged")
+	assert.Nil(t, r.Result, "ValidateUpdate should return nil result for allowed requests")
+}
+
+// TestValidateSensorUpdateNewGeneration tests that ValidateUpdate calls ValidateCreate when Generation is different
+func TestValidateSensorUpdateNewGeneration(t *testing.T) {
+	testSensor := fakeSensorWithFinalizer.DeepCopy()
+	testSensor.Finalizers = []string{}
+	testSensor.Generation++
+
+	assert.NotEqual(t, fakeSensorWithFinalizer.Generation, testSensor.Generation, "Test setup: generations should be different")
+
+	v := NewSensorValidator(fakeK8sClient, nil, nil, nil, fakeSensorWithFinalizer, testSensor)
+	r := v.ValidateUpdate(contextWithLogger(t))
+
+	assert.False(t, r.Allowed, "ValidateUpdate should deny when ValidateCreate is called with nil eventBusClient")
+	assert.NotNil(t, r.Result, "ValidateUpdate should return result with error message")
+	assert.Contains(t, r.Result.Message, "eventBusClient is nil", "Error message should indicate nil eventBusClient")
+}
+
+// TestValidateSensorUpdateNewGenerationValidation tests that ValidateUpdate calls ValidateCreate when generation changes
+func TestValidateSensorUpdateNewGenerationValidation(t *testing.T) {
+	testBus := fakeBus.DeepCopy()
+	testBus.Status.MarkDeployed("test", "test")
+	testBus.Status.MarkConfigured()
+
+	// Try to create the EventBus, but ignore "already exists" errors
+	_, err := fakeEventsClient.EventBus(testNamespace).Create(context.TODO(), testBus, metav1.CreateOptions{})
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		assert.Nil(t, err)
+	}
+
+	testSensor := fakeSensorWithFinalizer.DeepCopy()
+	testSensor.Finalizers = []string{}
+	testSensor.Generation++
+
+	v := NewSensorValidator(fakeK8sClient, fakeEventsClient.EventBus(testNamespace), fakeEventsClient.EventSources(testNamespace), fakeEventsClient.Sensors(testNamespace), fakeSensorWithFinalizer, testSensor)
+	r := v.ValidateUpdate(contextWithLogger(t))
+
+	assert.True(t, r.Allowed, "ValidateUpdate should succeed when generation changes and validation passes")
+	assert.Nil(t, r.Result, "ValidateUpdate should return nil result for allowed requests")
+}
+
+// TestValidateSensorUpdateNewGenerationValidationFails tests that ValidateUpdate returns validation failure when generation changes and EventBus is missing
+func TestValidateSensorUpdateNewGenerationValidationFails(t *testing.T) {
+	testSensor := fakeSensorWithFinalizer.DeepCopy()
+	testSensor.Finalizers = []string{}
+	testSensor.Generation++
+	testSensor.Spec.EventBusName = "non-existent-eventbus"
+
+	v := NewSensorValidator(fakeK8sClient, fakeEventsClient.EventBus(testNamespace), fakeEventsClient.EventSources(testNamespace), fakeEventsClient.Sensors(testNamespace), fakeSensorWithFinalizer, testSensor)
+	r := v.ValidateUpdate(contextWithLogger(t))
+
+	assert.False(t, r.Allowed, "ValidateUpdate should fail when generation changes and validation fails")
+	assert.NotNil(t, r.Result, "ValidateUpdate should return a result with error message")
+	assert.Contains(t, r.Result.Message, "failed to get EventBus", "Error message should mention EventBus failure")
+}
+
+// TestValidateSensorCreateDenied tests that ValidateCreate returns denied response when EventBus is not found
+func TestValidateSensorCreateDenied(t *testing.T) {
+	testSensor := fakeSensorWithFinalizer.DeepCopy()
+	testSensor.Spec.EventBusName = "non-existent-eventbus"
+
+	v := NewSensorValidator(fakeK8sClient, fakeEventsClient.EventBus(testNamespace), fakeEventsClient.EventSources(testNamespace), fakeEventsClient.Sensors(testNamespace), nil, testSensor)
+	r := v.ValidateCreate(contextWithLogger(t))
+
+	assert.False(t, r.Allowed, "ValidateCreate should deny when EventBus is not found")
+	assert.NotNil(t, r.Result, "ValidateCreate should return a result with error message")
+	assert.Contains(t, r.Result.Message, "failed to get EventBus", "Error message should mention EventBus failure")
 }


### PR DESCRIPTION
We have been running into an issue when deleting sensors, when the eventbus has already been deleted.  When we try to remove the finalizer from a sensor we're attempting to force delete, the admission webhook denies the request with:

```
error: sensors.argoproj.io "flex-managed-sensor" could not be patched: admission webhook "webhook.argo-events.argoproj.io" denied the request: failed to get EventBus eventBusName=default; err=eventbus.argoproj.io "default" not found
```

This PR should fix this bug.

While creating additional test cases to catch this bug, also noticed that the current code panics when eventBusClient is nil, so added a guard against that as well.

---

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
