### PR TITLE
fix(http): correct basicAuth password err handling

### DIFF
--- a/pkg/sensors/triggers/http/http.go
+++ b/pkg/sensors/triggers/http/http.go
@@ -197,7 +197,7 @@ func (t *HTTPTrigger) Execute(ctx context.Context, events map[string]*v1alpha1.E
 
 		if basicAuth.Password != nil {
 			password, err = sharedutil.GetSecretFromVolume(basicAuth.Password)
-			if !ok {
+			if err != nil {
 				return nil, fmt.Errorf("failed to retrieve the password, %w", err)
 			}
 		}


### PR DESCRIPTION
Replaced incorrect check on password retrieval with proper err check in HTTPTrigger.Execute. This ensures failures fetching the password secret surface as errors. Added unit test to verify execution fails early when password secret retrieval fails, and that no HTTP requests are made.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
