### PR TITLE
docs: Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Follow these [instructions](https://argoproj.github.io/argo-events/installation/
 
 ## User Interface/API
 
-The Argo Workflows has an API and user interface support Argo Events.
+Argo Workflows has an API and user interface that support Argo Events.
 
 ## Documentation
 
@@ -54,7 +54,7 @@ The Argo Workflows has an API and user interface support Argo Events.
 * [Argo Events - Event-Based Dependency Manager for Kubernetes](https://youtu.be/sUPkGChvD54)
 * [Argo Events Deep-dive](https://youtu.be/U4tCYcCK20w)
 * [Automating Research Workflows at BlackRock](https://www.youtube.com/watch?v=ZK510prml8o)
-* [Designing A Complete CI/CD Pipeline CI/CD Pipeline Using Argo Events, Workflows, and CD](https://www.slideshare.net/JulianMazzitelli/designing-a-complete-ci-cd-pipeline-using-argo-events-workflow-and-cd-products-228452500)
+* [Designing A Complete CI/CD Pipeline Using Argo Events, Workflows, and CD](https://www.slideshare.net/JulianMazzitelli/designing-a-complete-ci-cd-pipeline-using-argo-events-workflow-and-cd-products-228452500)
 * TGI Kubernetes with Joe
   Beda: [CloudEvents and Argo Events](https://www.youtube.com/watch?v=LQbBgQnUs_k&list=PL7bmigfV0EqQzxcNpmcdTJ9eFRPBe-iZa&index=2&t=0s)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you find a security related bug in Argo Events, we kindly ask you for responsible
+If you find a security-related bug in Argo Events, we kindly ask you for responsible
 disclosure and for giving us appropriate time to react, analyze and develop a
 fix to mitigate the found security vulnerability.
 

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -4602,7 +4602,7 @@
       "type": "object"
     },
     "io.argoproj.events.v1alpha1.URLArtifact": {
-      "description": "URLArtifact contains information about an artifact at an http endpoint.",
+      "description": "URLArtifact contains information about an artifact at an HTTP endpoint.",
       "properties": {
         "path": {
           "description": "Path is the complete URL",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4576,7 +4576,7 @@
       }
     },
     "io.argoproj.events.v1alpha1.URLArtifact": {
-      "description": "URLArtifact contains information about an artifact at an http endpoint.",
+      "description": "URLArtifact contains information about an artifact at an HTTP endpoint.",
       "type": "object",
       "required": [
         "path"

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -21924,7 +21924,7 @@ URLArtifact
 
 <p>
 
-URLArtifact contains information about an artifact at an http endpoint.
+URLArtifact contains information about an artifact at an HTTP endpoint.
 </p>
 
 </p>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To run Argo Events locally for development: [developer guide](developer_guide.md
 
 Dependencies increase the risk of security issues and have on-going maintenance costs.
 
-The dependency must pass these test:
+The dependency must pass these tests:
 
 - A strong use case.
 - It has an acceptable license (e.g. MIT).
@@ -53,4 +53,4 @@ No, we should not add that dependency.
 
 ### Contributor Workshop
 
-We have a [90m video on YouTube](https://youtu.be/zZv0lNCDG9w) to show you how to get some hands-on experience contributing (e.g., running locally, testing, etc...).
+We have a [90m video on YouTube](https://youtu.be/zZv0lNCDG9w) to show you how to gain hands-on experience in contributing (e.g., running locally, testing, etc...).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@
 **A**. Yes. If you want to deploy the event-source in a different namespace than `argo-events`, please update the event-source definition
 with the desired namespace and service account. Make sure to grant the service account the [necessary roles](https://github.com/argoproj/argo-events/blob/master/manifests/namespace-install.yaml).
 
-**Q. How to debug Argo-Events.**
+**Q. How to debug Argo Events?**
 
 **A**.
 

--- a/docs/concepts/sensor.md
+++ b/docs/concepts/sensor.md
@@ -5,11 +5,11 @@ It listens to events on the eventbus and acts as an event dependency manager to 
 
 ## Event dependency
 
-A dependency is an event the sensor is waiting to happen.
+A dependency is an event the sensor is waiting for.
 
 ## Specification
 
-Complete specification is available [here](../APIs.md#argoproj.io/v1alpha1.Sensor).
+The complete specification is available [here](../APIs.md#argoproj.io/v1alpha1.Sensor).
 
 ## Examples
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -35,7 +35,7 @@ make build
 
 ### 4. Changing Types
 
-If you're making a change to the `pkg/apis` package, please ensure you re-run
+If you're making a change to the `pkg/apis` package, please ensure you re-run the
 following command for code regeneration.
 
 ```
@@ -85,7 +85,7 @@ You might want to test certain changes on a managed cluster in the cloud. For ex
 
 #### 1. Building images
 
-We can use ephemeral containers for quick testing with images hosted by friends at [ttl.sh](https://ttl.sh/). 
+We can use ephemeral containers for quick testing with images hosted by our friends at [ttl.sh](https://ttl.sh/). 
 
 If you want a fresh build before building the container image, run the following commands to delete any existing binaries.
 

--- a/docs/dr_ha_recommendations.md
+++ b/docs/dr_ha_recommendations.md
@@ -2,7 +2,7 @@
 
 ## EventBus
 
-A simple EventBus used for non-prod deployment or testing purpose could be:
+A simple EventBus used for non-prod deployment or testing purposes could be:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -15,15 +15,15 @@ spec:
       auth: token
 ```
 
-However this is not good enough to run your production deployment, following
-settings are recommended to make it more reliable, and achieve high
+However, this is not good enough to run your production deployment. The following
+settings are recommended to make it more reliable and achieve high
 availability.
 
 ### Persistent Volumes
 
-Even though the EventBus PODs already have data sync mechanism between them,
-persistent volumes are still recommended to be used to avoid any events data
-lost when the PODs crash.
+Even though the EventBus PODs already have a data sync mechanism between them,
+persistent volumes are still recommended to avoid any event data
+loss when the PODs crash.
 
 An EventBus with persistent volumes looks like below:
 
@@ -100,7 +100,7 @@ Priority could be set through `spec.nats.native.priorityClassName` or
 
 ### PDB
 
-EventBus service is essential to EventSource and Sensor Pods, it would be better to have a `PodDisruptionBudget` to prevent it from [Pod Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). The following PDB object states `maxUnavailable` is 1, which is suitable for a 3 replica EventBus object.
+The EventBus service is essential to EventSource and Sensor Pods. It would be better to have a `PodDisruptionBudget` to prevent [Pod Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). The following PDB object states that `maxUnavailable` is 1, which is suitable for a 3-replica EventBus object.
 
 If your EventBus has a name other than `default`, change it accordingly in the yaml.
 

--- a/docs/eventbus/kafka.md
+++ b/docs/eventbus/kafka.md
@@ -26,13 +26,13 @@ for the full specification.
 
 ### url
 
-Comma seperated list of kafka broker urls, the kafka broker must be managed
+Comma separated list of kafka broker urls, the kafka broker must be managed
 independently of Argo Events.
 
 ### topic
 
 The topic name, defaults to `{namespace-name}-{eventbus-name}`. Two additional
-topics per Sensor are also required, see see [topics](#topics) below for more
+topics per Sensor are also required, see [topics](#topics) below for more
 information.
 
 ### version
@@ -94,7 +94,7 @@ Producer partitioning strategy. Supported values: `random`, `hash`, `roundrobin`
 
 You can enable TLS or SASL authentication, see above for configuration
 details. You must enable these features in your Kafka Cluster and make
-the certifactes/credentials available in a Kubernetes secret.
+the certificates/credentials available in a Kubernetes secret.
 
 ## Topics
 
@@ -127,7 +127,7 @@ named as follows.
 
 ## Horizontal Scaling and Leader Election
 
-Sensors that use a Kafka EventBus can scale horizontally. Specifiying replicas
+Sensors that use a Kafka EventBus can scale horizontally. Specifying replicas
 greater than one will result in all Sensor pods actively processing events.
 However, an EventSource that uses a Kafka EventBus cannot necessarily be
 horizontally scaled in an active-active manner, see [EventSource HA](../eventsources/ha.md)

--- a/docs/eventbus/stan.md
+++ b/docs/eventbus/stan.md
@@ -5,7 +5,7 @@ Streaming service with `exotic` NATS EventBus.
 
 ### Native
 
-A simplest `native` NATS EventBus example:
+The simplest `native` NATS EventBus example:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -33,7 +33,7 @@ spec:
   nats:
     native:
       replicas: 3 # optional, defaults to 3, and requires minimal 3
-      auth: token # optional, default to none
+      auth: token # optional, defaults to none
       persistence: # optional
         storageClassName: standard
         accessMode: ReadWriteOnce
@@ -118,7 +118,7 @@ for the full spec of `native`.
   deleted automatically. It can be customized by setting
   `spec.nats.native.maxAge`, i.e. `240h`.
 
-- Max subscription number is defaults to `1000`, it could be customized by
+- Max subscription number defaults to `1000`, it could be customized by
   setting `spec.nats.native.maxSubs`.
 
 ### Exotic

--- a/docs/eventsources/services.md
+++ b/docs/eventsources/services.md
@@ -2,7 +2,7 @@
 
 Some of the EventSources (`webhook`, `github`, `gitlab`, `sns`, `slack`,
 `Storage GRID` and `stripe`) start an HTTP service to receive the events, for
-your convenience, there is a field named `service` within EventSource spec can
+your convenience, there is a field named `service` within the EventSource spec that can
 help you create a `ClusterIP` service for testing.
 
 For example:
@@ -49,5 +49,5 @@ spec:
 
 Then you can expose the service for external access using native K8s objects as mentioned above.
 
-You can refer to [webhook heath check](webhook-health-check.md) if you need a
+You can refer to [webhook health check](webhook-health-check.md) if you need a
 health check endpoint for LB Service or Ingress configuration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ gcp pubsub, sns, sqs, etc.
 
 ## Getting Started
 
-Follow these [instruction](https://argoproj.github.io/argo-events/installation/)
+Follow these [instructions](https://argoproj.github.io/argo-events/installation/)
 to set up Argo Events.
 
 ## Documentation
@@ -69,6 +69,6 @@ organization name if you are using Argo Events.
 - [Argo Events - Event-Based Dependency Manager for Kubernetes](https://youtu.be/sUPkGChvD54)
 - [Argo Events Deep-dive](https://youtu.be/U4tCYcCK20w)
 - [Automating Research Workflows at BlackRock](https://www.youtube.com/watch?v=ZK510prml8o)
-- [Designing A Complete CI/CD Pipeline CI/CD Pipeline Using Argo Events, Workflows, and CD](https://www.slideshare.net/JulianMazzitelli/designing-a-complete-ci-cd-pipeline-using-argo-events-workflow-and-cd-products-228452500)
+- [Designing A Complete CI/CD Pipeline Using Argo Events, Workflows, and CD](https://www.slideshare.net/JulianMazzitelli/designing-a-complete-ci-cd-pipeline-using-argo-events-workflow-and-cd-products-228452500)
 - TGI Kubernetes with Joe Beda:
   [CloudEvents and Argo Events](https://www.youtube.com/watch?v=LQbBgQnUs_k&list=PL7bmigfV0EqQzxcNpmcdTJ9eFRPBe-iZa&index=2&t=0s)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@
 
                 oc adm policy add-scc-to-user anyuid system:serviceaccount:argo-events:argo-events-sa system:serviceaccount:argo-events:argo-events-webhook-sa
 
-             - Add update permissions for the `deployments/finalizers` and `clusterroles/finalizers` of the argo-events-webhook ClusterRole(this is necessary for the validating admission controller)
+             - Add update permissions for the `deployments/finalizers` and `clusterroles/finalizers` of the argo-events-webhook ClusterRole (this is necessary for the validating admission controller)
 
                 - apiGroups:
                   - rbac.authorization.k8s.io
@@ -71,7 +71,7 @@
 
                 oc adm policy add-scc-to-user anyuid system:serviceaccount:argo-events:default
 
-             - Add update permissions for the `deployments/finalizers` and `clusterroles/finalizers` of the argo-events-webhook ClusterRole(this is necessary for the validating admission controller)
+             - Add update permissions for the `deployments/finalizers` and `clusterroles/finalizers` of the argo-events-webhook ClusterRole (this is necessary for the validating admission controller)
 
                 - apiGroups:
                   - rbac.authorization.k8s.io
@@ -103,7 +103,7 @@ Use either [`cluster-install`](https://github.com/argoproj/argo-events/tree/stab
 
 ### Using Helm Chart
 
-Make sure you have helm client installed. To install helm, follow <a href="https://docs.helm.sh/using_helm/">the link.</a>
+Make sure you have the helm client installed. To install helm, follow <a href="https://docs.helm.sh/using_helm/">the link.</a>
 
 1. Add `argoproj` repository.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,7 +9,7 @@
 Each of generated EventSource, Sensor and EventBus PODs exposes an HTTP endpoint
 for its metrics, which include things like how many events were generated, how
 many actions were triggered, and so on. To let your Prometheus server discover
-those user metrics, add following to your configuration.
+those user metrics, add the following to your configuration.
 
 ```txt
     - job_name: 'argo-events'
@@ -34,9 +34,9 @@ those user metrics, add following to your configuration.
         regex: (.+):(\d222);eventbus-controller
 ```
 
-Also please make sure your Prometheus Service Account has the permission to do
-POD discovery. A sample `ClusterRole` like below needs to be added or merged,
-and grant it to your Service Account.
+Also, please make sure your Prometheus Service Account has the permission to do
+POD discovery. A sample `ClusterRole` like the one below needs to be added or merged
+and granted to your Service Account.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -66,12 +66,12 @@ How many events failed to send to EventBus.
 
 #### argo_events_events_processing_failed_total
 
-How many events failed to process due to all the reasons, it includes
+How many events failed to process for any reason. This includes
 `argo_events_events_sent_failed_total`.
 
 #### argo_events_event_processing_duration_milliseconds
 
-Event processing duration (from getting the event to send it to EventBus) in
+Event processing duration (from receiving the event to sending it to EventBus) in
 milliseconds.
 
 ### Sensor
@@ -86,8 +86,8 @@ How many actions failed.
 
 #### argo_events_action_retries_failed_total
 
-How many actions failed after the retries have been exhausted.  
-This is also incremented if there is no `retryStrategy` specified.
+How many actions failed after retries have been exhausted.
+This is also incremented if no `retryStrategy` is specified.
 
 #### argo_events_action_duration_milliseconds
 
@@ -95,9 +95,9 @@ Action triggering duration.
 
 ### EventBus
 
-For `native` NATS EventBus, check this
-[link](https://github.com/nats-io/prometheus-nats-exporter) for the metrics
-explanation.
+For the `native` NATS EventBus, check this
+[link](https://github.com/nats-io/prometheus-nats-exporter) for metrics
+explanations.
 
 ## Controller Metrics
 
@@ -126,9 +126,9 @@ Prometheus configuration.
 
 ## Golden Signals
 
-Following metrics are considered as
+The following metrics are considered
 [Golden Signals](https://sre.google/sre-book/monitoring-distributed-systems/#xref_monitoring_golden-signals)
-of monitoring your applications running with Argo Events.
+for monitoring your applications running with Argo Events.
 
 - Latency
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,11 +1,11 @@
 # Getting Started
 
-We are going to set up a sensor and event-source for webhook. The goal is to trigger an Argo workflow upon an HTTP Post request.
+We are going to set up a sensor and event-source for a webhook. The goal is to trigger an Argo workflow upon an HTTP POST request.
 
 Note: You will need to have [Argo Workflows](https://argoproj.github.io/argo-workflows/) installed to make this work.
-The Argo Workflow controller will need to be configured to listen for Workflow objects created in `argo-events` namespace.
+The Argo Workflow controller will need to be configured to listen for Workflow objects created in the `argo-events` namespace.
   (See [this](https://github.com/argoproj/argo-workflows/blob/master/docs/managed-namespace.md) link.)
-  The Workflow Controller will need to be installed either in a cluster-scope configuration (i.e. no "--namespaced" argument) so that it has visiblity to all namespaces, or with "--managed-namespace" set to define "argo-events" as a namespace it has visibility to. To deploy Argo Workflows with a cluster-scope configuration you can use this installation yaml file, setting `ARGO_WORKFLOWS_VERSION` with your desired version. A list of versions can be found by viewing [these](https://github.com/argoproj/argo-workflows/tags) project tags in the Argo Workflow GitHub repository.
+  The Workflow Controller will need to be installed either in a cluster-scope configuration (i.e., no "--namespaced" argument) so that it has visibility to all namespaces, or with "--managed-namespace" set to define "argo-events" as a namespace it has visibility to. To deploy Argo Workflows with a cluster-scope configuration, you can use this installation YAML file, setting `ARGO_WORKFLOWS_VERSION` with your desired version. A list of versions can be found by viewing [these](https://github.com/argoproj/argo-workflows/tags) project tags in the Argo Workflows GitHub repository.
 
         export ARGO_WORKFLOWS_VERSION=3.5.4
         kubectl create namespace argo
@@ -19,15 +19,15 @@ The Argo Workflow controller will need to be configured to listen for Workflow o
         kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/manifests/install-validating-webhook.yaml
 
 
-1. Make sure to have the eventbus pods running in the namespace. Run following command to create the eventbus.
+1. Make sure to have the EventBus pods running in the namespace. Run the following command to create the EventBus.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/eventbus/native.yaml
 
-1. Setup event-source for webhook as follows.
+1. Set up the event-source for the webhook as follows.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/event-sources/webhook.yaml
 
-   The above event-source contains a single event configuration that runs an HTTP server on port `12000` with endpoint `example`.
+   The event-source above contains a single event configuration that runs an HTTP server on port `12000` with the endpoint `example`.
 
    After running the above command, the event-source controller will create a pod and service.
 
@@ -38,17 +38,17 @@ The Argo Workflow controller will need to be configured to listen for Workflow o
          # workflow rbac
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/master/examples/rbac/workflow-rbac.yaml
 
-1. Create webhook sensor.
+1. Create the webhook sensor.
 
         kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/sensors/webhook.yaml
 
-   Once the sensor object is created, sensor controller will create corresponding pod and a service.
+   Once the sensor object is created, the sensor controller will create a corresponding pod and service.
 
-1. Expose the event-source pod via Ingress, OpenShift Route or port forward to consume requests over HTTP.
+1. Expose the event-source pod via Ingress, OpenShift Route, or port forward to consume requests over HTTP.
 
         kubectl -n argo-events port-forward svc/webhook-eventsource-svc 12000:12000
 
-1. Use either Curl or Postman to send a post request to the <http://localhost:12000/example>.
+1. Use either Curl or Postman to send a POST request to <http://localhost:12000/example>.
 
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,10 +9,10 @@ version, and z is the patch version, following Semantic Versioning terminology.
 
 We maintain release branches for the most recent two minor releases.
 
-Fixes may be backported to release branches, depending on severity, risk, and,
+Fixes may be backported to release branches, depending on severity, risk, and
 feasibility.
 
-If a release contains breaking changes, or CVE fixes, this will documented in
+If a release contains breaking changes or CVE fixes, this will be documented in
 the release notes.
 
 ## Supported Version Skew

--- a/docs/sensors/more-about-sensors-and-triggers.md
+++ b/docs/sensors/more-about-sensors-and-triggers.md
@@ -167,7 +167,7 @@ spec:
 ```
 
 If the trigger fails, it will retry up to the configured number of retries based
-on `retryStrategy`. If the maximum retries are reached and the trigger, the
+on `retryStrategy`. If the maximum retries are reached and the trigger fails, the
 `dlqTrigger` will be invoked if specified.  In order to use the `dlqTrigger`,
 the `atLeastOnce` must be set to true within the trigger and the `dlqTrigger` for
 the Sensor to know about the failure and invoke the `dlqTrigger`.

--- a/docs/sensors/trigger-conditions.md
+++ b/docs/sensors/trigger-conditions.md
@@ -43,7 +43,7 @@ spec:
           method: GET
 ```
 
-`Conditions` is a boolean expression contains dependency names, the trigger
+`Conditions` is a boolean expression containing dependency names, the trigger
 won't be executed until the expression resolves to true. The operators in
 `conditions` include:
 

--- a/docs/sensors/triggers/http-trigger.md
+++ b/docs/sensors/triggers/http-trigger.md
@@ -84,7 +84,7 @@ We will set up a basic go http server and connect it with the Minio events.
 In order to construct a request payload based on the event data, sensor offers
 `payload` field as a part of the HTTP trigger.
 
-Let's examine a HTTP trigger,
+Let's examine an HTTP trigger,
 
         http:
           url: http://http-server.argo-events.svc:8090/hello

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -3,7 +3,7 @@
 ## Service Account for EventSources
 
 A `Service Account` can be specified in the EventSource object with
-`spec.template.serviceAccountName`, however it is not needed for all the
+`spec.template.serviceAccountName`. However, it is not needed for all
 EventSource types except `resource`. For a `resource` EventSource, you need to
 specify a Service Account and give it `list` and `watch` permissions for the
 resource being watched.
@@ -20,7 +20,7 @@ For example, if you want to watch actions on `Deployment` objects, you need to:
 
         kubectl -n your-namespace create rolebinding deployments-watcher-role-binding --role=deployments-watcher --serviceaccount=your-namespace:my-sa
 
-    or (if you want to watch cluster scope)
+    or (if you want to watch at cluster scope)
 
         kubectl create clusterrole deployments-watcher --verb=list,watch --resource=deployments.apps
 
@@ -28,13 +28,13 @@ For example, if you want to watch actions on `Deployment` objects, you need to:
 
 ## Service Account for Sensors
 
-A `Service Account` also can be specified in a Sensor object via
-`spec.template.serviceAccountName`, this is only needed when `k8s` trigger or
+A `Service Account` can also be specified in a Sensor object via
+`spec.template.serviceAccountName`. This is only needed when a `k8s` trigger or
 `argoWorkflow` trigger is defined in the Sensor object.
 
-The sensor examples provided by us use `operate-workflow-sa` service account to
+The sensor examples provided by us use the `operate-workflow-sa` service account to
 execute the triggers, but it has more permissions than needed, and you may want
-to limit those privileges based on your use-case. It's always a good practice to
+to limit those privileges based on your use case. It's always a good practice to
 create a service account with minimum privileges to execute it.
 
 ### Argo Workflow Trigger
@@ -60,8 +60,8 @@ Sensor.
 
 When the Sensor is used to trigger a Workflow, you might need to configure the
 Service Account used in the Workflow spec (**NOT**
-`spec.template.serviceAccountName`) following Argo Workflow
+`spec.template.serviceAccountName`), following Argo Workflows
 [instructions](https://github.com/argoproj/argo-workflows/blob/master/docs/service-accounts.md).
 
-If it is used to trigger other K8s resources (i.e. a Deployment), make sure to
-follow least privilege principle.
+If it is used to trigger other K8s resources (i.e., a Deployment), make sure to
+follow the least privilege principle.

--- a/docs/tutorials/01-introduction.md
+++ b/docs/tutorials/01-introduction.md
@@ -7,24 +7,24 @@ to any type of event-source.
 
 ## Prerequisites
 
-- Follow the installation guide to set up the Argo Events.
+- Follow the installation guide to set up Argo Events.
 - Make sure to configure Argo Workflow controller to listen to workflow objects created in `argo-events` namespace.
   (See [this](https://github.com/argoproj/argo-workflows/blob/master/docs/managed-namespace.md) link.)
   The Workflow Controller will need to be installed either in a cluster-scope configuration (i.e. no "--namespaced" argument) so that it has visibility to all namespaces, or with "--managed-namespace" set to define "argo-events" as a namespace it has visibility to. To deploy Argo Workflows with a cluster-scope configuration you can use this installation yaml file:
 
         kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/latest/download/install.yaml
 
-- Make sure to read the concepts behind
-  [eventbus](https://argoproj.github.io/argo-events/concepts/eventbus/).
-  [sensor](https://argoproj.github.io/argo-events/concepts/sensor/).
-  [event source](https://argoproj.github.io/argo-events/concepts/event_source/).
-- Follow the [instruction](https://github.com/argoproj/argo-events/tree/master/examples) to create a Service Account `operate-workflow-sa` with proper privileges, and make sure the Service Account used by Workflows (here we use `default` in the tutorials for demonstration purpose) has proper RBAC settings.
+- Make sure to read the concepts behind:
+  - [eventbus](https://argoproj.github.io/argo-events/concepts/eventbus/)
+  - [sensor](https://argoproj.github.io/argo-events/concepts/sensor/)
+  - [event source](https://argoproj.github.io/argo-events/concepts/event_source/)
+- Follow the [instructions](https://github.com/argoproj/argo-events/tree/master/examples) to create a Service Account `operate-workflow-sa` with proper privileges, and make sure the Service Account used by Workflows (here we use `default` in the tutorials for demonstration purpose) has proper RBAC settings.
 
 ## Get Started
 
-We are going to set up a sensor and event-source for webhook. The goal is to trigger an Argo workflow upon an HTTP Post request.
+We are going to set up a sensor and event-source for webhook. The goal is to trigger an Argo workflow upon an HTTP POST request.
 
-- Let' set up the eventbus.
+- Let's set up the eventbus.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/eventbus/native.yaml
 

--- a/docs/tutorials/02-parameterization.md
+++ b/docs/tutorials/02-parameterization.md
@@ -59,7 +59,7 @@ the event-source over the eventbus, lets see how we can use the event context to
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/02-parameterization/sensor-01.yaml
 
-2. Send a HTTP request to the event-source pod.
+2. Send an HTTP request to the event-source pod.
 
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
@@ -83,7 +83,7 @@ print the message.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/02-parameterization/sensor-02.yaml
 
-2. Send a HTTP request to the event-source pod.
+2. Send an HTTP request to the event-source pod.
 
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
@@ -128,7 +128,7 @@ important when the `key` you defined in the parameter doesn't exist in the event
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/02-parameterization/sensor-03.yaml
 
-2. Send a HTTP request to the event-source pod.
+2. Send an HTTP request to the event-source pod.
 
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
@@ -237,7 +237,7 @@ a parameter comes handy.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/02-parameterization/sensor-04.yaml
 
-2. Send a HTTP request to the event-source.
+2. Send an HTTP request to the event-source.
 
         curl -d '{"message":"hey!!"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
@@ -269,7 +269,7 @@ applying a parameter at the trigger template level.
 
         kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/02-parameterization/sensor-05.yaml
 
-2. Send a HTTP request to the event-source.
+2. Send an HTTP request to the event-source.
 
         curl -d '{"dependencyName":"test-dep", "dataKey": "body.message", "dest": "spec.arguments.parameters.0.value", "message": "amazing!!"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 

--- a/docs/tutorials/06-trigger-conditions.md
+++ b/docs/tutorials/06-trigger-conditions.md
@@ -36,12 +36,12 @@ Make sure there are no errors in any of the event-sources.
 
 3. Let's create the sensor. If you take a closer look at the trigger templates,
     you will notice that it contains a field named `conditions`, which is a
-    boolean expression contains dependency names. So, as soon as the expression
+    boolean expression containing dependency names. So, as soon as the expression
     is resolved as true, the corresponding trigger will be executed.
 
          kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/06-trigger-conditions/sensor-01.yaml
 
-4. Send a HTTP request to Webhook event-source.
+4. Send an HTTP request to Webhook event-source.
 
         curl -d '{"message":"this is my first webhook"}' -H "Content-Type: application/json" -X POST http://localhost:12000/example
 
@@ -65,7 +65,7 @@ Make sure there are no errors in any of the event-sources.
 
          kubectl -n argo-events apply -f https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/tutorials/06-trigger-conditions/sensor-02.yaml
 
-    Send a HTTP request and perform a file drop on Minio bucket as done above.
+    Send an HTTP request and perform a file drop on Minio bucket as done above.
     You should get the following output.
 
         

--- a/docs/validating-admission-webhook.md
+++ b/docs/validating-admission-webhook.md
@@ -17,13 +17,13 @@ kubectl apply -n argo-events -f https://raw.githubusercontent.com/argoproj/argo-
 
 ## Benefits
 
-Using the validating webhook has following benefits:
+Using the validating webhook has the following benefits:
 
 - It notifies the error at the time applying the faulty spec, so that you don't
   need to check the CRD object `status` field to see if there's any condition
   errors later on.
 
-  e.g. Creating an `exotic` NATS EventBus without `ClusterID` specified:
+  For example, creating an `exotic` NATS EventBus without `ClusterID` specified:
 
 ```sh
 cat <<EOF | kubectl create -f -
@@ -40,13 +40,13 @@ Error from server (BadRequest): error when creating "STDIN": admission webhook "
 
 - Spec updating behavior can be validated.
 
-  Updating existing specs requires more validation, besides checking if the new
-  spec is valid, we also need to check if there's any immutable fields being
-  updated. This can not be done in the controller reconciliation, but we can do
+  Updating existing specs requires more validation. Besides checking if the new
+  spec is valid, we also need to check if any immutable fields are being
+  updated. This cannot be done in the controller reconciliation, but we can do
   it by using the validating webhook.
 
-  For example, updating Auth Strategy for a native NATS EventBus is prohibited,
-  a denied response as following will be returned.
+  For example, updating the Auth Strategy for a native NATS EventBus is prohibited.
+  A denied response as shown below will be returned.
 
 ```sh
 Error from server (BadRequest): error when applying patch:

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 The examples demonstrate how Argo Events works.
 
 To make the Sensors be able to trigger Workflows, a Service Account with RBAC
-settings as following is required (assume you run the examples in the namespace
+settings as follows is required (assume you run the examples in the namespace
 `argo-events`).
 
 ```yaml
@@ -46,7 +46,7 @@ subjects:
 
 To make the Workflow triggered by the Sensor work, you also need to give a
 Service Account with privileges to the Workflow (the examples use Service
-Account `default`), see the detail
+Account `default`), see the details
 [here](https://github.com/argoproj/argo-workflows/blob/master/docs/service-accounts.md).
 A minimal Role to make Workflow work looks like following (check the
 [origin](https://github.com/argoproj/argo-workflows/blob/master/docs/workflow-rbac.md)):

--- a/pkg/apis/events/openapi/openapi_generated.go
+++ b/pkg/apis/events/openapi/openapi_generated.go
@@ -8563,7 +8563,7 @@ func schema_pkg_apis_events_v1alpha1_URLArtifact(ref common.ReferenceCallback) c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "URLArtifact contains information about an artifact at an http endpoint.",
+				Description: "URLArtifact contains information about an artifact at an HTTP endpoint.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"path": {

--- a/pkg/apis/events/v1alpha1/generated.proto
+++ b/pkg/apis/events/v1alpha1/generated.proto
@@ -3355,7 +3355,7 @@ message TriggerTemplate {
   optional EmailTrigger email = 17;
 }
 
-// URLArtifact contains information about an artifact at an http endpoint.
+// URLArtifact contains information about an artifact at an HTTP endpoint.
 message URLArtifact {
   // Path is the complete URL
   optional string path = 1;

--- a/pkg/apis/events/v1alpha1/sensor_types.go
+++ b/pkg/apis/events/v1alpha1/sensor_types.go
@@ -949,7 +949,7 @@ type FileArtifact struct {
 	Path string `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"`
 }
 
-// URLArtifact contains information about an artifact at an http endpoint.
+// URLArtifact contains information about an artifact at an HTTP endpoint.
 type URLArtifact struct {
 	// Path is the complete URL
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`

--- a/test/stress/README.md
+++ b/test/stress/README.md
@@ -10,7 +10,7 @@ Argo Events provides a set of simple tools to do stress testing:
 
 - Set up Prometheus metrics monitoring.
 
-  Follow the [instruction](https://argoproj.github.io/argo-events/metrics/) to
+  Follow the [instructions](https://argoproj.github.io/argo-events/metrics/) to
   set up Prometheus to grab metrics, also make sure the basic Kubernetes metrics
   like Pod CPU/memory usage are captured. Display the metrics using tools like
   [Grafana](https://grafana.com/).


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help.



Checklist:



<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->


PS.  I'm not Windows, I'll use wsl to run codegen.  Let's see how it goes.  Maybe I'll need help to know what to fix.   
