### PR TITLE
Support Redis URL connections in event sources

### DIFF
--- a/pkg/apis/events/v1alpha1/eventsource_types.go
+++ b/pkg/apis/events/v1alpha1/eventsource_types.go
@@ -1373,6 +1373,9 @@ type RedisEventSource struct {
 	// Username required for ACL style authentication if any.
 	// +optional
 	Username string `json:"username,omitempty" protobuf:"bytes,10,opt,name=username"`
+	// URL holds a Redis connection string URL. If set, HostAddress, Password, and Username are ignored.
+	// +optional
+	URL *corev1.SecretKeySelector `json:"url,omitempty" protobuf:"bytes,11,opt,name=url"`
 }
 
 // RedisStreamEventSource describes an event source for
@@ -1409,6 +1412,9 @@ type RedisStreamEventSource struct {
 	// Username required for ACL style authentication if any.
 	// +optional
 	Username string `json:"username,omitempty" protobuf:"bytes,10,opt,name=username"`
+	// URL holds a Redis connection string URL. If set, HostAddress, Password, and Username are ignored.
+	// +optional
+	URL *corev1.SecretKeySelector `json:"url,omitempty" protobuf:"bytes,11,opt,name=url"`
 }
 
 // NSQEventSource describes the event source for NSQ PubSub

--- a/pkg/eventsources/sources/redis/start.go
+++ b/pkg/eventsources/sources/redis/start.go
@@ -66,22 +66,34 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 	redisEventSource := &el.RedisEventSource
 
-	opt := &redis.Options{
-		Addr: redisEventSource.HostAddress,
-		DB:   int(redisEventSource.DB),
-	}
+	var opt *redis.Options
 
-	log.Info("retrieving password if it has been configured...")
-	if redisEventSource.Password != nil {
-		password, err := sharedutil.GetSecretFromVolume(redisEventSource.Password)
+	if redisEventSource.URL != nil {
+		urlStr, err := sharedutil.GetSecretFromVolume(redisEventSource.URL)
 		if err != nil {
-			return fmt.Errorf("failed to find the secret password %s, %w", redisEventSource.Password.Name, err)
+			return fmt.Errorf("failed to find the secret URL %s, %w", redisEventSource.URL.Name, err)
 		}
-		opt.Password = password
-	}
-
-	if redisEventSource.Username != "" {
-		opt.Username = redisEventSource.Username
+		parsedOpt, err := redis.ParseURL(urlStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse redis URL, %w", err)
+		}
+		opt = parsedOpt
+	} else {
+		opt = &redis.Options{
+			Addr: redisEventSource.HostAddress,
+			DB:   int(redisEventSource.DB),
+		}
+		log.Info("retrieving password if it has been configured...")
+		if redisEventSource.Password != nil {
+			password, err := sharedutil.GetSecretFromVolume(redisEventSource.Password)
+			if err != nil {
+				return fmt.Errorf("failed to find the secret password %s, %w", redisEventSource.Password.Name, err)
+			}
+			opt.Password = password
+		}
+		if redisEventSource.Username != "" {
+			opt.Username = redisEventSource.Username
+		}
 	}
 
 	if redisEventSource.TLS != nil {

--- a/pkg/eventsources/sources/redis/validate.go
+++ b/pkg/eventsources/sources/redis/validate.go
@@ -31,7 +31,10 @@ func validate(eventSource *v1alpha1.RedisEventSource) error {
 	if eventSource == nil {
 		return v1alpha1.ErrNilEventSource
 	}
-	if eventSource.HostAddress == "" {
+	if eventSource.URL != nil && eventSource.HostAddress != "" {
+		return fmt.Errorf("url and hostAddress are mutually exclusive")
+	}
+	if eventSource.URL == nil && eventSource.HostAddress == "" {
 		return fmt.Errorf("host address must be specified")
 	}
 	if eventSource.Channels == nil {

--- a/pkg/eventsources/sources/redis_stream/start.go
+++ b/pkg/eventsources/sources/redis_stream/start.go
@@ -66,22 +66,34 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 	redisEventSource := &el.EventSource
 
-	opt := &redis.Options{
-		Addr: redisEventSource.HostAddress,
-		DB:   int(redisEventSource.DB),
-	}
+	var opt *redis.Options
 
-	log.Info("retrieving password if it has been configured...")
-	if redisEventSource.Password != nil {
-		password, err := sharedutil.GetSecretFromVolume(redisEventSource.Password)
+	if redisEventSource.URL != nil {
+		urlStr, err := sharedutil.GetSecretFromVolume(redisEventSource.URL)
 		if err != nil {
-			return fmt.Errorf("failed to find the secret password %s, %w", redisEventSource.Password.Name, err)
+			return fmt.Errorf("failed to find the secret URL %s, %w", redisEventSource.URL.Name, err)
 		}
-		opt.Password = password
-	}
-
-	if redisEventSource.Username != "" {
-		opt.Username = redisEventSource.Username
+		parsedOpt, err := redis.ParseURL(urlStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse redis URL, %w", err)
+		}
+		opt = parsedOpt
+	} else {
+		opt = &redis.Options{
+			Addr: redisEventSource.HostAddress,
+			DB:   int(redisEventSource.DB),
+		}
+		log.Info("retrieving password if it has been configured...")
+		if redisEventSource.Password != nil {
+			password, err := sharedutil.GetSecretFromVolume(redisEventSource.Password)
+			if err != nil {
+				return fmt.Errorf("failed to find the secret password %s, %w", redisEventSource.Password.Name, err)
+			}
+			opt.Password = password
+		}
+		if redisEventSource.Username != "" {
+			opt.Username = redisEventSource.Username
+		}
 	}
 
 	if redisEventSource.TLS != nil {

--- a/pkg/eventsources/sources/redis_stream/validate.go
+++ b/pkg/eventsources/sources/redis_stream/validate.go
@@ -31,7 +31,10 @@ func validate(eventSource *v1alpha1.RedisStreamEventSource) error {
 	if eventSource == nil {
 		return v1alpha1.ErrNilEventSource
 	}
-	if eventSource.HostAddress == "" {
+	if eventSource.URL != nil && eventSource.HostAddress != "" {
+		return fmt.Errorf("url and hostAddress are mutually exclusive")
+	}
+	if eventSource.URL == nil && eventSource.HostAddress == "" {
 		return fmt.Errorf("host address must be specified")
 	}
 	if eventSource.Streams == nil {


### PR DESCRIPTION
Fixes #3778

Adds support for passing a Redis connection URL directly to the event sources instead of configuring individual fields like host, password, and username. Makes it easier when you already have your Redis connection in URL format.

Updated both the redis and redis_stream packages to parse the URL using redis.ParseURL when it's provided. Falls back to the old method using individual connection parameters if no URL is set, so it's fully backward compatible.

Tested locally with both URL and traditional connection setup.

- [ ] I have added this project to the USERS.md

If CI is failing on `codegen` job, run `make codegen` to fix it.

If you don't know what to do with CI failures, please mark your PR as Draft.