### PR TITLE
Update image references to explicit docker.io registry paths

### DIFF
--- a/manifests/base/controller-manager/controller-config.yaml
+++ b/manifests/base/controller-manager/controller-config.yaml
@@ -8,8 +8,8 @@ data:
       nats:
         versions:
         - version: 0.22.1
-          natsStreamingImage: nats-streaming:0.22.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+          natsStreamingImage: docker.io/library/nats-streaming:0.22.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.8.0
       jetstream:
         # Default JetStream settings, could be overridden by EventBus JetStream specs
         settings: |
@@ -32,47 +32,47 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
         - version: 2.8.1
-          natsImage: nats:2.8.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.1-alpine
-          natsImage: nats:2.8.1-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.8.2
-          natsImage: nats:2.8.2
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.2-alpine
-          natsImage: nats:2.8.2-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.9.1
-          natsImage: nats:2.9.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.12
-          natsImage: nats:2.9.12
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.12
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.16
-          natsImage: nats:2.9.16
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.16
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.10.29
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -312,8 +312,8 @@ data:
       nats:
         versions:
         - version: 0.22.1
-          natsStreamingImage: nats-streaming:0.22.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+          natsStreamingImage: docker.io/library/nats-streaming:0.22.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.8.0
       jetstream:
         # Default JetStream settings, could be overridden by EventBus JetStream specs
         settings: |
@@ -336,49 +336,49 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
         - version: 2.8.1
-          natsImage: nats:2.8.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.1-alpine
-          natsImage: nats:2.8.1-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.8.2
-          natsImage: nats:2.8.2
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.2-alpine
-          natsImage: nats:2.8.2-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.9.1
-          natsImage: nats:2.9.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.12
-          natsImage: nats:2.9.12
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.12
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.16
-          natsImage: nats:2.9.16
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.16
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.10.29
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
 kind: ConfigMap
 metadata:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -232,8 +232,8 @@ data:
       nats:
         versions:
         - version: 0.22.1
-          natsStreamingImage: nats-streaming:0.22.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+          natsStreamingImage: docker.io/library/nats-streaming:0.22.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.8.0
       jetstream:
         # Default JetStream settings, could be overridden by EventBus JetStream specs
         settings: |
@@ -256,49 +256,49 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
         - version: 2.8.1
-          natsImage: nats:2.8.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.1-alpine
-          natsImage: nats:2.8.1-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.1-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.8.2
-          natsImage: nats:2.8.2
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.8.2-alpine
-          natsImage: nats:2.8.2-alpine
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.8.2-alpine
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: nats-server
         - version: 2.9.1
-          natsImage: nats:2.9.1
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.1
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.12
-          natsImage: nats:2.9.12
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.12
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.9.16
-          natsImage: nats:2.9.16
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          natsImage: docker.io/library/nats:2.9.16
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.7.0
           startCommand: /nats-server
         - version: 2.10.29
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: docker.io/library/nats:2.10.29
+          metricsExporterImage: docker.io/natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: docker.io/natsio/nats-server-config-reloader:0.14.0
           startCommand: /nats-server
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fixes #3825

Kubernetes 1.34 requires explicit registry paths instead of relying on implicit docker.io resolution. Updated all image references across the manifest files to use the full docker.io registry path. This applies to the NATS images and related sidecars.

Ran `make codegen` to validate the changes. Ready for review.