### PR TITLE
chore(deps): migrate to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.uber.org/ratelimit v0.3.1
 	go.uber.org/zap v1.27.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.49.0
 	golang.org/x/tools v0.43.0
 	google.golang.org/api v0.273.0
@@ -91,7 +92,6 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/jcmturner/gokrb5.v5 v5.3.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2
@@ -337,7 +337,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
@@ -365,6 +364,7 @@ require (
 	gopkg.in/jcmturner/rpc.v0 v0.0.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/klog v1.0.0 // indirect

--- a/pkg/eventsources/sources/amqp/start.go
+++ b/pkg/eventsources/sources/amqp/start.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	amqplib "github.com/rabbitmq/amqp091-go"
 	"go.uber.org/zap"


### PR DESCRIPTION
The old module path `gopkg.in/yaml.v3` is deprecated: https://github.com/go-yaml/yaml/tree/v3

The successor `go.yaml.in/yaml/v3` provides an identical API under a new path. The old path remains as an indirect dependency until transitive consumers migrate.

Indirect dependency for the old module comes from `controller-gen`:

```
$ go mod why -m gopkg.in/yaml.v3
# gopkg.in/yaml.v3
github.com/argoproj/argo-events/hack
sigs.k8s.io/controller-tools/cmd/controller-gen
sigs.k8s.io/controller-tools/pkg/schemapatcher
gopkg.in/yaml.v3
```

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
