### PR TITLE
feat(logging): support warn log level for event sources (#3003)

### DIFF
--- a/pkg/shared/logging/logger.go
+++ b/pkg/shared/logging/logger.go
@@ -27,6 +27,7 @@ const (
 	InfoLevel            = "info"
 	DebugLevel           = "debug"
 	ErrorLevel           = "error"
+	WarnLevel        = "warn"
 )
 
 // NewArgoEventsLogger returns a new ArgoEventsLogger
@@ -77,7 +78,10 @@ func ConfigureLogLevelLogger(logLevel string) zap.Config {
 		logConfig.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
 	case DebugLevel:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	default:
+	
+			case WarnLevel:
+		logConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
+default:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 	return logConfig

--- a/pkg/shared/logging/logger.go
+++ b/pkg/shared/logging/logger.go
@@ -27,7 +27,7 @@ const (
 	InfoLevel            = "info"
 	DebugLevel           = "debug"
 	ErrorLevel           = "error"
-	WarnLevel        = "warn"
+	WarnLevel            = "warn"
 )
 
 // NewArgoEventsLogger returns a new ArgoEventsLogger
@@ -78,10 +78,10 @@ func ConfigureLogLevelLogger(logLevel string) zap.Config {
 		logConfig.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
 	case DebugLevel:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	
-			case WarnLevel:
+
+	case WarnLevel:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
-default:
+	default:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 	return logConfig


### PR DESCRIPTION
Add WarnLevel constant and update ConfigureLogLevelLogger to handle the new 'warn' log level. This allows users to set LOG_LEVEL=warn to reduce verbosity for event source and sensor logs.

Fixes #3003.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
