### PR TITLE
fix: reduce lame_duck_duration to 30s to fit within terminationGracePeriodSeconds

### DIFF
--- a/pkg/reconciler/eventbus/installer/assets/jetstream/nats-cluster.conf
+++ b/pkg/reconciler/eventbus/installer/assets/jetstream/nats-cluster.conf
@@ -38,7 +38,7 @@ cluster {
   }
 }
 
-lame_duck_duration: 120s
+lame_duck_duration: 30s
 ##################
 #                #
 # Authorization  #

--- a/pkg/reconciler/eventbus/installer/assets/jetstream/nats.conf
+++ b/pkg/reconciler/eventbus/installer/assets/jetstream/nats.conf
@@ -18,7 +18,7 @@ jetstream {
   store_dir: "/data/jetstream/store"
   {{.Settings}}
 }
-lame_duck_duration: 120s
+lame_duck_duration: 30s
 ##################
 #                #
 # Authorization  #


### PR DESCRIPTION
## Summary

- Reduce NATS `lame_duck_duration` from `120s` to `30s` in both `nats.conf` and `nats-cluster.conf`
- The previous value (`120s`) exceeded the Pod's `terminationGracePeriodSeconds` (`60s`), causing Kubernetes to SIGKILL the NATS server before it could gracefully leave the Raft group
- EventBus clients are all in-cluster pods, so `30s` (NATS minimum) is sufficient for lame duck mode

Fixes #3948

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).
