### PR TITLE
fix: validate resource selector operations

### DIFF
--- a/pkg/eventsources/sources/resource/start.go
+++ b/pkg/eventsources/sources/resource/start.go
@@ -336,7 +336,7 @@ func filterFields(jsonData []byte, selectors []v1alpha1.Selector, log *zap.Sugar
 		match := exp.Match([]byte(res.Str))
 
 		switch selection.Operator(selector.Operation) {
-		case selection.Equals, selection.DoubleEquals:
+		case "", selection.Equals, selection.DoubleEquals:
 			if !match {
 				return false
 			}

--- a/pkg/eventsources/sources/resource/validate.go
+++ b/pkg/eventsources/sources/resource/validate.go
@@ -45,12 +45,12 @@ func validate(eventSource *v1alpha1.ResourceEventSource) error {
 	}
 	if eventSource.Filter != nil {
 		if eventSource.Filter.Labels != nil {
-			if err := validateSelectors(eventSource.Filter.Labels); err != nil {
+			if err := validateLabelSelectors(eventSource.Filter.Labels); err != nil {
 				return err
 			}
 		}
 		if eventSource.Filter.Fields != nil {
-			if err := validateSelectors(eventSource.Filter.Fields); err != nil {
+			if err := validateFieldSelectors(eventSource.Filter.Fields); err != nil {
 				return err
 			}
 		}
@@ -58,7 +58,7 @@ func validate(eventSource *v1alpha1.ResourceEventSource) error {
 	return nil
 }
 
-func validateSelectors(selectors []v1alpha1.Selector) error {
+func validateLabelSelectors(selectors []v1alpha1.Selector) error {
 	for _, sel := range selectors {
 		if sel.Key == "" {
 			return fmt.Errorf("key can't be empty for selector")
@@ -66,8 +66,24 @@ func validateSelectors(selectors []v1alpha1.Selector) error {
 		if sel.Operation == "" {
 			continue
 		}
-		if selection.Operator(sel.Operation) == "" {
+		switch selection.Operator(sel.Operation) {
+		case selection.Equals, selection.DoubleEquals, selection.NotEquals, selection.In, selection.NotIn, selection.Exists, selection.DoesNotExist, selection.GreaterThan, selection.LessThan:
+		default:
 			return fmt.Errorf("unknown selection operation %s", sel.Operation)
+		}
+	}
+	return nil
+}
+
+func validateFieldSelectors(selectors []v1alpha1.Selector) error {
+	for _, sel := range selectors {
+		if sel.Key == "" {
+			return fmt.Errorf("key can't be empty for selector")
+		}
+		switch selection.Operator(sel.Operation) {
+		case "", selection.Equals, selection.DoubleEquals, selection.NotEquals:
+		default:
+			return fmt.Errorf("unsupported field selector operation %s", sel.Operation)
 		}
 	}
 	return nil

--- a/pkg/eventsources/sources/resource/validate_test.go
+++ b/pkg/eventsources/sources/resource/validate_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/eventsources/sources"
@@ -52,4 +53,51 @@ func TestValidateEventSource(t *testing.T) {
 		err := l.ValidateEventSource(context.Background())
 		assert.NoError(t, err)
 	}
+}
+
+func TestValidateEventSourceAllowsEmptyFieldSelectorOperation(t *testing.T) {
+	listener := &EventListener{
+		ResourceEventSource: v1alpha1.ResourceEventSource{
+			GroupVersionResource: metav1.GroupVersionResource{
+				Version:  "v1",
+				Resource: "pods",
+			},
+			EventTypes: []v1alpha1.ResourceEventType{v1alpha1.ADD},
+			Filter: &v1alpha1.ResourceFilter{
+				Fields: []v1alpha1.Selector{
+					{
+						Key:   "metadata.name",
+						Value: "demo",
+					},
+				},
+			},
+		},
+	}
+
+	err := listener.ValidateEventSource(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestValidateEventSourceRejectsUnsupportedFieldSelectorOperation(t *testing.T) {
+	listener := &EventListener{
+		ResourceEventSource: v1alpha1.ResourceEventSource{
+			GroupVersionResource: metav1.GroupVersionResource{
+				Version:  "v1",
+				Resource: "pods",
+			},
+			EventTypes: []v1alpha1.ResourceEventType{v1alpha1.ADD},
+			Filter: &v1alpha1.ResourceFilter{
+				Fields: []v1alpha1.Selector{
+					{
+						Key:       "metadata.name",
+						Operation: "in",
+						Value:     "example",
+					},
+				},
+			},
+		},
+	}
+
+	err := listener.ValidateEventSource(context.Background())
+	assert.EqualError(t, err, "unsupported field selector operation in")
 }


### PR DESCRIPTION
### What
Tiny validation fix for resource event sources.

`filter.fields` only supports `=`, `==`, and `!=` at runtime. Before this, `operation: in` could pass validation, then the field filter rejected events later. kinda sneaky.

### Repro
Use an EventSource like this:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: EventSource
metadata:
  name: resource
spec:
  resource:
    example:
      version: v1
      resource: pods
      eventTypes:
        - ADD
      filter:
        fields:
          - key: metadata.name
            operation: in
            value: demo
```

Run `argo-events lint bad-eventsource.yaml`.
Before: it passed validation.
After: it fails with `unsupported field selector operation in`.

### Tests
`go test ./cmd/commands ./pkg/eventsources/sources/resource -count=1`
`go test ./pkg/eventsources/sources/...`

Checklist:

* [ ] My organization is added to USERS.md. N/A for this fix.