### PR TITLE
fix(doc): Update data filter doc about string handling

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -980,14 +980,14 @@
       "type": "object"
     },
     "io.argoproj.events.v1alpha1.DataFilter": {
-      "description": "DataFilter describes constraints and filters for event data Regular Expressions are purposefully not a feature as they are overkill for our uses here See Rob Pike's Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html",
+      "description": "DataFilter describes constraints and filters for event data.",
       "properties": {
         "comparator": {
           "description": "Comparator compares the event data with a user given value. Can be \"\u003e=\", \"\u003e\", \"=\", \"!=\", \"\u003c\", or \"\u003c=\". Is optional, and if left blank treated as equality \"=\".",
           "type": "string"
         },
         "path": {
-          "description": "Path is the JSONPath of the event's (JSON decoded) data key Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
+          "description": "Path is the JSONPath of the event's (JSON decoded) data key. Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
           "type": "string"
         },
         "template": {
@@ -999,7 +999,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Value is the allowed string values for this key Booleans are passed using strconv.ParseBool() Numbers are parsed using as float64 using strconv.ParseFloat() Strings are taken as is Nils this value is ignored",
+          "description": "Value is the allowed string values for this key. Booleans are parsed using strconv.ParseBool(), Numbers are parsed as float64 using strconv.ParseFloat(), Strings are treated as regular expressions, Nils value is ignored.",
           "items": {
             "type": "string"
           },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -984,7 +984,7 @@
       }
     },
     "io.argoproj.events.v1alpha1.DataFilter": {
-      "description": "DataFilter describes constraints and filters for event data Regular Expressions are purposefully not a feature as they are overkill for our uses here See Rob Pike's Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html",
+      "description": "DataFilter describes constraints and filters for event data.",
       "type": "object",
       "required": [
         "path",
@@ -997,7 +997,7 @@
           "type": "string"
         },
         "path": {
-          "description": "Path is the JSONPath of the event's (JSON decoded) data key Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
+          "description": "Path is the JSONPath of the event's (JSON decoded) data key. Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
           "type": "string"
         },
         "template": {
@@ -1009,7 +1009,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Value is the allowed string values for this key Booleans are passed using strconv.ParseBool() Numbers are parsed using as float64 using strconv.ParseFloat() Strings are taken as is Nils this value is ignored",
+          "description": "Value is the allowed string values for this key. Booleans are parsed using strconv.ParseBool(), Numbers are parsed as float64 using strconv.ParseFloat(), Strings are treated as regular expressions, Nils value is ignored.",
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -4910,10 +4910,7 @@ DataFilter
 
 <p>
 
-DataFilter describes constraints and filters for event data Regular
-Expressions are purposefully not a feature as they are overkill for our
-uses here See Rob Pike’s Post:
-<a href="https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html">https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html</a>
+DataFilter describes constraints and filters for event data.
 </p>
 
 </p>
@@ -4951,7 +4948,7 @@ Description
 
 <p>
 
-Path is the JSONPath of the event’s (JSON decoded) data key Path is a
+Path is the JSONPath of the event’s (JSON decoded) data key. Path is a
 series of keys separated by a dot. A key may contain wildcard characters
 ‘\*’ and ‘?’. To access an array value use the index as the key. The dot
 and wildcard characters can be escaped with ‘&rsquo;. See
@@ -4993,9 +4990,10 @@ Type contains the JSON type of the data
 
 <p>
 
-Value is the allowed string values for this key Booleans are passed
-using strconv.ParseBool() Numbers are parsed using as float64 using
-strconv.ParseFloat() Strings are taken as is Nils this value is ignored
+Value is the allowed string values for this key. Booleans are parsed
+using strconv.ParseBool(), Numbers are parsed as float64 using
+strconv.ParseFloat(), Strings are treated as regular expressions, Nils
+value is ignored.
 </p>
 
 </td>

--- a/pkg/apis/events/openapi/openapi_generated.go
+++ b/pkg/apis/events/openapi/openapi_generated.go
@@ -1958,12 +1958,12 @@ func schema_pkg_apis_events_v1alpha1_DataFilter(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DataFilter describes constraints and filters for event data Regular Expressions are purposefully not a feature as they are overkill for our uses here See Rob Pike's Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html",
+				Description: "DataFilter describes constraints and filters for event data.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Path is the JSONPath of the event's (JSON decoded) data key Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
+							Description: "Path is the JSONPath of the event's (JSON decoded) data key. Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'. To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\\\'. See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -1979,7 +1979,7 @@ func schema_pkg_apis_events_v1alpha1_DataFilter(ref common.ReferenceCallback) co
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the allowed string values for this key Booleans are passed using strconv.ParseBool() Numbers are parsed using as float64 using strconv.ParseFloat() Strings are taken as is Nils this value is ignored",
+							Description: "Value is the allowed string values for this key. Booleans are parsed using strconv.ParseBool(), Numbers are parsed as float64 using strconv.ParseFloat(), Strings are treated as regular expressions, Nils value is ignored.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/apis/events/v1alpha1/generated.proto
+++ b/pkg/apis/events/v1alpha1/generated.proto
@@ -766,11 +766,9 @@ message CustomTrigger {
   repeated TriggerParameter payload = 7;
 }
 
-// DataFilter describes constraints and filters for event data
-// Regular Expressions are purposefully not a feature as they are overkill for our uses here
-// See Rob Pike's Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html
+// DataFilter describes constraints and filters for event data.
 message DataFilter {
-  // Path is the JSONPath of the event's (JSON decoded) data key
+  // Path is the JSONPath of the event's (JSON decoded) data key.
   // Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
   // To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
   // See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
@@ -779,11 +777,11 @@ message DataFilter {
   // Type contains the JSON type of the data
   optional string type = 2;
 
-  // Value is the allowed string values for this key
-  // Booleans are passed using strconv.ParseBool()
-  // Numbers are parsed using as float64 using strconv.ParseFloat()
-  // Strings are taken as is
-  // Nils this value is ignored
+  // Value is the allowed string values for this key.
+  // Booleans are parsed using strconv.ParseBool(),
+  // Numbers are parsed as float64 using strconv.ParseFloat(),
+  // Strings are treated as regular expressions,
+  // Nils value is ignored.
   repeated string value = 3;
 
   // Comparator compares the event data with a user given value.

--- a/pkg/apis/events/v1alpha1/sensor_types.go
+++ b/pkg/apis/events/v1alpha1/sensor_types.go
@@ -211,22 +211,20 @@ const (
 	JSONTypeString JSONType = "string"
 )
 
-// DataFilter describes constraints and filters for event data
-// Regular Expressions are purposefully not a feature as they are overkill for our uses here
-// See Rob Pike's Post: https://commandcenter.blogspot.com/2011/08/regular-expressions-in-lexing-and.html
+// DataFilter describes constraints and filters for event data.
 type DataFilter struct {
-	// Path is the JSONPath of the event's (JSON decoded) data key
+	// Path is the JSONPath of the event's (JSON decoded) data key.
 	// Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
 	// To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
 	// See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
 	// Type contains the JSON type of the data
 	Type JSONType `json:"type" protobuf:"bytes,2,opt,name=type,casttype=JSONType"`
-	// Value is the allowed string values for this key
-	// Booleans are passed using strconv.ParseBool()
-	// Numbers are parsed using as float64 using strconv.ParseFloat()
-	// Strings are taken as is
-	// Nils this value is ignored
+	// Value is the allowed string values for this key.
+	// Booleans are parsed using strconv.ParseBool(),
+	// Numbers are parsed as float64 using strconv.ParseFloat(),
+	// Strings are treated as regular expressions,
+	// Nils value is ignored.
 	Value []string `json:"value" protobuf:"bytes,3,rep,name=value"`
 	// Comparator compares the event data with a user given value.
 	// Can be ">=", ">", "=", "!=", "<", or "<=".


### PR DESCRIPTION
Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

- Fix doc regarding strings being now handled as regexes, and not "as is" as it was in the past, in the sensors' data filters.
   _As mentioned [in the sensors' filters documentation](https://github.com/argoproj/argo-events/blob/0a2ee96a61adb7f375e1628fa3ee59676daa5687/docs/sensors/filters/data.md?plain=1#L117) and [defined there in the code](https://github.com/argoproj/argo-events/blob/eb4bb0d1e9be5b76f30b3923640628ee853f7c0b/pkg/sensors/dependencies/filter.go#L361), and as I indeed observed, the string values can be regular expressions, and are in any case treated as regexes._
   _The behaviour was introduced in [this PR](https://github.com/argoproj/argo-events/pull/396), but the associated comment was somehow changed back from “taken as regular expressions” to the initial “taken as is” a little later, in [this commit](https://github.com/argoproj/argo-events/commit/274e0d9d92a17bcebea33797e52a2d5ae3074eeb#diff-32c7d2897774f637062d53d234067e89222cbdae50e73deb47cc50dec0bebe1bR188)._
- Fix typos/punctuation in passing.


