### PR TITLE
fix(eventbus): close NATS connection when trigger connection init fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nats-io/graft v0.0.0-20220215174245-93d18541496f
+	github.com/nats-io/nats-server/v2 v2.11.15
 	github.com/nats-io/nats.go v1.53.1
 	github.com/nats-io/stan.go v0.10.4
 	github.com/nsqio/go-nsq v1.1.0
@@ -142,6 +143,7 @@ require (
 	github.com/alibabacloud-go/tea v1.2.2 // indirect
 	github.com/aliyun/credentials-go v1.3.10 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/antithesishq/antithesis-sdk-go v0.6.0-default-no-op // indirect
 	github.com/ardielle/ardielle-go v1.5.2 // indirect
 	github.com/awalterschulze/gographviz v0.0.0-20200901124122-0eecad45bd71 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
@@ -225,6 +227,7 @@ require (
 	github.com/google/go-github/v69 v69.2.0 // indirect
 	github.com/google/go-github/v84 v84.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
+	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect
@@ -267,6 +270,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
+	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
@@ -277,7 +281,7 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/nats-io/nats-server/v2 v2.11.15 // indirect
+	github.com/nats-io/jwt/v2 v2.8.1 // indirect
 	github.com/nats-io/nats-streaming-server v0.24.6 // indirect
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1097,6 +1097,7 @@ golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5 h1:ZUSxONxc981v7AW7QUg+I9WwZzSTTJ019ENBYr5pV/Q=

--- a/pkg/eventbus/jetstream/sensor/sensor_jetstream.go
+++ b/pkg/eventbus/jetstream/sensor/sensor_jetstream.go
@@ -77,7 +77,12 @@ func (stream *SensorJetstream) Connect(ctx context.Context, triggerName string, 
 		return nil, err
 	}
 
-	return NewJetstreamTriggerConn(conn, stream.sensorName, triggerName, dependencyExpression, deps)
+	triggerConn, err := NewJetstreamTriggerConn(conn, stream.sensorName, triggerName, dependencyExpression, deps)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return triggerConn, nil
 }
 
 // Update the K/V store to reflect the current Spec:

--- a/pkg/eventbus/jetstream/sensor/sensor_jetstream_test.go
+++ b/pkg/eventbus/jetstream/sensor/sensor_jetstream_test.go
@@ -1,0 +1,51 @@
+package sensor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/argoproj/argo-events/pkg/apis/events/v1alpha1"
+	eventbuscommon "github.com/argoproj/argo-events/pkg/eventbus/common"
+)
+
+func TestSensorJetstreamConnectClosesConnectionOnTriggerConnectionError(t *testing.T) {
+	natsServer, err := server.NewServer(&server.Options{
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+		Host:      "127.0.0.1",
+		Port:      -1,
+	})
+	require.NoError(t, err)
+	natsServer.Start()
+	t.Cleanup(func() {
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+	})
+	require.True(t, natsServer.ReadyForConnections(10*time.Second))
+
+	sensorSpec := &v1alpha1.Sensor{ObjectMeta: metav1.ObjectMeta{Name: "missing-kv-bucket"}}
+	stream, err := NewSensorJetstream(
+		natsServer.ClientURL(),
+		sensorSpec,
+		"",
+		&eventbuscommon.Auth{Strategy: v1alpha1.AuthStrategyNone},
+		zap.NewNop().Sugar(),
+		nil,
+	)
+	require.NoError(t, err)
+	baseline := natsServer.NumClients()
+
+	triggerConn, err := stream.Connect(context.Background(), "trigger", "dependency", nil, false)
+	require.Error(t, err)
+	require.Nil(t, triggerConn)
+	require.ErrorContains(t, err, "failed to get K/V store")
+	require.Eventually(t, func() bool {
+		return natsServer.NumClients() == baseline
+	}, 5*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- `SensorJetstream.Connect` opened a NATS connection via `MakeConnection()` and returned `NewJetstreamTriggerConn`'s error directly, without closing the connection on failure.
- Since the Sensor reconnect daemon retries every 5s (`pkg/sensors/listener.go`), a persistent K/V/JetStream init failure leaked one NATS connection per attempt — a production incident hit 65,536/65,536 connections exhausted.
- Fix closes `conn` on the failure path after `MakeConnection` succeeds; the returned `TriggerConnection` takes ownership only on success.

## Test plan
- [x] Added `TestSensorJetstreamConnectClosesConnectionOnTriggerConnectionError` (embedded JetStream server, missing K/V bucket) asserting `Connect` returns an error and the server's client count returns to baseline.
- [x] `go build ./...`
- [x] `go test ./pkg/eventbus/... -run . -v`
- [x] `go vet ./pkg/eventbus/jetstream/sensor/...`

Fixes #4106