### PR TITLE
fix: upgrade NATS JetStream from 2.10.10 to 2.10.29 to address CVEs

### DIFF
--- a/manifests/base/controller-manager/controller-config.yaml
+++ b/manifests/base/controller-manager/controller-config.yaml
@@ -32,7 +32,7 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.10
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
@@ -71,8 +71,8 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-        - version: 2.10.10
-          natsImage: nats:2.10.10
+        - version: 2.10.29
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -336,7 +336,7 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.10
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
@@ -375,8 +375,8 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-        - version: 2.10.10
-          natsImage: nats:2.10.10
+        - version: 2.10.29
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -256,7 +256,7 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.10
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
@@ -295,8 +295,8 @@ data:
           metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
           configReloaderImage: natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
-        - version: 2.10.10
-          natsImage: nats:2.10.10
+        - version: 2.10.29
+          natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server


### PR DESCRIPTION
## Description
This PR upgrades the NATS JetStream version from 2.10.10 to 2.10.29 to address critical security vulnerabilities.

## Changes
- Updated `latest` version to use `nats:2.10.29` image
- Updated explicit `2.10.10` version entry to `2.10.29`
- Applied changes to all three manifest files:
  - `manifests/base/controller-manager/controller-config.yaml`
  - `manifests/install.yaml`
  - `manifests/namespace-install.yaml`

## Rationale
Version 2.10.10 contains multiple critical CVEs that are resolved in 2.10.29. The upgrade remains within the 2.10.x line to ensure:

## Testing
- All manifest files updated consistently
- Version follows semantic versioning within minor release line

Fixes #3826