### PR TITLE
fix: paginate existing webhook lookups to stop creating duplicate webhooks

### DIFF
--- a/pkg/eventsources/sources/bitbucketserver/custombitbucketserverclient.go
+++ b/pkg/eventsources/sources/bitbucketserver/custombitbucketserverclient.go
@@ -8,10 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+
+	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
 )
 
 // customBitbucketServerClient returns a Bitbucket Server HTTP client that implements methods that gfleury/go-bitbucket-v1 does not.
-// Specifically getting Pull Requests associated to a commit is not supported by gfleury/go-bitbucket-v1.
+// Specifically getting Pull Requests associated to a commit is not supported by gfleury/go-bitbucket-v1, and its
+// FindWebhooks method drops the pagination parameters, which makes it unusable for repositories with many webhooks.
 type customBitbucketServerClient struct {
 	client *http.Client
 	ctx    context.Context
@@ -33,6 +36,16 @@ type pagedPullRequestsRes struct {
 	Values        []pullRequestRes `json:"values"`
 	Start         int              `json:"start"`
 	NextPageStart int              `json:"nextPageStart"`
+}
+
+// pagedWebhooksRes is a paged response with values of bitbucketv1.Webhook.
+type pagedWebhooksRes struct {
+	Size          int                   `json:"size"`
+	Limit         int                   `json:"limit"`
+	IsLastPage    bool                  `json:"isLastPage"`
+	Values        []bitbucketv1.Webhook `json:"values"`
+	Start         int                   `json:"start"`
+	NextPageStart int                   `json:"nextPageStart"`
 }
 
 type pagination struct {
@@ -78,6 +91,49 @@ func (c *customBitbucketServerClient) get(u string) ([]byte, error) {
 	}
 
 	return io.ReadAll(res.Body)
+}
+
+// GetWebhooks returns all the webhooks configured on the repository.
+//
+// Bitbucket Server returns only the first page of webhooks, so a repository
+// with more webhooks than the page size can have the webhook of this event
+// source go unnoticed, which results in a new duplicate webhook being created
+// on every event source restart.
+func (c *customBitbucketServerClient) GetWebhooks(project, repository string) ([]bitbucketv1.Webhook, error) {
+	p := pagination{Start: 0, Limit: 500}
+
+	webhooksURL := c.url.JoinPath(fmt.Sprintf("api/1.0/projects/%s/repos/%s/webhooks", project, repository))
+	query := webhooksURL.Query()
+	query.Set("limit", p.LimitStr())
+
+	var webhooks []bitbucketv1.Webhook
+	for {
+		query.Set("start", p.StartStr())
+		webhooksURL.RawQuery = query.Encode()
+
+		body, err := c.get(webhooksURL.String())
+		if err != nil {
+			return nil, err
+		}
+
+		var pagedWebhooks pagedWebhooksRes
+		err = json.Unmarshal(body, &pagedWebhooks)
+		if err != nil {
+			return nil, err
+		}
+
+		webhooks = append(webhooks, pagedWebhooks.Values...)
+
+		// The additional comparison guards against a response that would
+		// otherwise loop forever.
+		if pagedWebhooks.IsLastPage || pagedWebhooks.NextPageStart <= p.Start {
+			break
+		}
+
+		p.Start = pagedWebhooks.NextPageStart
+	}
+
+	return webhooks, nil
 }
 
 // GetCommitPullRequests returns all the Pull Requests associated to the commit id.

--- a/pkg/eventsources/sources/bitbucketserver/custombitbucketserverclient_test.go
+++ b/pkg/eventsources/sources/bitbucketserver/custombitbucketserverclient_test.go
@@ -1,0 +1,79 @@
+package bitbucketserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWebhooksFollowsPagination(t *testing.T) {
+	var requestedStarts []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "/api/1.0/projects/PROJ/repos/repo/webhooks", request.URL.Path)
+
+		start := request.URL.Query().Get("start")
+		requestedStarts = append(requestedStarts, start)
+
+		writer.Header().Set("Content-Type", "application/json")
+		switch start {
+		case "0":
+			fmt.Fprint(writer, `{"size":1,"limit":500,"start":0,"isLastPage":false,"nextPageStart":1,
+				"values":[{"id":1,"name":"other","url":"https://example.com/other"}]}`)
+		default:
+			fmt.Fprint(writer, `{"size":1,"limit":500,"start":1,"isLastPage":true,
+				"values":[{"id":2,"name":"Argo Events","url":"https://example.com/argo-events"}]}`)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := &customBitbucketServerClient{
+		client: server.Client(),
+		ctx:    context.Background(),
+		url:    serverURL,
+	}
+
+	webhooks, err := client.GetWebhooks("PROJ", "repo")
+	require.NoError(t, err)
+	require.Len(t, webhooks, 2)
+	// A webhook that is only present on a later page must still be returned.
+	assert.Equal(t, "https://example.com/argo-events", webhooks[1].Url)
+	assert.Equal(t, []string{"0", "1"}, requestedStarts)
+}
+
+func TestGetWebhooksStopsOnNonAdvancingPage(t *testing.T) {
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+
+		writer.Header().Set("Content-Type", "application/json")
+		// A response that keeps pointing at the current page must not loop forever.
+		fmt.Fprint(writer, `{"size":1,"limit":500,"start":0,"isLastPage":false,"nextPageStart":0,
+			"values":[{"id":1,"name":"Argo Events","url":"https://example.com/argo-events"}]}`)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := &customBitbucketServerClient{
+		client: server.Client(),
+		ctx:    context.Background(),
+		url:    serverURL,
+	}
+
+	webhooks, err := client.GetWebhooks("PROJ", "repo")
+	require.NoError(t, err)
+	assert.Len(t, webhooks, 1)
+	assert.Equal(t, 1, requests)
+}

--- a/pkg/eventsources/sources/bitbucketserver/start.go
+++ b/pkg/eventsources/sources/bitbucketserver/start.go
@@ -184,15 +184,11 @@ func (router *Router) PostInactivate() error {
 	return router.deleteWebhooks(bitbucketServerEventSource)
 }
 
+// listWebhooks returns all the webhooks configured on the given repository.
 func (router *Router) listWebhooks(repo v1alpha1.BitbucketServerRepository) ([]bitbucketv1.Webhook, error) {
-	apiResponse, err := router.client.DefaultApi.FindWebhooks(repo.ProjectKey, repo.RepositorySlug, nil)
+	hooks, err := router.customClient.GetWebhooks(repo.ProjectKey, repo.RepositorySlug)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list existing hooks to check for duplicates for repository %s/%s: %w", repo.ProjectKey, repo.RepositorySlug, err)
-	}
-
-	hooks, err := bitbucketv1.GetWebhooksResponse(apiResponse)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert the list of webhooks for repository %s/%s: %w", repo.ProjectKey, repo.RepositorySlug, err)
 	}
 
 	return hooks, nil

--- a/pkg/eventsources/sources/github/hook_util.go
+++ b/pkg/eventsources/sources/github/hook_util.go
@@ -1,10 +1,56 @@
 package github
 
 import (
+	"context"
+
 	gh "github.com/google/go-github/v50/github"
 
 	sharedutil "github.com/argoproj/argo-events/pkg/shared/util"
 )
+
+// hooksPerPage is the page size used when listing existing webhooks. It is the
+// maximum page size accepted by the GitHub API.
+const hooksPerPage = 100
+
+// listAllHooks collects every page of a paginated GitHub hook listing.
+//
+// The GitHub API returns only the first 30 items when no pagination options are
+// given, so a repository or organization with more webhooks than that can have
+// its existing hook go unnoticed, which results in a new duplicate hook being
+// created on every event source restart.
+func listAllHooks(ctx context.Context, list func(context.Context, *gh.ListOptions) ([]*gh.Hook, *gh.Response, error)) ([]*gh.Hook, error) {
+	opts := &gh.ListOptions{PerPage: hooksPerPage, Page: 1}
+
+	var all []*gh.Hook
+	for {
+		hooks, resp, err := list(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, hooks...)
+
+		// resp.NextPage is 0 on the last page. The additional comparison guards
+		// against a server response that would otherwise loop forever.
+		if resp == nil || resp.NextPage <= opts.Page {
+			return all, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// listOrganizationHooks returns all webhooks configured on the given organization.
+func listOrganizationHooks(ctx context.Context, client *gh.Client, org string) ([]*gh.Hook, error) {
+	return listAllHooks(ctx, func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		return client.Organizations.ListHooks(ctx, org, opts)
+	})
+}
+
+// listRepositoryHooks returns all webhooks configured on the given repository.
+func listRepositoryHooks(ctx context.Context, client *gh.Client, owner, repo string) ([]*gh.Hook, error) {
+	return listAllHooks(ctx, func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		return client.Repositories.ListHooks(ctx, owner, repo, opts)
+	})
+}
 
 // compareHook returns true if the hook matches the url and event.
 func compareHook(hook *gh.Hook, url string, events []string) bool {

--- a/pkg/eventsources/sources/github/hook_util_test.go
+++ b/pkg/eventsources/sources/github/hook_util_test.go
@@ -1,10 +1,13 @@
 package github
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	gh "github.com/google/go-github/v50/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareHook(t *testing.T) {
@@ -50,4 +53,69 @@ func TestGetHook(t *testing.T) {
 
 	assert.Equal(t, hooks[1], getHook(hooks, "https://example.com/", []string{"*"}))
 	assert.Nil(t, getHook(hooks, "https://example.com/", []string{"does_not_exist"}))
+}
+
+func TestListAllHooksSinglePage(t *testing.T) {
+	calls := 0
+	hooks, err := listAllHooks(context.Background(), func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		calls++
+		assert.Equal(t, hooksPerPage, opts.PerPage)
+		assert.Equal(t, 1, opts.Page)
+		return []*gh.Hook{hookWithURL("https://example0.com/")}, &gh.Response{NextPage: 0}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Len(t, hooks, 1)
+}
+
+func TestListAllHooksFollowsPagination(t *testing.T) {
+	pages := [][]*gh.Hook{
+		{hookWithURL("https://example0.com/")},
+		{hookWithURL("https://example1.com/")},
+		{hookWithURL("https://example2.com/")},
+	}
+
+	hooks, err := listAllHooks(context.Background(), func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		page := pages[opts.Page-1]
+		nextPage := opts.Page + 1
+		if opts.Page == len(pages) {
+			nextPage = 0
+		}
+		return page, &gh.Response{NextPage: nextPage}, nil
+	})
+
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	// A hook that is only present on a later page must still be found.
+	assert.Equal(t, hooks[2], getHook(hooks, "https://example2.com/", []string{"*"}))
+}
+
+func TestListAllHooksError(t *testing.T) {
+	hooks, err := listAllHooks(context.Background(), func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		return nil, nil, errors.New("boom")
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, hooks)
+}
+
+func TestListAllHooksStopsOnNonAdvancingPage(t *testing.T) {
+	calls := 0
+	hooks, err := listAllHooks(context.Background(), func(ctx context.Context, opts *gh.ListOptions) ([]*gh.Hook, *gh.Response, error) {
+		calls++
+		// A server that keeps pointing at the current page must not loop forever.
+		return []*gh.Hook{hookWithURL("https://example0.com/")}, &gh.Response{NextPage: opts.Page}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Len(t, hooks, 1)
+}
+
+func hookWithURL(url string) *gh.Hook {
+	return &gh.Hook{
+		Config: map[string]interface{}{"url": url},
+		Events: []string{"*"},
+	}
 }

--- a/pkg/eventsources/sources/github/start.go
+++ b/pkg/eventsources/sources/github/start.go
@@ -306,7 +306,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 		f := func() {
 			for _, org := range githubEventSource.Organizations {
-				hooks, _, err := router.githubClient.Organizations.ListHooks(ctx, org, nil)
+				hooks, err := listOrganizationHooks(ctx, router.githubClient, org)
 				if err != nil {
 					logger.Errorf("failed to list existing webhooks of organization %s. err: %+v", org, err)
 					continue
@@ -328,7 +328,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 			for _, r := range githubEventSource.GetOwnedRepositories() {
 				for _, name := range r.Names {
-					hooks, _, err := router.githubClient.Repositories.ListHooks(ctx, r.Owner, name, nil)
+					hooks, err := listRepositoryHooks(ctx, router.githubClient, r.Owner, name)
 					if err != nil {
 						logger.Errorf("failed to list existing webhooks of %s/%s. err: %+v", r.Owner, name, err)
 						continue

--- a/pkg/eventsources/sources/gitlab/hook_util.go
+++ b/pkg/eventsources/sources/gitlab/hook_util.go
@@ -4,6 +4,50 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
+// hooksPerPage is the page size used when listing existing webhooks. It is the
+// maximum page size accepted by the GitLab API.
+const hooksPerPage = 100
+
+// listAllHooks collects every page of a paginated GitLab hook listing.
+//
+// The GitLab API returns only the first 20 items when no pagination options are
+// given, so a project or group with more webhooks than that can have its
+// existing hook go unnoticed, which results in a new duplicate hook being
+// created on every event source restart.
+func listAllHooks[T any](list func(gitlab.ListOptions) ([]*T, *gitlab.Response, error)) ([]*T, error) {
+	opts := gitlab.ListOptions{PerPage: hooksPerPage, Page: 1}
+
+	var all []*T
+	for {
+		hooks, resp, err := list(opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, hooks...)
+
+		// resp.NextPage is 0 on the last page. The additional comparison guards
+		// against a server response that would otherwise loop forever.
+		if resp == nil || resp.NextPage <= opts.Page {
+			return all, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// listProjectHooks returns all webhooks configured on the given project.
+func listProjectHooks(client *gitlab.Client, project string) ([]*gitlab.ProjectHook, error) {
+	return listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.ProjectHook, *gitlab.Response, error) {
+		return client.Projects.ListProjectHooks(project, &gitlab.ListProjectHooksOptions{ListOptions: opts})
+	})
+}
+
+// listGroupHooks returns all webhooks configured on the given group.
+func listGroupHooks(client *gitlab.Client, group string) ([]*gitlab.GroupHook, error) {
+	return listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.GroupHook, *gitlab.Response, error) {
+		return client.Groups.ListGroupHooks(group, &gitlab.ListGroupHooksOptions{ListOptions: opts})
+	})
+}
+
 func getProjectHook(hooks []*gitlab.ProjectHook, url string) *gitlab.ProjectHook {
 	for _, h := range hooks {
 		if h.URL != url {

--- a/pkg/eventsources/sources/gitlab/hook_util_test.go
+++ b/pkg/eventsources/sources/gitlab/hook_util_test.go
@@ -1,9 +1,11 @@
 package gitlab
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
@@ -33,4 +35,62 @@ func TestGetProjectHook(t *testing.T) {
 
 	assert.Equal(t, hooks[1], getProjectHook(hooks, "https://example1.com/"))
 	assert.Nil(t, getProjectHook(hooks, "https://example.com/"))
+}
+
+func TestListAllHooksSinglePage(t *testing.T) {
+	calls := 0
+	hooks, err := listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.ProjectHook, *gitlab.Response, error) {
+		calls++
+		assert.Equal(t, int64(hooksPerPage), opts.PerPage)
+		assert.Equal(t, int64(1), opts.Page)
+		return []*gitlab.ProjectHook{{URL: "https://example0.com/"}}, &gitlab.Response{NextPage: 0}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Len(t, hooks, 1)
+}
+
+func TestListAllHooksFollowsPagination(t *testing.T) {
+	pages := [][]*gitlab.ProjectHook{
+		{{URL: "https://example0.com/"}},
+		{{URL: "https://example1.com/"}},
+		{{URL: "https://example2.com/"}},
+	}
+
+	hooks, err := listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.ProjectHook, *gitlab.Response, error) {
+		page := pages[opts.Page-1]
+		nextPage := opts.Page + 1
+		if int(opts.Page) == len(pages) {
+			nextPage = 0
+		}
+		return page, &gitlab.Response{NextPage: nextPage}, nil
+	})
+
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	// A hook that is only present on a later page must still be found.
+	assert.Equal(t, hooks[2], getProjectHook(hooks, "https://example2.com/"))
+}
+
+func TestListAllHooksError(t *testing.T) {
+	hooks, err := listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.ProjectHook, *gitlab.Response, error) {
+		return nil, nil, errors.New("boom")
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, hooks)
+}
+
+func TestListAllHooksStopsOnNonAdvancingPage(t *testing.T) {
+	calls := 0
+	hooks, err := listAllHooks(func(opts gitlab.ListOptions) ([]*gitlab.GroupHook, *gitlab.Response, error) {
+		calls++
+		// A server that keeps pointing at the current page must not loop forever.
+		return []*gitlab.GroupHook{{URL: "https://example0.com/"}}, &gitlab.Response{NextPage: opts.Page}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Len(t, hooks, 1)
 }

--- a/pkg/eventsources/sources/gitlab/start.go
+++ b/pkg/eventsources/sources/gitlab/start.go
@@ -244,7 +244,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 
 		f := func() {
 			for _, g := range gitlabEventSource.GetGroups() {
-				hooks, _, err := router.gitlabClient.Groups.ListGroupHooks(g, &gitlab.ListGroupHooksOptions{})
+				hooks, err := listGroupHooks(router.gitlabClient, g)
 				if err != nil {
 					logger.Errorf("failed to list existing webhooks of group %s. err: %+v", g, err)
 					continue
@@ -265,7 +265,7 @@ func (el *EventListener) StartListening(ctx context.Context, dispatch func([]byt
 			}
 
 			for _, p := range gitlabEventSource.GetProjects() {
-				hooks, _, err := router.gitlabClient.Projects.ListProjectHooks(p, &gitlab.ListProjectHooksOptions{})
+				hooks, err := listProjectHooks(router.gitlabClient, p)
 				if err != nil {
 					logger.Errorf("failed to list existing webhooks of project %s. err: %+v", p, err)
 					continue


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).

## Problem

Before creating its webhook, an event source lists the existing webhooks of the project / repository / organization / group and looks for one with a matching URL. Those listings are requested without any pagination parameters, so only the first page is ever inspected:

| Source | Call | Page size actually used |
| --- | --- | --- |
| GitLab | `Projects.ListProjectHooks(p, &gitlab.ListProjectHooksOptions{})` | 20 |
| GitLab | `Groups.ListGroupHooks(g, &gitlab.ListGroupHooksOptions{})` | 20 |
| GitHub | `Repositories.ListHooks(ctx, owner, name, nil)` | 30 |
| GitHub | `Organizations.ListHooks(ctx, org, nil)` | 30 |
| Bitbucket Server | `DefaultApi.FindWebhooks(project, slug, nil)` | first page |

When a project has more webhooks than one page, the webhook of the event source may not be on that page. The event source then logs `hook not found for project ..., creating ...` and creates another identical webhook — on every restart. The duplicates make it worse, because they push the real webhook even further out of the first page, so the behaviour never recovers on its own.

Observed on GitLab: a project accumulated 78 identical hooks for the same event source endpoint, hit the GitLab limit of 100 project hooks, and the event source is now stuck failing with

```
failed to create gitlab webhook for project ...: 422 {message: Maximum number of project hooks (100) exceeded}
```

This is a different root cause than #2682 (duplicates caused by a race between replicas) — it reproduces with a single replica.

## Fix

Follow pagination in all of the existing-webhook lookups, so an already-created webhook is always found:

* `gitlab`: new `listProjectHooks` / `listGroupHooks` helpers around a generic `listAllHooks` that requests `per_page=100` and follows `resp.NextPage`.
* `github`: new `listRepositoryHooks` / `listOrganizationHooks` helpers around a generic `listAllHooks` that requests `PerPage=100` and follows `resp.NextPage`.
* `bitbucketserver`: the vendored `gfleury/go-bitbucket-v1` `FindWebhooks` forwards only the `event` and `statistics` options and drops `start` / `limit`, so it cannot page. The listing moves to the existing `customBitbucketServerClient` (which already implements paginated requests for commit pull requests) as `GetWebhooks`, using `limit=500` and `nextPageStart`.

Each loop also stops when the response does not advance the page, so a misbehaving server cannot cause an endless loop.

Bitbucket Cloud is not affected: `ktrysmt/go-bitbucket` follows the `next` link inside `executePaginated` by default.

Note that this fixes the creation of new duplicates; webhooks that were already duplicated by the old behaviour still have to be cleaned up manually.

## Tests

* `gitlab`: single page, multi-page (hook found only on the last page), listing error, non-advancing page.
* `github`: same four cases.
* `bitbucketserver`: `httptest` server serving two pages, asserting both `start=0` and `start=1` are requested and the webhook on the second page is returned; plus the non-advancing page case.

`make test` and `make lint` pass locally.
