### PR TITLE
Update ARGO_VERSION to v3.7.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk update && apk upgrade && \
     apk add ca-certificates && \
     apk --no-cache add tzdata
 
-ENV ARGO_VERSION=v3.7.7
+ENV ARGO_VERSION=v3.7.9
 
 RUN wget -q https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-${ARCH}.gz
 RUN gunzip -f argo-linux-${ARCH}.gz


### PR DESCRIPTION
Update ARGO_VERSION to latest release to get the Go vulnerabilities fixed.

Maybe in the long term this could be automated by using renovate?
