### PR TITLE
fix: reduce leader election frequency

### DIFF
--- a/pkg/shared/leaderelection/leaderelection.go
+++ b/pkg/shared/leaderelection/leaderelection.go
@@ -250,9 +250,9 @@ func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallba
 			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 				Lock:            lock,
 				ReleaseOnCancel: true,
-				LeaseDuration:   5 * time.Second,
-				RenewDeadline:   2 * time.Second,
-				RetryPeriod:     1 * time.Second,
+				LeaseDuration:   15 * time.Second,
+				RenewDeadline:   10 * time.Second,
+				RetryPeriod:     2 * time.Second,
 				Callbacks: leaderelection.LeaderCallbacks{
 					OnStartedLeading: callbacks.OnStartedLeading,
 					OnStoppedLeading: callbacks.OnStoppedLeading,


### PR DESCRIPTION
The leader election causes CrashLoops for EventSources/Sensor due to being too aggressive.
This PR sets it to the default values of the [pkg](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig) as mentioned in issue 3790. This might help with the issues [3790](https://github.com/argoproj/argo-events/issues/3790) (using kubernetes leader election due to kafka) (#3790) and [3760](https://github.com/argoproj/argo-events/issues/3760) (using NATS for election).

I wasn't sure if disabling leader election for replicas=1 or exposing the config would be a desired change, so this is just a minimal change to reduce the frequency.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
