### PR TITLE
fix(sensor): bump action_retries_failed_total on async trigger failures

### DIFF
--- a/pkg/sensors/listener.go
+++ b/pkg/sensors/listener.go
@@ -377,6 +377,13 @@ func (sensorCtx *SensorContext) triggerActions(ctx context.Context, sensor *v1al
 		go func() {
 			err := sensorCtx.triggerWithRateLimit(ctx, sensor, trigger, eventsMapping, depNames, eventIDs)
 			if err != nil {
+				// Fire-and-forget triggers (AtLeastOnce=false) do not go
+				// through the caller's DoWithRetry loop, so the caller
+				// cannot observe this failure and bump
+				// action_retries_failed_total. Record it here instead to
+				// keep the metric consistent with the AtLeastOnce=true
+				// path. See argoproj/argo-events#3947.
+				sensorCtx.metrics.ActionRetriesFailed(sensor.Name, trigger.Template.Name)
 				// Log the error, and let it continue
 				logger := logging.FromContext(ctx)
 				logger.Errorw("Failed to execute a trigger", zap.Error(err), zap.String(logging.LabelTriggerName, trigger.Template.Name))


### PR DESCRIPTION
## Summary

`action_retries_failed_total` was never incremented when a sensor did not specify a `retryStrategy`, as reported in #3947.

- The **synchronous** path (`AtLeastOnce=true`) runs `triggerActions` inside `DoWithRetry`, so a failure is observed by the caller and the metric is bumped at `listener.go:224`.
- The **async** path (`AtLeastOnce=false`, the default) fires `triggerWithRateLimit` in a goroutine and returns `nil` immediately, so `DoWithRetry` never sees the error and the metric stays at zero even though the action effectively failed after its single (non-retried) attempt.

Increment `action_retries_failed_total` from inside the goroutine when the async trigger returns an error, matching the synchronous behaviour and the [documented metric semantics](https://argoproj.github.io/argo-events/metrics/#argo_events_action_retries_failed_total). No double-counting: the synchronous caller only bumps the counter when its own `DoWithRetry` returns an error, which never happens on the async path.

Fixes #3947

Signed-off-by: Ali <alliasgher123@gmail.com>