### PR TITLE
fix(bitbucketserver): replace %w with %v in Logger.Errorf call

### DIFF
--- a/pkg/eventsources/sources/bitbucketserver/start.go
+++ b/pkg/eventsources/sources/bitbucketserver/start.go
@@ -297,7 +297,7 @@ func (router *Router) manageBitbucketServerWebhooks(ctx context.Context, bitbuck
 			case <-ticker.C:
 				err = router.applyBitbucketServerWebhooks(bitbucketServerEventSource)
 				if err != nil {
-					router.route.Logger.Errorf("re-applying bitbucketserver webhooks failed: %w", err)
+					router.route.Logger.Errorf("re-applying bitbucketserver webhooks failed: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
  `Logger.Errorf` is backed by `zap.SugaredLogger`, which uses `fmt.Sprintf`internally. The `%w` verb is only meaningful in `fmt.Errorf` for error  wrapping — passing it to `Logger.Errorf` produces a garbled log line like
  `%!w(*errors.errorString=&{...})` instead of the actual error message.

  Replace `%w` with `%v` to produce a human-readable log output, consistent with how other event sources in this codebase handle error logging.

  Fixes #3989