### PR TITLE
fix: avoid duplicate slashes in formatted webhook URLs

### DIFF
--- a/pkg/shared/util/util.go
+++ b/pkg/shared/util/util.go
@@ -87,7 +87,7 @@ func FormatEndpoint(endpoint string) string {
 
 // FormattedURL returns a formatted url
 func FormattedURL(url, endpoint string) string {
-	return fmt.Sprintf("%s%s", url, FormatEndpoint(endpoint))
+	return fmt.Sprintf("%s%s", strings.TrimRight(url, "/"), FormatEndpoint(endpoint))
 }
 
 func ErrEventSourceTypeMismatch(eventSourceType string) string {

--- a/pkg/shared/util/util_test.go
+++ b/pkg/shared/util/util_test.go
@@ -45,6 +45,7 @@ func TestFormatEndpoint(t *testing.T) {
 
 func TestFormattedURL(t *testing.T) {
 	assert.Equal(t, "test-url/fake", FormattedURL("test-url", "fake"))
+	assert.Equal(t, "test-url/fake", FormattedURL("test-url/", "/fake"))
 }
 
 type statusVal int


### PR DESCRIPTION
## What
Tiny fix for webhook URL formatting. If `url` ends with `/` and `endpoint` starts with `/`, we currently register a URL with `//` in the path. pretty easy to hit, no weird setup needed.

## Repro
```go
FormattedURL("https://example.com/", "/push")
// before: https://example.com//push
// after:  https://example.com/push
```

This can affect providers using `FormattedURL` for webhook registration, like GitHub, GitLab, Bitbucket, SNS, Stripe, StorageGrid and Gerrit.

## Tests
`go test ./pkg/shared/util ./pkg/eventsources/sources/github ./pkg/eventsources/sources/gitlab ./pkg/eventsources/sources/bitbucket ./pkg/eventsources/sources/bitbucketserver ./pkg/eventsources/sources/awssns ./pkg/eventsources/sources/stripe ./pkg/eventsources/sources/storagegrid ./pkg/eventsources/sources/gerrit`