### PR TITLE
feat(logging): support warn log level via LOG_LEVEL=warn

### DIFF
--- a/pkg/shared/logging/logger.go
+++ b/pkg/shared/logging/logger.go
@@ -27,6 +27,7 @@ const (
 	InfoLevel            = "info"
 	DebugLevel           = "debug"
 	ErrorLevel           = "error"
+	WarnLevel            = "warn"
 )
 
 // NewArgoEventsLogger returns a new ArgoEventsLogger
@@ -77,6 +78,8 @@ func ConfigureLogLevelLogger(logLevel string) zap.Config {
 		logConfig.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
 	case DebugLevel:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	case WarnLevel:
+		logConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
 	default:
 		logConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}

--- a/pkg/shared/logging/logger_test.go
+++ b/pkg/shared/logging/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
+	"go.uber.org/zap"
 )
 
 func TestNewArgoEventsLogger(t *testing.T) {
@@ -11,4 +12,23 @@ func TestNewArgoEventsLogger(t *testing.T) {
 		log := NewArgoEventsLogger()
 		convey.So(log, convey.ShouldNotBeNil)
 	})
+}
+
+func TestConfigureLogLevelLogger(t *testing.T) {
+	cases := map[string]zap.AtomicLevel{
+		InfoLevel:  zap.NewAtomicLevelAt(zap.InfoLevel),
+		DebugLevel: zap.NewAtomicLevelAt(zap.DebugLevel),
+		ErrorLevel: zap.NewAtomicLevelAt(zap.ErrorLevel),
+		WarnLevel:  zap.NewAtomicLevelAt(zap.WarnLevel),
+		"":         zap.NewAtomicLevelAt(zap.InfoLevel),
+		"garbage":  zap.NewAtomicLevelAt(zap.InfoLevel),
+	}
+	for level, want := range cases {
+		t.Run(level, func(t *testing.T) {
+			got := ConfigureLogLevelLogger(level).Level
+			if got.Level() != want.Level() {
+				t.Fatalf("ConfigureLogLevelLogger(%q).Level = %v, want %v", level, got.Level(), want.Level())
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

The eventsource webhook emits an INFO line for every event it receives, which can be noisy in deployments with high event volume. `ConfigureLogLevelLogger` currently accepts `debug`, `info`, `error` via the `LOG_LEVEL` env var and silently falls back to info for anything else, so operators who want a quieter configuration have no middle ground between info and error.

This PR exports a `WarnLevel = "warn"` constant next to the existing level constants and handles it in the `switch` inside `ConfigureLogLevelLogger`. Unknown values still default to info, so there's no behaviour change for existing deployments.

A previous attempt (#4004) was self-closed by its author without a maintainer review; this PR is functionally equivalent and adds a table-driven unit test covering all levels plus the fallback case.

Closes #3003

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).