### PR TITLE
fix: return from ConsumeClaim when the Kafka batch channel closes

### DIFF
--- a/pkg/eventbus/kafka/sensor/kafka_handler.go
+++ b/pkg/eventbus/kafka/sensor/kafka_handler.go
@@ -145,7 +145,12 @@ func (h *KafkaHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim s
 
 	for {
 		select {
-		case msgs := <-batch:
+		case msgs, ok := <-batch:
+			if !ok {
+				// the claim's message channel closed, so sarama can rebalance
+				h.Logger.Info("Kafka batch channel closed, returning from ConsumeClaim")
+				return nil
+			}
 			if len(msgs) == 0 {
 				h.Logger.Warn("Kafka batch contains no messages")
 				continue

--- a/pkg/eventbus/kafka/sensor/kafka_handler_test.go
+++ b/pkg/eventbus/kafka/sensor/kafka_handler_test.go
@@ -1,0 +1,90 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// fakeConsumerGroupSession is a minimal sarama.ConsumerGroupSession whose
+// Context() stays live for the lifetime of the test, mirroring a session
+// that has not been rebalanced away.
+type fakeConsumerGroupSession struct {
+	ctx context.Context
+}
+
+func (f *fakeConsumerGroupSession) Claims() map[string][]int32                  { return nil }
+func (f *fakeConsumerGroupSession) MemberID() string                            { return "fake-member" }
+func (f *fakeConsumerGroupSession) GenerationID() int32                         { return 1 }
+func (f *fakeConsumerGroupSession) MarkOffset(string, int32, int64, string)     {}
+func (f *fakeConsumerGroupSession) Commit()                                     {}
+func (f *fakeConsumerGroupSession) ResetOffset(string, int32, int64, string)    {}
+func (f *fakeConsumerGroupSession) MarkMessage(*sarama.ConsumerMessage, string) {}
+func (f *fakeConsumerGroupSession) Context() context.Context                    { return f.ctx }
+
+// fakeConsumerGroupClaim exposes a message channel the test controls
+// directly, so it can be closed to simulate a sarama rebalance.
+type fakeConsumerGroupClaim struct {
+	topic     string
+	partition int32
+	messages  chan *sarama.ConsumerMessage
+}
+
+func (f *fakeConsumerGroupClaim) Topic() string                            { return f.topic }
+func (f *fakeConsumerGroupClaim) Partition() int32                         { return f.partition }
+func (f *fakeConsumerGroupClaim) InitialOffset() int64                     { return 0 }
+func (f *fakeConsumerGroupClaim) HighWaterMarkOffset() int64               { return 0 }
+func (f *fakeConsumerGroupClaim) Messages() <-chan *sarama.ConsumerMessage { return f.messages }
+
+// TestConsumeClaim_ReturnsOnClosedChannel reproduces the DEV-209308 hang: a
+// Kafka broker restart closes the claim's message channel while the
+// session's context is still alive. ConsumeClaim must return so sarama can
+// rebalance, instead of looping forever on the nil slice a closed channel
+// produces.
+func TestConsumeClaim_ReturnsOnClosedChannel(t *testing.T) {
+	const topic = "test-topic"
+	const partition = int32(0)
+
+	claim := &fakeConsumerGroupClaim{
+		topic:     topic,
+		partition: partition,
+		messages:  make(chan *sarama.ConsumerMessage),
+	}
+	session := &fakeConsumerGroupSession{ctx: context.Background()}
+
+	h := &KafkaHandler{
+		Mutex:  &sync.Mutex{},
+		Logger: zap.NewNop().Sugar(),
+		Handlers: map[string]func(*sarama.ConsumerMessage) ([]*sarama.ProducerMessage, int64, func()){
+			topic: func(*sarama.ConsumerMessage) ([]*sarama.ProducerMessage, int64, func()) {
+				return nil, 0, nil
+			},
+		},
+		checkpoints: Checkpoints{
+			topic: {
+				partition: &Checkpoint{Logger: zap.NewNop().Sugar()},
+			},
+		},
+	}
+
+	// Close the claim's channel to simulate the broker-restart rebalance,
+	// while the session context stays alive (its Done() never fires).
+	close(claim.messages)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.ConsumeClaim(session, claim)
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ConsumeClaim did not return after its message channel closed; it is stuck in the hot-loop from DEV-209308")
+	}
+}


### PR DESCRIPTION
Fixes #4147

## Problem

On a Kafka broker rolling restart, `base.Batch()`'s internal goroutine closes its output channel when the claim's `Messages()` channel closes. `ConsumeClaim` read that channel without the comma-ok form, so a closed channel produced a nil slice on every receive instead of blocking. The handler logged `"Kafka batch contains no messages"` and looped forever, burning a full CPU core, without ever reaching the `session.Context().Done()` case — the session itself was still alive, only the claim had been revoked. Sarama never got the chance to rebalance the partition, and the sensor pod stayed `Ready` throughout, so nothing detected the stall.

See #4147 for the full root-cause writeup and links to the relevant source.

## Fix

Read the batched channel with comma-ok and return `nil` as soon as it closes, so sarama treats this exactly like any other consumer handler exit and reassigns the claim.

## Testing

Added `pkg/eventbus/kafka/sensor/kafka_handler_test.go` with hand-rolled `sarama.ConsumerGroupSession` / `sarama.ConsumerGroupClaim` fakes (this package had no existing test file or sarama fakes to reuse). The test closes the claim's message channel while the session context stays alive, and asserts `ConsumeClaim` returns within a bounded timeout. It fails (times out) against the old code and passes against the fix.

```
go test -race -count=1 ./pkg/eventbus/kafka/sensor/...
go build ./...
```

Both pass locally.

#3495 is related but covers a different path (`ErrIncompleteResponse` inside `Listen`) — it does not touch `ConsumeClaim`'s read of the batched channel and does not affect the scenario here.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-events/blob/master/USERS.md).