### PR TITLE
eventsources: guard empty StorageGrid records in filterName

### DIFF
--- a/pkg/eventsources/sources/storagegrid/start.go
+++ b/pkg/eventsources/sources/storagegrid/start.go
@@ -82,6 +82,9 @@ func filterName(notification *events.StorageGridNotification, eventSource *v1alp
 	if eventSource.Filter == nil {
 		return true
 	}
+	if len(notification.Message.Records) == 0 {
+		return false
+	}
 	if eventSource.Filter.Prefix != "" && eventSource.Filter.Suffix != "" {
 		return strings.HasPrefix(notification.Message.Records[0].S3.Object.Key, eventSource.Filter.Prefix) && strings.HasSuffix(notification.Message.Records[0].S3.Object.Key, eventSource.Filter.Suffix)
 	}

--- a/pkg/eventsources/sources/storagegrid/start_test.go
+++ b/pkg/eventsources/sources/storagegrid/start_test.go
@@ -156,4 +156,23 @@ func TestFilterName(t *testing.T) {
 		ok := filterName(gridNotification, storageGridEventSource)
 		convey.So(ok, convey.ShouldEqual, true)
 	})
+
+	convey.Convey("A notification with no records must not panic and should not pass a prefix/suffix filter", t, func() {
+		storageGridEventSource := &v1alpha1.StorageGridEventSource{
+			Filter: &v1alpha1.StorageGridFilter{
+				Prefix: "hello-",
+				Suffix: ".txt",
+			},
+		}
+		emptyNotification := `{"Action":"Publish","Message":{"Records":[]},"TopicArn":"urn:h:sns:us-east::my_topic_1","Version":"2010-03-31"}`
+		var gridNotification *events.StorageGridNotification
+		err := json.Unmarshal([]byte(emptyNotification), &gridNotification)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(gridNotification, convey.ShouldNotBeNil)
+
+		convey.So(func() {
+			ok := filterName(gridNotification, storageGridEventSource)
+			convey.So(ok, convey.ShouldEqual, false)
+		}, convey.ShouldNotPanic)
+	})
 }


### PR DESCRIPTION
`filterName` reads `notification.Message.Records[0].S3.Object.Key` to apply a StorageGrid event source's prefix/suffix filter, but it never checks that `Records` is non-empty. `Message.Records` is populated by unmarshaling the webhook body in `HandleRoute` (via `url.QueryUnescape` then `qson.ToJSON` then `json.Unmarshal`), and a notification with no records (for example a StorageGrid test notification, or a body that decodes to an object with no records) leaves it empty, so indexing `[0]` panics.

It is reachable when the event source has a filter with a Prefix or Suffix set (that is the path that reaches the index), and the webhook endpoint has no auth secret by default, so an unauthenticated sender can hit it. The panic is recovered per-request by net/http, so it is a request-level failure (the notification is dropped and a stack trace is logged) rather than a process crash.

The sibling S3-notification source (minio) passes the whole `Records` slice through and never blindly indexes `[0]`; this adds the same kind of guard to `filterName`. I added a test that runs a zero-record notification through `filterName` to confirm it returns false instead of panicking.

---

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

I am contributing this as an individual bug fix, so the USERS.md item does not apply.
