### PR TITLE
fix: upgrade Go toolchain to 1.25.5 to address HIGH severity CVEs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
       - name: Restore go build cache
         uses: actions/cache@v5
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
       - name: Restore go build cache
         uses: actions/cache@v5
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
       - name: Restore go build cache
         uses: actions/cache@v5
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
       - name: Restore go build cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
       - name: build
         run: make docs
       - name: deploy

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ start: image
 	kubectl -n argo-events wait --for=condition=Ready --timeout 60s pod --all
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.1.6
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.7.2
 
 .PHONY: lint
 lint: $(GOPATH)/bin/golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-events
 
-go 1.24.1
+go 1.25.5
 
 retract v1.15.1 // Contains retractions only.
 


### PR DESCRIPTION
Fixes #3807

## Description

This PR upgrades the Go toolchain from **1.24.1** to **1.25.5** to address HIGH severity CVEs in the Go standard library (net/http, crypto, encoding packages).

## Changes

- Updated `go.mod` to use Go 1.25.5
- Updated `.github/workflows/ci.yaml` to use Go 1.25.5
- Updated `.github/workflows/gh-pages.yaml` to use Go 1.25.5

## Why is this needed?

Security scanning tools (e.g., Trivy) identify multiple HIGH severity vulnerabilities in Go stdlib packages in the current container images. These vulnerabilities are fixed in Go 1.25.3+, and this PR upgrades to Go 1.25.5 for the latest security patches.

This blocks deployments in regulated environments and is part of broader security hardening efforts.

## Checklist

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).