### PR TITLE
fix: release action by upgrading cosign 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.0.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.6.1'
 
       - name: Install crane to get digest of image
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4


### PR DESCRIPTION
the `release` action is failing on step "Install cosign" with:

```bash
ERROR: cosign versions below v2.0.0 are no longer supported.
ERROR: Requested version: v1.13.1
ERROR: Please use cosign v2.6.0 or later.
ERROR: See https://github.com/sigstore/cosign/releases for available versions.
Error: Process completed with exit code 1.
```

this PR upgrade the cosign version