### PR TITLE
fix: upgrade NATS JetStream from 2.10.29 to 2.14.4

### DIFF
--- a/manifests/base/controller-manager/controller-config.yaml
+++ b/manifests/base/controller-manager/controller-config.yaml
@@ -32,9 +32,9 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server
         - version: 2.8.1
           natsImage: nats:2.8.1
@@ -75,4 +75,9 @@ data:
           natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.14.4
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -336,9 +336,9 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server
         - version: 2.8.1
           natsImage: nats:2.8.1
@@ -379,6 +379,11 @@ data:
           natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.14.4
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server
 kind: ConfigMap
 metadata:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -256,9 +256,9 @@ data:
           discard: 0
         versions:
         - version: latest
-          natsImage: nats:2.10.29
-          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
-          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server
         - version: 2.8.1
           natsImage: nats:2.8.1
@@ -299,6 +299,11 @@ data:
           natsImage: nats:2.10.29
           metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
           configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.14.4
+          natsImage: nats:2.14.4
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.20.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.23.0
           startCommand: /nats-server
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Description

This PR upgrades the NATS JetStream default image from `2.10.29` to `2.14.4` (latest stable release as of August 2026). The 2.10.x branch has reached end-of-life with no further patches planned.

Also bumps sidecar images to their latest compatible versions:
- `prometheus-nats-exporter`: 0.14.0 → 0.20.1
- `nats-server-config-reloader`: 0.14.0 → 0.23.0

## Changes

- Updated `latest` version entry to use `nats:2.14.4` with latest sidecars
- Added explicit `2.14.4` version entry for users who pin to specific versions
- Retained `2.10.29` entry for backward compatibility
- Applied changes consistently to all three manifest files:
  - `manifests/base/controller-manager/controller-config.yaml`
  - `manifests/install.yaml`
  - `manifests/namespace-install.yaml`

## Rationale

- NATS 2.10.x is EOL — no further security patches will be released for this branch
- The `nats.go` client v1.52.0 (currently in go.mod) is fully compatible with NATS server 2.14.x
- The `nats-server/v2 v2.11.15` indirect dependency in go.mod confirms the codebase already works with post-2.10 server behavior
- Wire protocol is backward-compatible across 2.x minor versions
- All Docker images verified available on Docker Hub:
  - `nats:2.14.4` (released July 30, 2026)
  - `natsio/prometheus-nats-exporter:0.20.1` (released June 1, 2026)
  - `natsio/nats-server-config-reloader:0.23.0` (released May 12, 2026)

## Testing

- All manifest files updated consistently
- Version follows semantic versioning
- Existing version entries preserved for backward compatibility

Follows up on #3844 which upgraded from 2.10.10 to 2.10.29.

## CVE Posture for current images in this PR

nats-2.14.4: [Chainguard](https://images.chainguard.dev/directory/image/nats/versions#/version/nats/ce2d1984a010471142503340d670612d63ffb9f6%252F8536acfbd6da02be%252F88f74b72beaf369c/vulnerabilities)
prometheus-nats-exporter-0.20.1: [Chainguard](https://images.chainguard.dev/directory/image/prometheus-nats-exporter/versions#/version/prometheus-nats-exporter/ce2d1984a010471142503340d670612d63ffb9f6%252Fa15721cf6b468ccf%252Fa54a8a0cb43afc66/vulnerabilities)
nats-server-config-reloader-0.23.0: [Chainguard](https://images.chainguard.dev/directory/image/nats-server-config-reloader/versions#/version/nats-server-config-reloader/ce2d1984a010471142503340d670612d63ffb9f6%252F972f9eeaa1adc434%252F52f2230619744cd9/vulnerabilities)
