### PR TITLE
feat: upgrade cosign version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: "v1.13.1"
+          cosign-release: "v3.0.2"
 
       - name: Install crane to get digest of image
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4


### PR DESCRIPTION
Upgrade cosign version to v3.0.2 to fix [release step](https://github.com/argoproj/argo-events/actions/runs/18622147764/job/53095031072#step:7:239)
```
ERROR: cosign versions below v2.0.0 are no longer supported.
ERROR: Requested version: v1.13.1
ERROR: Please use cosign v2.6.0 or later.
```
