### PR TITLE
feat: make Kubernetes leader election timeouts configurable via env vars

### DIFF
--- a/pkg/apis/events/v1alpha1/const.go
+++ b/pkg/apis/events/v1alpha1/const.go
@@ -111,6 +111,12 @@ const (
 	EnvVarPodName = "POD_NAME"
 	// ENVVarLeaderElection sets the leader election mode
 	EnvVarLeaderElection = "LEADER_ELECTION"
+	// EnvVarLeaderElectionLeaseDuration sets the leader election lease duration (e.g. "15s")
+	EnvVarLeaderElectionLeaseDuration = "LEADER_ELECTION_LEASE_DURATION"
+	// EnvVarLeaderElectionRenewDeadline sets the leader election renew deadline (e.g. "10s")
+	EnvVarLeaderElectionRenewDeadline = "LEADER_ELECTION_RENEW_DEADLINE"
+	// EnvVarLeaderElectionRetryPeriod sets the leader election retry period (e.g. "2s")
+	EnvVarLeaderElectionRetryPeriod = "LEADER_ELECTION_RETRY_PERIOD"
 	// EnvImagePullPolicy is the env var to set container's ImagePullPolicy
 	EnvImagePullPolicy = "IMAGE_PULL_POLICY"
 )

--- a/pkg/shared/leaderelection/leaderelection.go
+++ b/pkg/shared/leaderelection/leaderelection.go
@@ -217,6 +217,19 @@ func newKubernetesElector(namespace string, leasename string, hostname string) (
 	}, nil
 }
 
+func durationFromEnv (envVar string, defaultDuration time.Duration) time.Duration {
+	variable, exists := os.LookupEnv(envVar)
+	if !exists {
+		return defaultDuration
+	}
+	d, err := time.ParseDuration(variable)
+	if err != nil {
+		 fmt.Fprintf(os.Stderr, "invalid value for %s, using default\n", envVar)
+		 return defaultDuration
+	}
+	return d
+}
+
 func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallbacks) {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/shared/leaderelection/leaderelection.go
+++ b/pkg/shared/leaderelection/leaderelection.go
@@ -263,9 +263,9 @@ func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallba
 			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 				Lock:            lock,
 				ReleaseOnCancel: true,
-				LeaseDuration:   5 * time.Second,
-				RenewDeadline:   2 * time.Second,
-				RetryPeriod:     1 * time.Second,
+				LeaseDuration:   durationFromEnv(aev1.EnvVarLeaderElectionLeaseDuration, 5 * time.Second),
+				RenewDeadline:   durationFromEnv(aev1.EnvVarLeaderElectionRenewDeadline, 2 * time.Second),
+				RetryPeriod:     durationFromEnv(aev1.EnvVarLeaderElectionRetryPeriod, 1 * time.Second),
 				Callbacks: leaderelection.LeaderCallbacks{
 					OnStartedLeading: callbacks.OnStartedLeading,
 					OnStoppedLeading: callbacks.OnStoppedLeading,

--- a/pkg/shared/leaderelection/leaderelection.go
+++ b/pkg/shared/leaderelection/leaderelection.go
@@ -217,15 +217,15 @@ func newKubernetesElector(namespace string, leasename string, hostname string) (
 	}, nil
 }
 
-func durationFromEnv (envVar string, defaultDuration time.Duration) time.Duration {
+func durationFromEnv(envVar string, defaultDuration time.Duration) time.Duration {
 	variable, exists := os.LookupEnv(envVar)
 	if !exists {
 		return defaultDuration
 	}
 	d, err := time.ParseDuration(variable)
 	if err != nil {
-		 fmt.Fprintf(os.Stderr, "invalid value for %s, using default\n", envVar)
-		 return defaultDuration
+		fmt.Fprintf(os.Stderr, "invalid value for %s, using default\n", envVar)
+		return defaultDuration
 	}
 	return d
 }
@@ -263,9 +263,9 @@ func (e *kubernetesElector) RunOrDie(ctx context.Context, callbacks LeaderCallba
 			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 				Lock:            lock,
 				ReleaseOnCancel: true,
-				LeaseDuration:   durationFromEnv(aev1.EnvVarLeaderElectionLeaseDuration, 5 * time.Second),
-				RenewDeadline:   durationFromEnv(aev1.EnvVarLeaderElectionRenewDeadline, 2 * time.Second),
-				RetryPeriod:     durationFromEnv(aev1.EnvVarLeaderElectionRetryPeriod, 1 * time.Second),
+				LeaseDuration:   durationFromEnv(aev1.EnvVarLeaderElectionLeaseDuration, 5*time.Second),
+				RenewDeadline:   durationFromEnv(aev1.EnvVarLeaderElectionRenewDeadline, 2*time.Second),
+				RetryPeriod:     durationFromEnv(aev1.EnvVarLeaderElectionRetryPeriod, 1*time.Second),
 				Callbacks: leaderelection.LeaderCallbacks{
 					OnStartedLeading: callbacks.OnStartedLeading,
 					OnStoppedLeading: callbacks.OnStoppedLeading,

--- a/pkg/shared/leaderelection/leaderelection_test.go
+++ b/pkg/shared/leaderelection/leaderelection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	aev1 "github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
 	"github.com/stretchr/testify/assert"

--- a/pkg/shared/leaderelection/leaderelection_test.go
+++ b/pkg/shared/leaderelection/leaderelection_test.go
@@ -52,14 +52,14 @@ func TestLeaderElectionWithKubernetesElector(t *testing.T) {
 }
 
 func TestDurationFromEnv(t *testing.T) {
-    d := durationFromEnv("SOME_VAR", 5*time.Second)
-    assert.Equal(t, 5*time.Second, d)
+	d := durationFromEnv("SOME_VAR", 5*time.Second)
+	assert.Equal(t, 5*time.Second, d)
 
-    t.Setenv("SOME_VAR", "10s")
-    d = durationFromEnv("SOME_VAR", 5*time.Second)
-    assert.Equal(t, 10*time.Second, d)
+	t.Setenv("SOME_VAR", "10s")
+	d = durationFromEnv("SOME_VAR", 5*time.Second)
+	assert.Equal(t, 10*time.Second, d)
 
-    t.Setenv("SOME_VAR", "abc")
-    d = durationFromEnv("SOME_VAR", 5*time.Second)
-    assert.Equal(t, 5*time.Second, d)
+	t.Setenv("SOME_VAR", "abc")
+	d = durationFromEnv("SOME_VAR", 5*time.Second)
+	assert.Equal(t, 5*time.Second, d)
 }

--- a/pkg/shared/leaderelection/leaderelection_test.go
+++ b/pkg/shared/leaderelection/leaderelection_test.go
@@ -50,3 +50,16 @@ func TestLeaderElectionWithKubernetesElector(t *testing.T) {
 		assert.True(t, ok)
 	}
 }
+
+func TestDurationFromEnv(t *testing.T) {
+    d := durationFromEnv("SOME_VAR", 5*time.Second)
+    assert.Equal(t, 5*time.Second, d)
+
+    t.Setenv("SOME_VAR", "10s")
+    d = durationFromEnv("SOME_VAR", 5*time.Second)
+    assert.Equal(t, 10*time.Second, d)
+
+    t.Setenv("SOME_VAR", "abc")
+    d = durationFromEnv("SOME_VAR", 5*time.Second)
+    assert.Equal(t, 5*time.Second, d)
+}


### PR DESCRIPTION
## What

Add three environment variables to configure Kubernetes leader election timeouts:
- `LEADER_ELECTION_LEASE_DURATION` (default: 5s)
- `LEADER_ELECTION_RENEW_DEADLINE` (default: 2s)
- `LEADER_ELECTION_RETRY_PERIOD` (default: 1s)

## Why

When using Kafka as EventBus, Argo Events falls back to Kubernetes leader election.
The hardcoded `RenewDeadline=2s` is too tight for API servers under load, causing
`context deadline exceeded` errors → pod loses lease → restarts in a loop.

Users now can set this value variable via environment variable